### PR TITLE
If you set unsupportedConfigOverrides you replace all the controller args

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ spec:
     # Here's an example to supply custom DNS settings.
     controller:
       args:
-        - "--dns01-recursive-nameservers=1.1.1.1:53"
-        - "--dns01-recursive-nameservers-only"
+        - --v=2
+        - --cluster-resource-namespace=$(POD_NAMESPACE)
+        - --leader-election-namespace=kube-system
+        - --dns01-recursive-nameservers-only
+        - --dns01-recursive-nameservers=8.8.8.8:53,8.8.4.4:53
 ```


### PR DESCRIPTION
Because we replace the args in here:

https://github.com/openshift/cert-manager-operator/blob/master/pkg/controller/deployment/unsupported_config_overrides.go#L20

The cluster-resource-namespace will not be set, it will get the default value (cert-manager) and you won't find the Secrets for your ClusterIssuers.

Maybe we need add args instead of replacing them.