### PR TITLE
Fix namespace in Makefile, change to default namespace in alm-examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ verify-deps:
 	hack/verify-deps.sh
 
 local-run: build
-	./cert-manager-operator start --config=./hack/local-run-config.yaml --kubeconfig=$${KUBECONFIG:-$$HOME/.kube/config} --namespace=openshift-cert-manager-operator
+	./cert-manager-operator start --config=./hack/local-run-config.yaml --kubeconfig=$${KUBECONFIG:-$$HOME/.kube/config} --namespace=cert-manager-operator
 .PHONY: local-run
 
 ##@ Build

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Update the version of cert-manager in the `Makefile`:
   +++ b/Makefile
   @@ -13,7 +13,7 @@ BUNDLE_IMAGE_TAG?=latest
   
-  TEST_OPERATOR_NAMESPACE?=openshift-cert-manager-operator
+  TEST_OPERATOR_NAMESPACE?=cert-manager-operator
   
   -MANIFEST_SOURCE = https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.yaml
   +MANIFEST_SOURCE = https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
           "kind": "Challenge",
           "metadata": {
             "name": "tls-cert-sample",
-            "namespace": "sample-namespace"
+            "namespace": "default"
           },
           "spec": {
             "authorizationURL": "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX",
@@ -53,7 +53,7 @@ metadata:
               "cert-manager.io/private-key-secret-name": "tls-cert-sample"
             },
             "name": "tls-cert-sample",
-            "namespace": "sample-namespace"
+            "namespace": "default"
           },
           "spec": {
             "commonName": "sample.dns.name",
@@ -72,7 +72,7 @@ metadata:
           "kind": "Certificate",
           "metadata": {
             "name": "selfsigned-ca",
-            "namespace": "sample-namespace"
+            "namespace": "default"
           },
           "spec": {
             "commonName": "selfsigned-ca.dns.name",
@@ -94,7 +94,7 @@ metadata:
           "kind": "Certificate",
           "metadata": {
             "name": "tls-cert",
-            "namespace": "sample-namespace"
+            "namespace": "default"
           },
           "spec": {
             "commonName": "sample.dns.name",
@@ -119,7 +119,7 @@ metadata:
               "cert-manager.io/private-key-secret-name": "tls-cert-sample"
             },
             "name": "tls-cert-sample",
-            "namespace": "sample-namespace"
+            "namespace": "default"
           },
           "spec": {
             "groups": [
@@ -150,7 +150,7 @@ metadata:
           "kind": "Issuer",
           "metadata": {
             "name": "ca-issuer",
-            "namespace": "sample-namespace"
+            "namespace": "default"
           },
           "spec": {
             "ca": {
@@ -163,7 +163,7 @@ metadata:
           "kind": "Issuer",
           "metadata": {
             "name": "letsencrypt-staging",
-            "namespace": "sample-namespace"
+            "namespace": "default"
           },
           "spec": {
             "acme": {

--- a/config/samples/letsencrypt/cert-manager.io_v1_certificate.yaml
+++ b/config/samples/letsencrypt/cert-manager.io_v1_certificate.yaml
@@ -2,7 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: tls-cert
-  namespace: sample-namespace
+  namespace: default
 spec:
   isCA: false
   commonName: "sample.dns.name" #❗Replace this with your own DNS name

--- a/config/samples/letsencrypt/cert-manager.io_v1_issuer.yaml
+++ b/config/samples/letsencrypt/cert-manager.io_v1_issuer.yaml
@@ -2,7 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: letsencrypt-staging
-  namespace: sample-namespace
+  namespace: default
 spec:
   acme:
     server: https://acme-staging-v02.api.letsencrypt.org/directory

--- a/config/samples/letsencrypt/extra/acme.cert-manager.io_v1_challenge.yaml
+++ b/config/samples/letsencrypt/extra/acme.cert-manager.io_v1_challenge.yaml
@@ -2,7 +2,7 @@ apiVersion: acme.cert-manager.io/v1
 kind: Challenge
 metadata:
   name: tls-cert-sample
-  namespace: sample-namespace
+  namespace: default
 spec:
   authorizationURL: https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/XXXXX
   dnsName: sample.dns.name

--- a/config/samples/letsencrypt/extra/acme.cert-manager.io_v1_order.yaml
+++ b/config/samples/letsencrypt/extra/acme.cert-manager.io_v1_order.yaml
@@ -6,7 +6,7 @@ metadata:
     cert-manager.io/certificate-revision: "1"
     cert-manager.io/private-key-secret-name: tls-cert-sample
   name: tls-cert-sample
-  namespace: sample-namespace
+  namespace: default
 spec:
   commonName: sample.dns.name
   dnsNames:

--- a/config/samples/letsencrypt/extra/cert-manager.io_v1_certificaterequest.yaml
+++ b/config/samples/letsencrypt/extra/cert-manager.io_v1_certificaterequest.yaml
@@ -6,7 +6,7 @@ metadata:
     cert-manager.io/certificate-revision: "1"
     cert-manager.io/private-key-secret-name: tls-cert-sample
   name: tls-cert-sample
-  namespace: sample-namespace
+  namespace: default
 spec:
   groups:
   - system:serviceaccounts

--- a/config/samples/selfsigned/cert-manager.io_v1_certificate.yaml
+++ b/config/samples/selfsigned/cert-manager.io_v1_certificate.yaml
@@ -2,7 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: selfsigned-ca
-  namespace: sample-namespace
+  namespace: default
 spec:
   isCA: true
   commonName: selfsigned-ca.dns.name

--- a/config/samples/selfsigned/cert-manager.io_v1_issuer.yaml
+++ b/config/samples/selfsigned/cert-manager.io_v1_issuer.yaml
@@ -2,7 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: ca-issuer
-  namespace: sample-namespace
+  namespace: default
 spec:
   ca:
     secretName: ca-root-secret


### PR DESCRIPTION
As a part of #83 we changed the operator namespace to use "cert-manager-operator" instead of "openshift-cert-manager-operator". In certain files such as README.md (upgrade section) as well as Makefile (local-run target) the value of the namespace reflects old value. This is intended at changing those values.

Additionally, the entries in alm-examples of the ClusterServiceVersion used to have `namespace: sample-namespace`, this PR would change it to `namespace: default` easing in applying the manifests.

Signed-off-by: Swarup Ghosh <swghosh@redhat.com>