### PR TITLE
[CFE-698] Unsupported config overrides to use union of default args

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cert-manager/cert-manager v1.9.1
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/golangci/golangci-lint v1.50.1
+	github.com/google/go-cmp v0.5.9
 	github.com/google/go-jsonnet v0.17.0
 	github.com/mogensen/kubernetes-split-yaml v0.3.0
 	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68
@@ -106,7 +107,6 @@ require (
 	github.com/golangci/revgrep v0.0.0-20220804021717-745bb2f7c2e6 // indirect
 	github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.0 // indirect

--- a/pkg/controller/deployment/unsupported_config_overrides.go
+++ b/pkg/controller/deployment/unsupported_config_overrides.go
@@ -1,23 +1,72 @@
 package deployment
 
 import (
+	"fmt"
+	"strings"
+
 	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
 )
 
+const argKeyValSeparator = "="
+
+// UnsupportedConfigOverrides overrides the values of container args in the deployment
 func UnsupportedConfigOverrides(deployment *appsv1.Deployment, unsupportedConfigOverrides *v1alpha1.UnsupportedConfigOverrides) *appsv1.Deployment {
 	if unsupportedConfigOverrides == nil {
 		return deployment
 	}
 	if len(unsupportedConfigOverrides.Webhook.Args) > 0 && deployment.Name == "cert-manager-webhook" {
-		deployment.Spec.Template.Spec.Containers[0].Args = unsupportedConfigOverrides.Webhook.Args
+		deployment.Spec.Template.Spec.Containers[0].Args = mergeContainerArgs(
+			deployment.Spec.Template.Spec.Containers[0].Args,
+			unsupportedConfigOverrides.Webhook.Args)
 	}
 	if len(unsupportedConfigOverrides.CAInjector.Args) > 0 && deployment.Name == "cert-manager-cainjector" {
-		deployment.Spec.Template.Spec.Containers[0].Args = unsupportedConfigOverrides.CAInjector.Args
+		deployment.Spec.Template.Spec.Containers[0].Args = mergeContainerArgs(
+			deployment.Spec.Template.Spec.Containers[0].Args,
+			unsupportedConfigOverrides.CAInjector.Args)
 	}
 	if len(unsupportedConfigOverrides.Controller.Args) > 0 && deployment.Name == "cert-manager" {
-		deployment.Spec.Template.Spec.Containers[0].Args = unsupportedConfigOverrides.Controller.Args
+		deployment.Spec.Template.Spec.Containers[0].Args = mergeContainerArgs(
+			deployment.Spec.Template.Spec.Containers[0].Args,
+			unsupportedConfigOverrides.Controller.Args)
 	}
 	return deployment
+}
+
+// mergeContainerArgs merges the source args with override values
+// using a map that tracks unique keys for each arg containing a
+// key value pair of form `key[=value]`
+func mergeContainerArgs(sourceArgs []string, overrideArgs []string) (destArgs []string) {
+	destArgMap := map[string]string{}
+	parseArgMap(destArgMap, sourceArgs)
+	parseArgMap(destArgMap, overrideArgs)
+
+	destArgs = make([]string, len(destArgMap))
+	i := 0
+	for key, val := range destArgMap {
+		if len(val) > 0 {
+			destArgs[i] = fmt.Sprintf("%s%s%s", key, argKeyValSeparator, val)
+		} else {
+			destArgs[i] = key
+		}
+		i++
+	}
+	return destArgs
+}
+
+// parseArgMap adds new entries to the map using keys
+// parsed from each arg (of the form `key=[value]`) from the
+// list of args
+func parseArgMap(argMap map[string]string, args []string) {
+	for _, arg := range args {
+		splitted := strings.Split(arg, argKeyValSeparator)
+		if len(splitted) > 0 && arg != "" {
+			key := splitted[0]
+			// ensure that for given arg eg. "--gate=FeatureA=true"Config
+			// the value remains "FeatureA=true" instead of just "FeatureA"
+			value := strings.Join(splitted[1:], argKeyValSeparator)
+			argMap[key] = value
+		}
+	}
 }

--- a/pkg/controller/deployment/unsupported_config_overrides_test.go
+++ b/pkg/controller/deployment/unsupported_config_overrides_test.go
@@ -1,60 +1,210 @@
 package deployment
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
 	"github.com/openshift/cert-manager-operator/pkg/operator/assets"
 )
 
 func TestUnsupportedConfigOverrides(t *testing.T) {
-	deploymentFile, err := assets.Asset("cert-manager-deployment/controller/cert-manager-deployment.yaml")
-	require.NoError(t, err)
-	testDeployment := resourceread.ReadDeploymentV1OrDie(deploymentFile)
-	defaultArgs := testDeployment.Spec.Template.Spec.Containers[0].Args
+	deploymentAssetPaths := map[string]string{
+		"cert-manager":            "cert-manager-deployment/controller/cert-manager-deployment.yaml",
+		"cert-manager-cainjector": "cert-manager-deployment/cainjector/cert-manager-cainjector-deployment.yaml",
+		"cert-manager-webhook":    "cert-manager-deployment/webhook/cert-manager-webhook-deployment.yaml",
+	}
+	deployments := make(map[string]*appsv1.Deployment)
+	for deploymentName, assetPath := range deploymentAssetPaths {
+		manifestFile, err := assets.Asset(assetPath)
+		require.NoError(t, err)
+		deployments[deploymentName] = resourceread.ReadDeploymentV1OrDie(manifestFile)
+	}
+
+	deploymentDefaultArgs := make(map[string][]string)
+	for deploymentName := range deployments {
+		deploymentDefaultArgs[deploymentName] = deployments[deploymentName].Spec.Template.Spec.Containers[0].Args
+	}
+
+	testArgsToAppend := []string{
+		"--test-arg", "--featureX=enable",
+	}
+	testArgsToOverrideReplace := []string{
+		"--v=5", "--featureY=disable",
+	}
 
 	type TestData struct {
-		overrides *v1alpha1.UnsupportedConfigOverrides
-		wantArgs  []string
+		deploymentName string
+		overrides      *v1alpha1.UnsupportedConfigOverrides
+		wantArgs       []string
 	}
 	tests := map[string]TestData{
-		"nil config overrides should not touch the deployment": {
-			overrides: nil,
-			wantArgs:  defaultArgs,
+		// unsupported config overrides as nil
+		"nil config overrides should not touch the controller deployment": {
+			deploymentName: "cert-manager",
+			overrides:      nil,
+			wantArgs:       deploymentDefaultArgs["cert-manager"],
 		},
-		"Empty config overrides should not touch the deployment": {
-			overrides: &v1alpha1.UnsupportedConfigOverrides{},
-			wantArgs:  defaultArgs,
+		"nil config overrides should not touch the cainjector deployment": {
+			deploymentName: "cert-manager-cainjector",
+			overrides:      nil,
+			wantArgs:       deploymentDefaultArgs["cert-manager-cainjector"],
 		},
-		"Other config overrides should not touch the controller": {
+		"nil config overrides should not touch the webhook deployment": {
+			deploymentName: "cert-manager-webhook",
+			overrides:      nil,
+			wantArgs:       deploymentDefaultArgs["cert-manager-webhook"],
+		},
+
+		// unsupported config overrides as empty
+		"Empty config overrides should not touch the controller deployment": {
+			deploymentName: "cert-manager",
+			overrides:      &v1alpha1.UnsupportedConfigOverrides{},
+			wantArgs:       deploymentDefaultArgs["cert-manager"],
+		},
+		"Empty config overrides should not touch the cainjector deployment": {
+			deploymentName: "cert-manager-cainjector",
+			overrides:      &v1alpha1.UnsupportedConfigOverrides{},
+			wantArgs:       deploymentDefaultArgs["cert-manager-cainjector"],
+		},
+		"Empty config overrides should not touch the webhook deployment": {
+			deploymentName: "cert-manager-webhook",
+			overrides:      &v1alpha1.UnsupportedConfigOverrides{},
+			wantArgs:       deploymentDefaultArgs["cert-manager-webhook"],
+		},
+
+		// unsupported config overrides for webhook, cainjector should not
+		// modify controller deployment
+		"Other config overrides should not touch the controller deployment": {
+			deploymentName: "cert-manager",
 			overrides: &v1alpha1.UnsupportedConfigOverrides{
 				Webhook: v1alpha1.UnsupportedConfigOverridesForCertManagerWebhook{
-					Args: []string{"test"},
+					Args: testArgsToAppend,
 				},
 				CAInjector: v1alpha1.UnsupportedConfigOverridesForCertManagerCAInjector{
-					Args: []string{"test"},
+					Args: testArgsToAppend,
 				},
 			},
-			wantArgs: defaultArgs,
+			wantArgs: deploymentDefaultArgs["cert-manager"],
 		},
-		"Controller overrides should work": {
+
+		// unsupported config overrides as a mechanism of appending new args
+		"Controller overrides should append newer overriden values": {
+			deploymentName: "cert-manager",
 			overrides: &v1alpha1.UnsupportedConfigOverrides{
 				Controller: v1alpha1.UnsupportedConfigOverridesForCertManagerController{
-					Args: []string{"test"},
+					Args: testArgsToAppend,
 				},
 			},
-			wantArgs: []string{"test"},
+			wantArgs: append(deploymentDefaultArgs["cert-manager"], testArgsToAppend...),
+		},
+		"CAInjector overrides should append newer overriden values": {
+			deploymentName: "cert-manager-cainjector",
+			overrides: &v1alpha1.UnsupportedConfigOverrides{
+				CAInjector: v1alpha1.UnsupportedConfigOverridesForCertManagerCAInjector{
+					Args: testArgsToAppend,
+				},
+			},
+			wantArgs: append(deploymentDefaultArgs["cert-manager-cainjector"], testArgsToAppend...),
+		},
+		"Webhook overrides should append newer overriden values": {
+			deploymentName: "cert-manager-webhook",
+			overrides: &v1alpha1.UnsupportedConfigOverrides{
+				Webhook: v1alpha1.UnsupportedConfigOverridesForCertManagerWebhook{
+					Args: testArgsToAppend,
+				},
+			},
+			wantArgs: append(deploymentDefaultArgs["cert-manager-webhook"], testArgsToAppend...),
+		},
+
+		// unsupported config overrides as a mechanism of replacing existing values
+		// of already present args
+		"Controller overrides existing values for --v": {
+			deploymentName: "cert-manager",
+			overrides: &v1alpha1.UnsupportedConfigOverrides{
+				Controller: v1alpha1.UnsupportedConfigOverridesForCertManagerController{
+					Args: testArgsToOverrideReplace,
+				},
+			},
+			wantArgs: append(
+				removeFromSlice(deploymentDefaultArgs["cert-manager"], "--v="),
+				testArgsToOverrideReplace...,
+			),
+		},
+		"CAInjector overrides existing values for --v": {
+			deploymentName: "cert-manager-cainjector",
+			overrides: &v1alpha1.UnsupportedConfigOverrides{
+				CAInjector: v1alpha1.UnsupportedConfigOverridesForCertManagerCAInjector{
+					Args: testArgsToOverrideReplace,
+				},
+			},
+			wantArgs: append(
+				removeFromSlice(deploymentDefaultArgs["cert-manager-cainjector"], "--v="),
+				testArgsToOverrideReplace...,
+			),
+		},
+		"Webhook overrides existing values for --v": {
+			deploymentName: "cert-manager-webhook",
+			overrides: &v1alpha1.UnsupportedConfigOverrides{
+				Webhook: v1alpha1.UnsupportedConfigOverridesForCertManagerWebhook{
+					Args: testArgsToOverrideReplace,
+				},
+			},
+			wantArgs: append(
+				removeFromSlice(deploymentDefaultArgs["cert-manager-webhook"], "--v="),
+				testArgsToOverrideReplace...,
+			),
 		},
 	}
+
 	for tcName, tcData := range tests {
 		tcName := tcName
 		tcData := tcData
 		t.Run(tcName, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tcData.wantArgs, UnsupportedConfigOverrides(testDeployment.DeepCopy(), tcData.overrides).Spec.Template.Spec.Containers[0].Args)
+			newDeployment := UnsupportedConfigOverrides(deployments[tcData.deploymentName].DeepCopy(), tcData.overrides)
+			require.ElementsMatch(t, tcData.wantArgs, newDeployment.Spec.Template.Spec.Containers[0].Args)
 		})
 	}
+}
+
+func TestParseArgMap(t *testing.T) {
+	testArgs := []string{
+		"", // should be ignored at the time of parse
+		"--", "--foo", "--v=1", "--test=v1=v2", "--gates=Feature1=True",
+		"--log-level=Debug=false,Info=false,Warning=True,Error=true",
+		"--extra-flags='--v=2 --gates=Feature2=True'",
+	}
+	wantMap := map[string]string{
+		"--":            "",
+		"--foo":         "",
+		"--v":           "1",
+		"--test":        "v1=v2",
+		"--gates":       "Feature1=True",
+		"--log-level":   "Debug=false,Info=false,Warning=True,Error=true",
+		"--extra-flags": "'--v=2 --gates=Feature2=True'",
+	}
+
+	argMap := make(map[string]string)
+	parseArgMap(argMap, testArgs)
+	if !reflect.DeepEqual(argMap, wantMap) {
+		t.Fatalf("unexpected update to arg map, diff = %v", cmp.Diff(wantMap, argMap))
+	}
+}
+
+// removeFromSlice constructs a new slice by removing string(s) with prefix
+func removeFromSlice(args []string, removalPrefix string) []string {
+	targetArgs := []string{}
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, removalPrefix) {
+			targetArgs = append(targetArgs, arg)
+		}
+	}
+	return targetArgs
 }


### PR DESCRIPTION
Currently, using UnsupportedConfigOverrides does not take the union of the default args. This change allows the override to work such that it can merge expected default values with user provided overrides.

Signed-off-by: Swarup Ghosh <swghosh@redhat.com>