### PR TITLE
Support multiple image overrides

### DIFF
--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -81,8 +81,12 @@ spec:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
                         value: cert-manager-operator
-                      - name: RELATED_IMAGE_CERT_MANAGER
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/cert-manager-jetstack-cert-manager-rhel-8:latest
+                      - name: RELATED_IMAGE_CERT_MANAGER_WEBHOOK
+                        value: quay.io/jetstack/cert-manager-webhook:v1.7.1
+                      - name: RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR
+                        value: quay.io/jetstack/cert-manager-cainjector:v1.7.1
+                      - name: RELATED_IMAGE_CERT_MANAGER_CONTROLLER
+                        value: quay.io/jetstack/cert-manager-controller:v1.7.1
                       - name: OPERAND_IMAGE_VERSION
                         value: 1.7.1
                       - name: OPERATOR_IMAGE_VERSION

--- a/pkg/controller/deployment/related_images.go
+++ b/pkg/controller/deployment/related_images.go
@@ -1,20 +1,29 @@
 package deployment
 
-import "os"
-
-const (
-	environmentalVariableCertManagerRelatedImage = "RELATED_IMAGE_CERT_MANAGER"
+import (
+	"os"
+	"strings"
 )
 
-// Overrides provided image when environmentalVariableCertManagerRelatedImage environment variable is specified.
+var imageEnvMap = map[string]string{
+	"quay.io/jetstack/cert-manager-controller": "RELATED_IMAGE_CERT_MANAGER_CONTROLLER",
+	"quay.io/jetstack/cert-manager-webhook":    "RELATED_IMAGE_CERT_MANAGER_WEBHOOK",
+	"quay.io/jetstack/cert-manager-cainjector": "RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR",
+}
+
+// Overrides provided image when envCertManagerControllerRelatedImage environment variable is specified.
 // Otherwise, returns provided defaultImage.
 //
 // This function assumes the Cert Manager is provided in all-in-one image. This function will need to be updated
 // is this assumption doesn't hold.
 func certManagerImage(defaultImage string) string {
-	env := os.Getenv(environmentalVariableCertManagerRelatedImage)
-	if env == "" {
-		return defaultImage
+	for image, env := range imageEnvMap {
+		if strings.Contains(defaultImage, image) {
+			overriddenImage := os.Getenv(env)
+			if overriddenImage != "" {
+				return overriddenImage
+			}
+		}
 	}
-	return env
+	return defaultImage
 }

--- a/pkg/controller/deployment/related_images_test.go
+++ b/pkg/controller/deployment/related_images_test.go
@@ -16,7 +16,7 @@ func Test_certManagerImage(t *testing.T) {
 		want string
 	}{
 		{
-			name: "Use default image on empty " + environmentalVariableCertManagerRelatedImage + " variable",
+			name: "Use default image on empty RELATED_IMAGE_CERT_MANAGER_CONTROLLER variable",
 			args: args{
 				defaultImage:       "quay.io/jetstack/cert-manager-controller:latest",
 				relatedImageEnvVar: "",
@@ -24,7 +24,7 @@ func Test_certManagerImage(t *testing.T) {
 			want: "quay.io/jetstack/cert-manager-controller:latest",
 		},
 		{
-			name: "Use related image on non-empty " + environmentalVariableCertManagerRelatedImage + " variable",
+			name: "Use related image on non-empty RELATED_IMAGE_CERT_MANAGER_CONTROLLER variable",
 			args: args{
 				defaultImage:       "quay.io/jetstack/cert-manager-controller:latest",
 				relatedImageEnvVar: "registry.redhat.io/cert-manager/cert-manager-operator-1.5-rhel-8:latest",
@@ -34,11 +34,11 @@ func Test_certManagerImage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv(environmentalVariableCertManagerRelatedImage, tt.args.relatedImageEnvVar)
+			os.Setenv("RELATED_IMAGE_CERT_MANAGER_CONTROLLER", tt.args.relatedImageEnvVar)
 			if got := certManagerImage(tt.args.defaultImage); got != tt.want {
 				t.Errorf("certManagerImage() = %v, want %v", got, tt.want)
 			}
-			os.Unsetenv(environmentalVariableCertManagerRelatedImage)
+			os.Unsetenv("RELATED_IMAGE_CERT_MANAGER_CONTROLLER")
 		})
 	}
 }


### PR DESCRIPTION
This Pull Request introduces the support for multiple image overrides. During the downstream productization, the images will be replaced with all-in-one image.

This is a counterpart for https://github.com/openshift/release/pull/26351
