### PR TITLE
Additional namespaces patches for CRDs

### DIFF
--- a/bundle/manifests/certificaterequests.cert-manager.io-crd.yaml
+++ b/bundle/manifests/certificaterequests.cert-manager.io-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
+    cert-manager.io/inject-ca-from-secret: openshift-cert-manager/cert-manager-webhook-ca
   labels:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
@@ -15,8 +15,8 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: openshift-cert-manager
-          namespace: cert-manager
+          name: cert-manager-webhook
+          namespace: openshift-cert-manager
           path: /convert
       conversionReviewVersions:
         - v1

--- a/bundle/manifests/certificates.cert-manager.io-crd.yaml
+++ b/bundle/manifests/certificates.cert-manager.io-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
+    cert-manager.io/inject-ca-from-secret: openshift-cert-manager/cert-manager-webhook-ca
   labels:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
@@ -15,8 +15,8 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: openshift-cert-manager
-          namespace: cert-manager
+          name: cert-manager-webhook
+          namespace: openshift-cert-manager
           path: /convert
       conversionReviewVersions:
         - v1

--- a/bundle/manifests/challenges.acme.cert-manager.io-crd.yaml
+++ b/bundle/manifests/challenges.acme.cert-manager.io-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
+    cert-manager.io/inject-ca-from-secret: openshift-cert-manager/cert-manager-webhook-ca
   labels:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
@@ -15,8 +15,8 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: openshift-cert-manager
-          namespace: cert-manager
+          name: cert-manager-webhook
+          namespace: openshift-cert-manager
           path: /convert
       conversionReviewVersions:
         - v1

--- a/bundle/manifests/clusterissuers.cert-manager.io-crd.yaml
+++ b/bundle/manifests/clusterissuers.cert-manager.io-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
+    cert-manager.io/inject-ca-from-secret: openshift-cert-manager/cert-manager-webhook-ca
   labels:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
@@ -15,8 +15,8 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: openshift-cert-manager
-          namespace: cert-manager
+          name: cert-manager-webhook
+          namespace: openshift-cert-manager
           path: /convert
       conversionReviewVersions:
         - v1

--- a/bundle/manifests/issuers.cert-manager.io-crd.yaml
+++ b/bundle/manifests/issuers.cert-manager.io-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
+    cert-manager.io/inject-ca-from-secret: openshift-cert-manager/cert-manager-webhook-ca
   labels:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
@@ -15,8 +15,8 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: openshift-cert-manager
-          namespace: cert-manager
+          name: cert-manager-webhook
+          namespace: openshift-cert-manager
           path: /convert
       conversionReviewVersions:
         - v1

--- a/bundle/manifests/orders.acme.cert-manager.io-crd.yaml
+++ b/bundle/manifests/orders.acme.cert-manager.io-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
+    cert-manager.io/inject-ca-from-secret: openshift-cert-manager/cert-manager-webhook-ca
   labels:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
@@ -15,8 +15,8 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: openshift-cert-manager
-          namespace: cert-manager
+          name: cert-manager-webhook
+          namespace: openshift-cert-manager
           path: /convert
       conversionReviewVersions:
         - v1

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -46,6 +46,11 @@ local processManifests(manifest) =
       name: targetOperandNamespace,
     }
   } else if manifest.kind == 'CustomResourceDefinition' then manifest {
+       metadata+: {
+         annotations+: {
+           "cert-manager.io/inject-ca-from-secret": targetOperandNamespace + "/cert-manager-webhook-ca"
+         },
+       },
        // Cert Manager uses conversion webhook, we need to make sure we override the
        // namespace that we use.
        spec+: {
@@ -53,7 +58,7 @@ local processManifests(manifest) =
            webhook+: {
              clientConfig+: {
                service+: {
-                 name: targetOperandNamespace
+                 namespace: targetOperandNamespace
                }
              }
            }


### PR DESCRIPTION
This Pull Request fixes namespace name for CRDs and makes sure, a proper CA is used for the webhook.
