### PR TITLE
CFE-754: Add seccompProfile RuntimeDefault to operator deployment

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -653,6 +653,8 @@ spec:
                     type: RuntimeDefault
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: cert-manager-operator-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,6 +36,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
           - /usr/bin/cert-manager-operator


### PR DESCRIPTION
Add seccompProfile RuntimeDefault to deployment which helps avoid pod security violation of operator pod(s).

Signed-off-by: Swarup Ghosh <swghosh@redhat.com>