### PR TITLE
Use RELATED_IMAGE_CERT_MANAGER variable

### DIFF
--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -60,6 +60,8 @@ spec:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
                         value: cert-manager-operator
+                      - name: RELATED_IMAGE_CERT_MANAGER
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/cert-manager-cert-manager-1.5-rhel-8:latest
                     image: registry-proxy.engineering.redhat.com/rh-osbs/cert-manager-cert-manager-operator-1.5-rhel-8:latest
                     imagePullPolicy: Always
                     name: cert-manager-operator

--- a/pkg/controller/deployment/generic_deployment_controller.go
+++ b/pkg/controller/deployment/generic_deployment_controller.go
@@ -77,6 +77,9 @@ func (c *genericDeploymentController) Sync(ctx context.Context, syncContext fact
 
 	assert, _ := assets.Asset(c.deploymentFile)
 	deployment := resourceread.ReadDeploymentV1OrDie(assert)
+	for _, c := range deployment.Spec.Template.Spec.Containers {
+		c.Image = certManagerImage(c.Image)
+	}
 	_, opStatus, _, _ := c.operatorClient.GetOperatorState()
 	appliedDeployment, _, err = resourceapply.ApplyDeployment(ctx, c.kubeClient.AppsV1(), syncContext.Recorder(), deployment, resourcemerge.ExpectedDeploymentGeneration(deployment, opStatus.Generations))
 

--- a/pkg/controller/deployment/related_images.go
+++ b/pkg/controller/deployment/related_images.go
@@ -1,0 +1,20 @@
+package deployment
+
+import "os"
+
+const (
+	environmentalVariableCertManagerRelatedImage = "RELATED_IMAGE_CERT_MANAGER"
+)
+
+// Overrides provided image when environmentalVariableCertManagerRelatedImage environment variable is specified.
+// Otherwise, returns provided defaultImage.
+//
+// This function assumes the Cert Manager is provided in all-in-one image. This function will need to be updated
+// is this assumption doesn't hold.
+func certManagerImage(defaultImage string) string {
+	env := os.Getenv(environmentalVariableCertManagerRelatedImage)
+	if env == "" {
+		return defaultImage
+	}
+	return env
+}

--- a/pkg/controller/deployment/related_images_test.go
+++ b/pkg/controller/deployment/related_images_test.go
@@ -1,0 +1,44 @@
+package deployment
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_certManagerImage(t *testing.T) {
+	type args struct {
+		defaultImage       string
+		relatedImageEnvVar string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Use default image on empty " + environmentalVariableCertManagerRelatedImage + " variable",
+			args: args{
+				defaultImage:       "quay.io/jetstack/cert-manager-controller:latest",
+				relatedImageEnvVar: "",
+			},
+			want: "quay.io/jetstack/cert-manager-controller:latest",
+		},
+		{
+			name: "Use related image on non-empty " + environmentalVariableCertManagerRelatedImage + " variable",
+			args: args{
+				defaultImage:       "quay.io/jetstack/cert-manager-controller:latest",
+				relatedImageEnvVar: "registry.redhat.io/cert-manager/cert-manager-operator-1.5-rhel-8:latest",
+			},
+			want: "registry.redhat.io/cert-manager/cert-manager-operator-1.5-rhel-8:latest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv(environmentalVariableCertManagerRelatedImage, tt.args.relatedImageEnvVar)
+			if got := certManagerImage(tt.args.defaultImage); got != tt.want {
+				t.Errorf("certManagerImage() = %v, want %v", got, tt.want)
+			}
+			os.Unsetenv(environmentalVariableCertManagerRelatedImage)
+		})
+	}
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/AUTH-108

This PR provides the support for overriding the operand image by using the `RELATED_IMAGE_CERT_MANAGER` environmental variable.

This feature is required for:
- Flexibility in testing
- Supporting SHA Digest pinning and supporting the offline installation mode
- Respinning the images in case of CVE

For more information, please refer to the [OSBS documentation](https://osbs.readthedocs.io/en/latest/users.html#creating-the-relatedimages-section). 