### PR TITLE
Always create certmanager/cluster CR

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Operator uses the [upstream deployment manifests](https://github.com/jetstac
 - [cert_manager_controller_deployment.go](pkg/controller/deployment/cert_manager_controller_deployment.go)
 - [cert_manager_webhook_deployment.go](pkg/controller/deployment/cert_manager_webhook_deployment.go)
 
-The deployment is triggered upon creating a cluster-scoped `CertManager` object named `cluster`. An example might be found in the [deploy](deploy) directory.
+The Operator automatically deploys a cluster-scoped `CertManager` object named `cluster` if it's missing (with default values).
 
 ### Directory structure
 

--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -13,19 +13,6 @@ metadata:
     support: The OpenShift Engineering Team
     operatorframework.io/suggested-namespace: openshift-cert-manager-operator
     operatorframework.io/cluster-monitoring: "true"
-    alm-examples: |
-      [
-        {
-          "apiVersion": "operator.openshift.io/v1alpha1",
-          "kind": "CertManager",
-          "metadata": {
-            "name": "cluster"
-          },
-          "spec": {
-            "managementState": "Managed"
-          }
-        }
-      ]
   name: openshift-cert-manager.v0.0.1
   namespace: placeholder
 spec:

--- a/pkg/controller/deployment/default_cert_manager_controller.go
+++ b/pkg/controller/deployment/default_cert_manager_controller.go
@@ -1,0 +1,59 @@
+package deployment
+
+import (
+	"context"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/cert-manager-operator/apis/operator/v1alpha1"
+	alpha1 "github.com/openshift/cert-manager-operator/pkg/operator/clientset/versioned/typed/operator/v1alpha1"
+)
+
+type DefaultCertManagerController struct {
+	operatorClient    v1helpers.OperatorClient
+	controllerFactory *factory.Factory
+	recorder          events.Recorder
+	certManagerClient alpha1.OperatorV1alpha1Interface
+}
+
+func NewDefaultCertManagerController(operatorClient v1helpers.OperatorClient, certManagerClient alpha1.OperatorV1alpha1Interface, eventsRecorder events.Recorder) factory.Controller {
+	controller := DefaultCertManagerController{
+		operatorClient:    operatorClient,
+		certManagerClient: certManagerClient,
+		controllerFactory: factory.New().ResyncEvery(time.Minute).WithInformers(
+			operatorClient.Informer(),
+		),
+		recorder: eventsRecorder.WithComponentSuffix("default-cert-manager-controller"),
+	}
+
+	return controller.controllerFactory.WithSync(controller.sync).ToController("DefaultCertManager", controller.recorder)
+}
+
+func (c *DefaultCertManagerController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	_, _, _, err := c.operatorClient.GetOperatorState()
+	if apierrors.IsNotFound(err) {
+		syncCtx.Recorder().Eventf("StatusNotFound", "Creating \"cluster\" certmanager")
+		_, err = c.createDefaultCertManager(ctx)
+	}
+	return err
+}
+
+func (c *DefaultCertManagerController) createDefaultCertManager(ctx context.Context) (*v1alpha1.CertManager, error) {
+	cm := &v1alpha1.CertManager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: v1alpha1.CertManagerSpec{
+			OperatorSpec: operatorv1.OperatorSpec{
+				ManagementState: operatorv1.Managed,
+			},
+		},
+	}
+	return c.certManagerClient.CertManagers().Create(ctx, cm, metav1.CreateOptions{})
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -101,7 +101,13 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		cc.EventRecorder,
 	)
 
-	controllersToStart = append(controllersToStart, statusController)
+	defaultCertManagerController := deployment.NewDefaultCertManagerController(
+		operatorClient,
+		certManagerOperatorClient.OperatorV1alpha1(),
+		cc.EventRecorder,
+	)
+
+	controllersToStart = append(controllersToStart, statusController, defaultCertManagerController)
 
 	for _, informer := range []interface{ Start(<-chan struct{}) }{
 		configInformers,


### PR DESCRIPTION
https://issues.redhat.com/browse/AUTH-105

This PR enables the Operator to always create the `certmanager/cluster` CR, so that other pieces of code could assume it's always there. This approach has stronger guarantees than defining the `certmanager/cluster` in the OLM bundle (someone can just delete it). The convention of having those objects comes down from library-go and core. Most of the controllers need it to write their status. 

This decision has a few consequences:
- We no longer need an example in the bundle. 
- We don't need to mention this requirement anywhere in the docs (but I'm doing it either way - to make users aware that there is something like this).