### PR TITLE
[WIP] Use owner references

### DIFF
--- a/pkg/controller/deployment/cert_manager_cainjector_deployment.go
+++ b/pkg/controller/deployment/cert_manager_cainjector_deployment.go
@@ -36,6 +36,7 @@ func NewCertManagerCAInjectorStaticResourcesController(operatorClient v1helpers.
 	kubeInformersForTargetNamespace v1helpers.KubeInformersForNamespaces,
 	eventsRecorder events.Recorder,
 ) factory.Controller {
+	ownerReferenceSetter := NewOwnerReferenceSetter(operatorClient)
 	return staticresourcecontroller.NewStaticResourceController(
 		certManagerCAInjectorStaticResourcesControllerName,
 		assets.Asset,
@@ -43,7 +44,7 @@ func NewCertManagerCAInjectorStaticResourcesController(operatorClient v1helpers.
 		kubeClientContainer,
 		operatorClient,
 		eventsRecorder,
-	).AddKubeInformers(kubeInformersForTargetNamespace)
+	).AddKubeInformers(kubeInformersForTargetNamespace).WithPreprocessFunc(ownerReferenceSetter.preprocessResources)
 }
 
 func NewCertManagerCAInjectorDeploymentController(operatorClient v1helpers.OperatorClient,

--- a/pkg/controller/deployment/cert_manager_controller_deployment.go
+++ b/pkg/controller/deployment/cert_manager_controller_deployment.go
@@ -57,6 +57,7 @@ func NewCertManagerControllerStaticResourcesController(operatorClient v1helpers.
 	kubeClientContainer *resourceapply.ClientHolder,
 	kubeInformersForTargetNamespace v1helpers.KubeInformersForNamespaces,
 	eventsRecorder events.Recorder) factory.Controller {
+	ownerReferenceSetter := NewOwnerReferenceSetter(operatorClient)
 	return staticresourcecontroller.NewStaticResourceController(
 		certManagerControllerStaticResourcesControllerName,
 		assets.Asset,
@@ -64,7 +65,7 @@ func NewCertManagerControllerStaticResourcesController(operatorClient v1helpers.
 		kubeClientContainer,
 		operatorClient,
 		eventsRecorder,
-	).AddKubeInformers(kubeInformersForTargetNamespace)
+	).AddKubeInformers(kubeInformersForTargetNamespace).WithPreprocessFunc(ownerReferenceSetter.preprocessResources)
 }
 
 func NewCertManagerControllerDeploymentController(operatorClient v1helpers.OperatorClient,

--- a/pkg/controller/deployment/cert_manager_webhook_deployment.go
+++ b/pkg/controller/deployment/cert_manager_webhook_deployment.go
@@ -39,6 +39,7 @@ func NewCertManagerWebhookStaticResourcesController(operatorClient v1helpers.Ope
 	kubeClientContainer *resourceapply.ClientHolder,
 	kubeInformersForTargetNamespace v1helpers.KubeInformersForNamespaces,
 	eventsRecorder events.Recorder) factory.Controller {
+	ownerReferenceSetter := NewOwnerReferenceSetter(operatorClient)
 	return staticresourcecontroller.NewStaticResourceController(
 		certManagerWebhookStaticResourcesControllerName,
 		assets.Asset,
@@ -46,7 +47,7 @@ func NewCertManagerWebhookStaticResourcesController(operatorClient v1helpers.Ope
 		kubeClientContainer,
 		operatorClient,
 		eventsRecorder,
-	).AddKubeInformers(kubeInformersForTargetNamespace)
+	).AddKubeInformers(kubeInformersForTargetNamespace).WithPreprocessFunc(ownerReferenceSetter.preprocessResources)
 }
 
 func NewCertManagerWebhookDeploymentController(operatorClient v1helpers.OperatorClient,

--- a/pkg/controller/deployment/owner_reference_setter.go
+++ b/pkg/controller/deployment/owner_reference_setter.go
@@ -1,0 +1,53 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/library-go/pkg/controller"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift/cert-manager-operator/apis/operator/v1alpha1"
+)
+
+type OwnerReferenceSetter struct {
+	operatorClient v1helpers.OperatorClient
+}
+
+func NewOwnerReferenceSetter(operatorClient v1helpers.OperatorClient) OwnerReferenceSetter {
+	return OwnerReferenceSetter{
+		operatorClient: operatorClient,
+	}
+}
+
+func (o *OwnerReferenceSetter) preprocessResources(_ context.Context, object runtime.Object) (runtime.Object, error) {
+	ownerRef, err := createOwnerReference(o.operatorClient)
+	if err != nil {
+		return nil, err
+	}
+	controller.EnsureOwnerRef(object.(metav1.Object), ownerRef)
+	return object, nil
+}
+
+func createOwnerReference(operatorClient v1helpers.OperatorClient) (v1.OwnerReference, error) {
+	if operatorClient == nil {
+		return v1.OwnerReference{}, fmt.Errorf("operatorclient not found")
+	}
+	meta, err := operatorClient.GetObjectMeta()
+	if err != nil {
+		return v1.OwnerReference{}, err
+	}
+	return v1.OwnerReference{
+		//TODO: Consider making it config.openshift.io? This way we could just call
+		// oc delete co cert-manager and it would cascade into other objects as well.
+		APIVersion:         v1alpha1.GroupVersion.String(),
+		Kind:               "CertManager",
+		Name:               meta.GetName(),
+		UID:                meta.GetUID(),
+		BlockOwnerDeletion: &[]bool{false}[0],
+		Controller:         &[]bool{false}[0],
+	}, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/controller/ownerref.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/ownerref.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EnsureOwnerRef adds the ownerref if needed. Removes ownerrefs with conflicting UIDs.
+// Returns true if the input is mutated.
+func EnsureOwnerRef(metadata metav1.Object, newOwnerRef metav1.OwnerReference) bool {
+	foundButNotEqual := false
+	for _, existingOwnerRef := range metadata.GetOwnerReferences() {
+		if existingOwnerRef.APIVersion == newOwnerRef.APIVersion &&
+			existingOwnerRef.Kind == newOwnerRef.Kind &&
+			existingOwnerRef.Name == newOwnerRef.Name {
+
+			// if we're completely the same, there's nothing to do
+			if equality.Semantic.DeepEqual(existingOwnerRef, newOwnerRef) {
+				return false
+			}
+
+			foundButNotEqual = true
+			break
+		}
+	}
+
+	// if we weren't found, then we just need to add ourselves
+	if !foundButNotEqual {
+		metadata.SetOwnerReferences(append(metadata.GetOwnerReferences(), newOwnerRef))
+		return true
+	}
+
+	// if we need to remove an existing ownerRef, just do the easy thing and build it back from scratch
+	newOwnerRefs := []metav1.OwnerReference{newOwnerRef}
+	for i := range metadata.GetOwnerReferences() {
+		existingOwnerRef := metadata.GetOwnerReferences()[i]
+		if existingOwnerRef.APIVersion == newOwnerRef.APIVersion &&
+			existingOwnerRef.Kind == newOwnerRef.Kind &&
+			existingOwnerRef.Name == newOwnerRef.Name {
+			continue
+		}
+		newOwnerRefs = append(newOwnerRefs, existingOwnerRef)
+	}
+	metadata.SetOwnerReferences(newOwnerRefs)
+	return true
+}
+
+// HasOwnerRef checks to see if an object has a particular owner.  It is not opinionated about
+// the bool fields
+func HasOwnerRef(metadata metav1.Object, needle metav1.OwnerReference) bool {
+	for _, existingOwnerRef := range metadata.GetOwnerReferences() {
+		if existingOwnerRef.APIVersion == needle.APIVersion &&
+			existingOwnerRef.Kind == needle.Kind &&
+			existingOwnerRef.Name == needle.Name &&
+			existingOwnerRef.UID == needle.UID {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -57,21 +57,29 @@ func init() {
 // In case, the returned ready flag is false, a proper error with a valid description is recommended.
 type StaticResourcesPreconditionsFuncType func(ctx context.Context) (bool, error)
 
+// PreprocessResourcesFuncType gives the caller an opportunity to preprocess decoded resources
+// before applying them.
+//
+// An error emitted from this function will be translated into
+// an error emitted by this controller.
+type PreprocessResourcesFuncType func(ctx context.Context, object runtime.Object) (runtime.Object, error)
+
 type StaticResourceController struct {
 	name                   string
 	manifests              []conditionalManifests
+	preprocessFunction     PreprocessResourcesFuncType
 	ignoreNotFoundOnCreate bool
-	preconditions          []StaticResourcesPreconditionsFuncType
 
+	preconditions          []StaticResourcesPreconditionsFuncType
 	operatorClient v1helpers.OperatorClient
+
 	clients        *resourceapply.ClientHolder
 
 	eventRecorder events.Recorder
-
-	factory          *factory.Factory
-	restMapper       meta.RESTMapper
-	categoryExpander restmapper.CategoryExpander
-	performanceCache resourceapply.ResourceCache
+	factory             *factory.Factory
+	restMapper          meta.RESTMapper
+	categoryExpander    restmapper.CategoryExpander
+	performanceCache    resourceapply.ResourceCache
 }
 
 type conditionalManifests struct {
@@ -112,6 +120,7 @@ func NewStaticResourceController(
 
 		factory:          factory.New().WithInformers(operatorClient.Informer()).ResyncEvery(1 * time.Minute),
 		performanceCache: resourceapply.NewResourceCache(),
+		preprocessFunction: defaultPreprocessFunc,
 	}
 	c.WithConditionalResources(manifests, files, nil, nil)
 
@@ -137,6 +146,16 @@ func (c *StaticResourceController) WithIgnoreNotFoundOnCreate() *StaticResourceC
 // When the requirement is not met, the controller reports degraded status.
 func (c *StaticResourceController) WithPrecondition(precondition StaticResourcesPreconditionsFuncType) *StaticResourceController {
 	c.preconditions = append(c.preconditions, precondition)
+	return c
+}
+
+// WithPreprocessFunc adds a pre-process function to the static resources passed into this controller. The caller
+// can apply custom logic to the decoded resorces before applying them.
+//
+// There can be only one pre-process function, so calling this multiple times will override (and not append) the
+// pre-process function.
+func (c *StaticResourceController) WithPreprocessFunc(preprocessFunc PreprocessResourcesFuncType) factory.Controller {
+	c.preprocessFunction = preprocessFunc
 	return c
 }
 
@@ -322,9 +341,9 @@ func (c *StaticResourceController) Sync(ctx context.Context, syncContext factory
 			continue
 
 		case shouldCreate:
-			directResourceResults = resourceapply.ApplyDirectly(ctx, c.clients, syncContext.Recorder(), c.performanceCache, conditionalManifest.manifests, conditionalManifest.files...)
+			directResourceResults = resourceapply.ApplyDirectlyWithPreprocess(ctx, c.clients, syncContext.Recorder(), c.performanceCache, conditionalManifest.manifests, c.preprocessFunction, conditionalManifest.files...)
 		case shouldDelete:
-			directResourceResults = resourceapply.DeleteAll(ctx, c.clients, syncContext.Recorder(), conditionalManifest.manifests, conditionalManifest.files...)
+			directResourceResults = resourceapply.DeleteAllWithPreprocess(ctx, c.clients, syncContext.Recorder(), conditionalManifest.manifests, c.preprocessFunction, conditionalManifest.files...)
 		}
 
 		for _, currResult := range directResourceResults {
@@ -439,4 +458,8 @@ func (c *StaticResourceController) Run(ctx context.Context, workers int) {
 
 func defaultStaticResourcesPreconditionsFunc(_ context.Context) (bool, error) {
 	return true, nil
+}
+
+func defaultPreprocessFunc(_ context.Context, object runtime.Object) (runtime.Object, error) {
+	return object, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -274,6 +274,7 @@ github.com/openshift/library-go/pkg/config/clusterstatus
 github.com/openshift/library-go/pkg/config/configdefaults
 github.com/openshift/library-go/pkg/config/leaderelection
 github.com/openshift/library-go/pkg/config/serving
+github.com/openshift/library-go/pkg/controller
 github.com/openshift/library-go/pkg/controller/controllercmd
 github.com/openshift/library-go/pkg/controller/factory
 github.com/openshift/library-go/pkg/controller/fileobserver


### PR DESCRIPTION
This Pull Request ensures all owner references are set when creating all objects.

In order to perform a cleanup, you need to uninstall the Cert Manager Operator (e.g. via OpenShift UI) and invoke:

```
oc delete certmanagers.operator.openshift.io --all
```

After a few seconds, Kubernetes GC will remove the operands. 

This Pull Request depends on https://github.com/openshift/library-go/pull/1307