### PR TITLE
Fix valid-subscription annotation in manifests/csv

### DIFF
--- a/bundle/manifests/cert-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     "operatorframework.io/arch.amd64": supported
   annotations:
-    operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     capabilities: Seamless Upgrades
     categories: Security
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/cert-manager-cert-manager-operator-rhel8:latest


### PR DESCRIPTION
Change CSV annotation `operators.openshift.io/valid-subscription` in bundle/manifests to remove erroneous 'OpenShift Kubernetes Engine'.

xref: http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/cert-manager-operator-bundle-container-v1.9.1-11/fd9b45f0-603f-477e-a04d-433c16bc68bc/operator-valid-subscriptions-bundle-image-output.txt

Signed-off-by: Swarup Ghosh <swghosh@redhat.com>