### PR TITLE
Fix namespace for conversion

### DIFF
--- a/bundle/manifests/certificaterequests.cert-manager.io-crd.yaml
+++ b/bundle/manifests/certificaterequests.cert-manager.io-crd.yaml
@@ -15,7 +15,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: cert-manager-webhook
+          name: openshift-cert-manager
           namespace: cert-manager
           path: /convert
       conversionReviewVersions:

--- a/bundle/manifests/certificates.cert-manager.io-crd.yaml
+++ b/bundle/manifests/certificates.cert-manager.io-crd.yaml
@@ -15,7 +15,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: cert-manager-webhook
+          name: openshift-cert-manager
           namespace: cert-manager
           path: /convert
       conversionReviewVersions:

--- a/bundle/manifests/challenges.acme.cert-manager.io-crd.yaml
+++ b/bundle/manifests/challenges.acme.cert-manager.io-crd.yaml
@@ -15,7 +15,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: cert-manager-webhook
+          name: openshift-cert-manager
           namespace: cert-manager
           path: /convert
       conversionReviewVersions:

--- a/bundle/manifests/clusterissuers.cert-manager.io-crd.yaml
+++ b/bundle/manifests/clusterissuers.cert-manager.io-crd.yaml
@@ -15,7 +15,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: cert-manager-webhook
+          name: openshift-cert-manager
           namespace: cert-manager
           path: /convert
       conversionReviewVersions:

--- a/bundle/manifests/issuers.cert-manager.io-crd.yaml
+++ b/bundle/manifests/issuers.cert-manager.io-crd.yaml
@@ -15,7 +15,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: cert-manager-webhook
+          name: openshift-cert-manager
           namespace: cert-manager
           path: /convert
       conversionReviewVersions:

--- a/bundle/manifests/orders.acme.cert-manager.io-crd.yaml
+++ b/bundle/manifests/orders.acme.cert-manager.io-crd.yaml
@@ -15,7 +15,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: cert-manager-webhook
+          name: openshift-cert-manager
           namespace: cert-manager
           path: /convert
       conversionReviewVersions:

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -45,7 +45,21 @@ local processManifests(manifest) =
     metadata+: {
       name: targetOperandNamespace,
     }
-  } else if manifest.kind == 'RoleBinding' then manifest {
+  } else if manifest.kind == 'CustomResourceDefinition' then manifest {
+       // Cert Manager uses conversion webhook, we need to make sure we override the
+       // namespace that we use.
+       spec+: {
+         conversion+: {
+           webhook+: {
+             clientConfig+: {
+               service+: {
+                 name: targetOperandNamespace
+               }
+             }
+           }
+         }
+       }
+     } else if manifest.kind == 'RoleBinding' then manifest {
     // We need conditional processing here as leader election RoleBindings needs to go into kube-system
     metadata+: {
       [if 'namespace' in manifest.metadata && manifest.metadata.namespace == sourceOperandNamespace then 'namespace']: targetOperandNamespace,


### PR DESCRIPTION
This Pull Request fixes the following error:

```
Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": service "cert-manager-webhook" not found
Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": service "cert-manager-webhook" not found
```