### PR TITLE
CFE-755: Support cluster-wide egress proxy injection

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -213,6 +213,7 @@ metadata:
     createdAt: 2023-03-03T00:00:00
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: cert-manager-operator
+    operators.openshift.io/infrastructure-features: '["proxy-aware"]'
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.25.1
@@ -620,6 +621,7 @@ spec:
                     type: RuntimeDefault
               - args:
                 - start
+                - --trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)
                 command:
                 - /usr/bin/cert-manager-operator
                 env:
@@ -643,6 +645,7 @@ spec:
                   value: 1.10.2
                 - name: OPERATOR_IMAGE_VERSION
                   value: 1.10.2
+                - name: TRUSTED_CA_CONFIGMAP_NAME
                 image: openshift.io/cert-manager-operator:latest
                 imagePullPolicy: Always
                 name: cert-manager-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,6 +43,7 @@ spec:
           - /usr/bin/cert-manager-operator
         args:
           - start
+          - "--trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)"
         env:
           - name: WATCH_NAMESPACE
             valueFrom:
@@ -64,6 +65,7 @@ spec:
             value: 1.10.2
           - name: OPERATOR_IMAGE_VERSION
             value: 1.10.2
+          - name: TRUSTED_CA_CONFIGMAP_NAME
         image: controller:latest
         imagePullPolicy: Always
         name: cert-manager-operator

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -9,6 +9,7 @@ metadata:
     createdAt: 2023-03-03T00:00:00
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: cert-manager-operator
+    operators.openshift.io/infrastructure-features: '["proxy-aware"]'
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
       Platform Plus"]'
     operators.operatorframework.io/project_layout: unknown

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,0 +1,52 @@
+# Configuring egress proxy for Cert Manager Operator
+
+If a cluster wide egress proxy is configured on the OpenShift cluster, OLM automatically update all the operators' deployments with `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` environment variables.  
+Those variables are then propagated down to the cert-manager (operand) controllers by the cert manager operator.
+
+## Trusted Certificate Authority
+
+### Running operator
+
+Follow the instructions below to let Cert Manager Operator trust a custom Certificate Authority (CA). The operator's OLM subscription has to be already created.
+
+1.  Create the configmap containing the CA bundle in `cert-manager` namespace. Run the following commands to [inject](https://docs.openshift.com/container-platform/4.12/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki) the CA bundle trusted by OpenShift into a configmap:
+
+    ```bash
+    oc -n cert-manager create configmap trusted-ca
+    oc -n cert-manager label cm trusted-ca config.openshift.io/inject-trusted-cabundle=true
+    ```
+
+2.  Consume the created configmap in Cert Manager Operator's deployment by updating its subscription:
+
+        ```bash
+        oc -n cert-manager-operator patch subscription cert-manager-operator --type='merge' -p '{"spec":{"config":{"env":[{"name":"TRUSTED_CA_CONFIGMAP_NAME","value":"trusted-ca"}]}}}'
+        ```
+
+    _Note_: Alternatively, you can also patch the `cert-manager-operator-controller-manager` deployment in the `cert-manager-operator` namespace.
+    `bash
+    oc set env deployment/cert-manager-operator-controller-manager TRUSTED_CA_CONFIGMAP_NAME=trusted-ca 
+    `
+
+3.  Wait for the operator deployment to finish the rollout and verify that CA bundle is added to the existing controller:
+
+    ```bash
+    oc get deployment -n cert-manager cert-manager -o=jsonpath={.spec.template.spec.'containers[0].volumeMounts'} | jq
+    [
+      {
+        "mountPath": "/etc/pki/tls/certs/cert-manager-tls-ca-bundle.crt",
+        "name": "trusted-ca",
+        "subPath": "ca-bundle.crt"
+      }
+    ]
+
+    oc get deployment -n cert-manager cert-manager -o=jsonpath={.spec.template.spec.volumes} | jq
+    [
+      {
+        "configMap": {
+          "defaultMode": 420,
+          "name": "trusted-ca"
+        },
+        "name": "trusted-ca"
+      }
+    ]
+    ```

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20230120202327-72f107311084
 	github.com/openshift/library-go v0.0.0-20230120214501-9bc305884fcb
+	github.com/operator-framework/operator-lib v0.11.0
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -676,6 +676,8 @@ github.com/openshift/client-go v0.0.0-20230120202327-72f107311084 h1:66uaqNwA+qY
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084/go.mod h1:M3h9m001PWac3eAudGG3isUud6yBjr5XpzLYLLTlHKo=
 github.com/openshift/library-go v0.0.0-20230120214501-9bc305884fcb h1:ru6U+KzNbVFZXSfUkuH6WfHGCZ8rpBvKkJo8nXF+n5k=
 github.com/openshift/library-go v0.0.0-20230120214501-9bc305884fcb/go.mod h1:wrrjvk/CK+nte9Wxend9/K6apy6Zep28lzM27/aJar8=
+github.com/operator-framework/operator-lib v0.11.0 h1:eYzqpiOfq9WBI4Trddisiq/X9BwCisZd3rIzmHRC9Z8=
+github.com/operator-framework/operator-lib v0.11.0/go.mod h1:RpyKhFAoG6DmKTDIwMuO6pI3LRc8IE9rxEYWy476o6g=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -18,5 +18,6 @@ func NewOperator() *cobra.Command {
 	).NewCommandWithContext(context.TODO())
 	cmd.Use = "start"
 	cmd.Short = "Start the cert-manager Operator"
+	cmd.Flags().StringVar(&operator.TrustedCAConfigMapName, "trusted-ca-configmap", "", "The name of the config map containing TLS CA(s) which should be trusted by the controller's containers. PEM encoded file under \"ca-bundle.crt\" key is expected.")
 	return cmd
 }

--- a/pkg/controller/deployment/cert_manager_cainjector_deployment.go
+++ b/pkg/controller/deployment/cert_manager_cainjector_deployment.go
@@ -33,7 +33,7 @@ var (
 
 func NewCertManagerCAInjectorStaticResourcesController(operatorClient v1helpers.OperatorClient,
 	kubeClientContainer *resourceapply.ClientHolder,
-	kubeInformersForTargetNamespace v1helpers.KubeInformersForNamespaces,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	eventsRecorder events.Recorder,
 ) factory.Controller {
 	return staticresourcecontroller.NewStaticResourceController(
@@ -43,7 +43,7 @@ func NewCertManagerCAInjectorStaticResourcesController(operatorClient v1helpers.
 		kubeClientContainer,
 		operatorClient,
 		eventsRecorder,
-	).AddKubeInformers(kubeInformersForTargetNamespace)
+	).AddKubeInformers(kubeInformersForNamespaces)
 }
 
 func NewCertManagerCAInjectorDeploymentController(operatorClient v1helpers.OperatorClientWithFinalizers,
@@ -51,6 +51,7 @@ func NewCertManagerCAInjectorDeploymentController(operatorClient v1helpers.Opera
 	kubeClient kubernetes.Interface,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
 	eventsRecorder events.Recorder, targetVersion string, versionRecorder status.VersionGetter,
+	trustedCAConfigmapName string,
 ) factory.Controller {
 	return newGenericDeploymentController(
 		certManagerCAInjectorDeploymentControllerName,
@@ -61,5 +62,7 @@ func NewCertManagerCAInjectorDeploymentController(operatorClient v1helpers.Opera
 		kubeClient,
 		kubeInformersForTargetNamespace,
 		eventsRecorder,
-		versionRecorder)
+		versionRecorder,
+		trustedCAConfigmapName,
+	)
 }

--- a/pkg/controller/deployment/cert_manager_controller_deployment.go
+++ b/pkg/controller/deployment/cert_manager_controller_deployment.go
@@ -55,7 +55,7 @@ var (
 
 func NewCertManagerControllerStaticResourcesController(operatorClient v1helpers.OperatorClient,
 	kubeClientContainer *resourceapply.ClientHolder,
-	kubeInformersForTargetNamespace v1helpers.KubeInformersForNamespaces,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	eventsRecorder events.Recorder) factory.Controller {
 	return staticresourcecontroller.NewStaticResourceController(
 		certManagerControllerStaticResourcesControllerName,
@@ -64,14 +64,14 @@ func NewCertManagerControllerStaticResourcesController(operatorClient v1helpers.
 		kubeClientContainer,
 		operatorClient,
 		eventsRecorder,
-	).AddKubeInformers(kubeInformersForTargetNamespace)
+	).AddKubeInformers(kubeInformersForNamespaces)
 }
 
 func NewCertManagerControllerDeploymentController(operatorClient v1helpers.OperatorClientWithFinalizers,
 	certManagerOperatorInformers certmanoperatorinformers.SharedInformerFactory,
 	kubeClient kubernetes.Interface,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
-	eventsRecorder events.Recorder, targetVersion string, versionRecorder status.VersionGetter) factory.Controller {
+	eventsRecorder events.Recorder, targetVersion string, versionRecorder status.VersionGetter, trustedCAConfigmapName string) factory.Controller {
 	return newGenericDeploymentController(
 		certManagerControllerDeploymentControllerName,
 		targetVersion,
@@ -81,5 +81,7 @@ func NewCertManagerControllerDeploymentController(operatorClient v1helpers.Opera
 		kubeClient,
 		kubeInformersForTargetNamespace,
 		eventsRecorder,
-		versionRecorder)
+		versionRecorder,
+		trustedCAConfigmapName,
+	)
 }

--- a/pkg/controller/deployment/cert_manager_controller_set.go
+++ b/pkg/controller/deployment/cert_manager_controller_set.go
@@ -24,22 +24,23 @@ type CertManagerControllerSet struct {
 
 func NewCertManagerControllerSet(
 	kubeClient kubernetes.Interface,
-	kubeInformersForTargetNamespace v1helpers.KubeInformersForNamespaces,
-	informersFactory informers.SharedInformerFactory,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	kubeInformersForTargetNamespace informers.SharedInformerFactory,
 	operatorClient v1helpers.OperatorClientWithFinalizers,
 	certManagerOperatorInformers certmanoperatorinformers.SharedInformerFactory,
 	kubeClientContainer *resourceapply.ClientHolder,
 	eventRecorder events.Recorder,
 	targetVersion string,
 	versionRecorder status.VersionGetter,
+	trustedCAConfigmapName string,
 ) *CertManagerControllerSet {
 	return &CertManagerControllerSet{
-		certManagerControllerStaticResourcesController: NewCertManagerControllerStaticResourcesController(operatorClient, kubeClientContainer, kubeInformersForTargetNamespace, eventRecorder),
-		certManagerControllerDeploymentController:      NewCertManagerControllerDeploymentController(operatorClient, certManagerOperatorInformers, kubeClient, informersFactory, eventRecorder, targetVersion, versionRecorder),
-		certManagerWebhookStaticResourcesController:    NewCertManagerWebhookStaticResourcesController(operatorClient, kubeClientContainer, kubeInformersForTargetNamespace, eventRecorder),
-		certManagerWebhookDeploymentController:         NewCertManagerWebhookDeploymentController(operatorClient, certManagerOperatorInformers, kubeClient, informersFactory, eventRecorder, targetVersion, versionRecorder),
-		certManagerCAInjectorStaticResourcesController: NewCertManagerCAInjectorStaticResourcesController(operatorClient, kubeClientContainer, kubeInformersForTargetNamespace, eventRecorder),
-		certManagerCAInjectorDeploymentController:      NewCertManagerCAInjectorDeploymentController(operatorClient, certManagerOperatorInformers, kubeClient, informersFactory, eventRecorder, targetVersion, versionRecorder),
+		certManagerControllerStaticResourcesController: NewCertManagerControllerStaticResourcesController(operatorClient, kubeClientContainer, kubeInformersForNamespaces, eventRecorder),
+		certManagerControllerDeploymentController:      NewCertManagerControllerDeploymentController(operatorClient, certManagerOperatorInformers, kubeClient, kubeInformersForTargetNamespace, eventRecorder, targetVersion, versionRecorder, trustedCAConfigmapName),
+		certManagerWebhookStaticResourcesController:    NewCertManagerWebhookStaticResourcesController(operatorClient, kubeClientContainer, kubeInformersForNamespaces, eventRecorder),
+		certManagerWebhookDeploymentController:         NewCertManagerWebhookDeploymentController(operatorClient, certManagerOperatorInformers, kubeClient, kubeInformersForTargetNamespace, eventRecorder, targetVersion, versionRecorder, trustedCAConfigmapName),
+		certManagerCAInjectorStaticResourcesController: NewCertManagerCAInjectorStaticResourcesController(operatorClient, kubeClientContainer, kubeInformersForNamespaces, eventRecorder),
+		certManagerCAInjectorDeploymentController:      NewCertManagerCAInjectorDeploymentController(operatorClient, certManagerOperatorInformers, kubeClient, kubeInformersForTargetNamespace, eventRecorder, targetVersion, versionRecorder, trustedCAConfigmapName),
 	}
 }
 

--- a/pkg/controller/deployment/cert_manager_webhook_deployment.go
+++ b/pkg/controller/deployment/cert_manager_webhook_deployment.go
@@ -37,7 +37,7 @@ var (
 
 func NewCertManagerWebhookStaticResourcesController(operatorClient v1helpers.OperatorClient,
 	kubeClientContainer *resourceapply.ClientHolder,
-	kubeInformersForTargetNamespace v1helpers.KubeInformersForNamespaces,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	eventsRecorder events.Recorder) factory.Controller {
 	return staticresourcecontroller.NewStaticResourceController(
 		certManagerWebhookStaticResourcesControllerName,
@@ -46,14 +46,14 @@ func NewCertManagerWebhookStaticResourcesController(operatorClient v1helpers.Ope
 		kubeClientContainer,
 		operatorClient,
 		eventsRecorder,
-	).AddKubeInformers(kubeInformersForTargetNamespace)
+	).AddKubeInformers(kubeInformersForNamespaces)
 }
 
 func NewCertManagerWebhookDeploymentController(operatorClient v1helpers.OperatorClientWithFinalizers,
 	certManagerOperatorInformers certmanoperatorinformers.SharedInformerFactory,
 	kubeclient kubernetes.Interface,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
-	eventsRecorder events.Recorder, targetVersion string, versionRecorder status.VersionGetter) factory.Controller {
+	eventsRecorder events.Recorder, targetVersion string, versionRecorder status.VersionGetter, trustedCAConfigmapName string) factory.Controller {
 	return newGenericDeploymentController(
 		certManagerWebhookDeploymentControllerName,
 		targetVersion,
@@ -63,5 +63,7 @@ func NewCertManagerWebhookDeploymentController(operatorClient v1helpers.Operator
 		kubeclient,
 		kubeInformersForTargetNamespace,
 		eventsRecorder,
-		versionRecorder)
+		versionRecorder,
+		trustedCAConfigmapName,
+	)
 }

--- a/pkg/controller/deployment/deployment_overrides.go
+++ b/pkg/controller/deployment/deployment_overrides.go
@@ -1,14 +1,30 @@
 package deployment
 
 import (
+	"fmt"
 	"sort"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	coreinformersv1 "k8s.io/client-go/informers/core/v1"
 
 	v1 "github.com/openshift/api/operator/v1"
+	"github.com/operator-framework/operator-lib/proxy"
 
 	certmanagerinformer "github.com/openshift/cert-manager-operator/pkg/operator/informers/externalversions/operator/v1alpha1"
+	"github.com/openshift/cert-manager-operator/pkg/operator/operatorclient"
+)
+
+const (
+	// trustedCAVolumeName is the name of the volume with the CA bundle to be trusted by the controller.
+	trustedCAVolumeName = "trusted-ca"
+	// trustedCAPath is the mounting path for the trusted CA bundle.
+	// Default certificate path is taken from the golang source:
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.19.5:src/crypto/x509/root_linux.go;drc=82f09b75ca181a6be0e594e1917e4d3d91934b27;l=20
+	trustedCAPath = "/etc/pki/tls/certs/cert-manager-tls-ca-bundle.crt"
+	// defaultCABundleKey is the default name for the data key of the configmap injected with the trusted CA.
+	defaultCABundleKey = "ca-bundle.crt"
 )
 
 // overrideArgsFunc defines a function signature that is accepted by
@@ -62,6 +78,52 @@ func withContainerEnvOverrideHook(certmanagerinformer certmanagerinformer.CertMa
 				deployment.Spec.Template.Spec.Containers[0].Env, overrideEnv)
 
 		}
+		return nil
+	}
+}
+
+// withProxyEnv patches the operand deployment if operator
+// has proxy variables set. Sets HTTPS_PROXY, HTTP_PROXY and NO_PROXY.
+func withProxyEnv(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+	deployment.Spec.Template.Spec.Containers[0].Env = mergeContainerEnvs(deployment.Spec.Template.Spec.Containers[0].Env, proxy.ReadProxyVarsFromEnv())
+	return nil
+}
+
+// withCAConfigMap patches the operand deployment to include the custom
+// ca bundle as a volume. This is set when a trusted ca configmap is provided.
+func withCAConfigMap(configmapinformer coreinformersv1.ConfigMapInformer, deployment *appsv1.Deployment, trustedCAConfigmapName string) func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+	return func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+
+		if len(trustedCAConfigmapName) == 0 {
+			return nil
+		}
+
+		_, err := configmapinformer.Lister().ConfigMaps(operatorclient.TargetNamespace).Get(trustedCAConfigmapName)
+		if err != nil && apierrors.IsNotFound(err) {
+			return fmt.Errorf("(Retrying) trusted CA config map %q doesn't exist due to %v", trustedCAConfigmapName, err)
+		} else if err != nil {
+			return err
+		}
+
+		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: trustedCAVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: trustedCAConfigmapName,
+					},
+				},
+			},
+		})
+
+		for i := range deployment.Spec.Template.Spec.Containers {
+			deployment.Spec.Template.Spec.Containers[i].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
+				Name:      trustedCAVolumeName,
+				MountPath: trustedCAPath,
+				SubPath:   defaultCABundleKey,
+			})
+		}
+
 		return nil
 	}
 }

--- a/vendor/github.com/operator-framework/operator-lib/LICENSE
+++ b/vendor/github.com/operator-framework/operator-lib/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/operator-framework/operator-lib/proxy/doc.go
+++ b/vendor/github.com/operator-framework/operator-lib/proxy/doc.go
@@ -1,0 +1,33 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package proxy implements helper functions to facilitate making operators proxy-aware.
+
+This package assumes that proxy environment variables `HTTPS_PROXY`,
+`HTTP_PROXY`, and/or `NO_PROXY` are set in the Operator environment, typically
+via the Operator deployment.
+
+Proxy-aware operators can use the ReadProxyVarsFromEnv to retrieve these values
+as a slice of corev1 EnvVars. Each of the proxy variables are duplicated in
+upper and lower case to support applications that use either. In their
+reconcile functions, Operator authors are then responsible for setting these
+variables in the Container Envs that must use the proxy, For example:
+
+	// Pods with Kubernetes < 1.22
+	for i, cSpec := range (myPod.Spec.Containers) {
+		myPod.Spec.Containers[i].Env = append(cSpec.Env, ReadProxyVarsFromEnv()...)
+	}
+*/
+package proxy

--- a/vendor/github.com/operator-framework/operator-lib/proxy/proxy.go
+++ b/vendor/github.com/operator-framework/operator-lib/proxy/proxy.go
@@ -1,0 +1,45 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ProxyEnvNames are standard environment variables for proxies
+var ProxyEnvNames = []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
+
+// ReadProxyVarsFromEnv retrieves the standard proxy-related environment
+// variables from the running environment and returns a slice of corev1 EnvVar
+// containing upper and lower case versions of those variables.
+func ReadProxyVarsFromEnv() []corev1.EnvVar {
+	envVars := []corev1.EnvVar{}
+	for _, s := range ProxyEnvNames {
+		value, isSet := os.LookupEnv(s)
+		if isSet {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  s,
+				Value: value,
+			}, corev1.EnvVar{
+				Name:  strings.ToLower(s),
+				Value: value,
+			})
+		}
+	}
+	return envVars
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -715,6 +715,9 @@ github.com/openshift/library-go/pkg/operator/staticresourcecontroller
 github.com/openshift/library-go/pkg/operator/status
 github.com/openshift/library-go/pkg/operator/v1helpers
 github.com/openshift/library-go/pkg/serviceability
+# github.com/operator-framework/operator-lib v0.11.0
+## explicit; go 1.17
+github.com/operator-framework/operator-lib/proxy
 # github.com/pelletier/go-toml v1.9.5
 ## explicit; go 1.12
 github.com/pelletier/go-toml


### PR DESCRIPTION
Description
---

This PR adds egress proxy injection support to the operator. Proxy environment variables will now be propagated to the operand from the operator deployment. This PR also provides an option to provide custom trusted CA certificates. 

- `pkg/controller/deployment/cert_manager_cainjector_deployment.go`, `pkg/controller/deployment/cert_manager_controller_set.go`, `pkg/controller/deployment/cert_manager_controller_deployment.go` and `pkg/controller/deployment/cert_manager_webhook_deployment.go` : Fix informers arg names and pass trusted CA configmap at runtime. 
- `pkg/controller/deployment/deployment_overrides.go` : Add 2 new deployment hooks to inject proxy env variables and inject trusted CA configmap as a volume. 
- `pkg/controller/deployment/generic_deployment_controller.go` : Add configmap informers to re-sync deployments (watch configmaps in the operand namespace).
