### PR TITLE
Add default channel as stable-v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ endif
 # To re-generate a bundle for any other default channel without changing the default setup, you can:
 # - use the DEFAULT_CHANNEL as arg of the bundle target (e.g make bundle DEFAULT_CHANNEL=stable)
 # - use environment variables to overwrite this value (e.g export DEFAULT_CHANNEL="stable")
+DEFAULT_CHANNEL ?= stable-v1
 ifneq ($(origin DEFAULT_CHANNEL), undefined)
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,6 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=cert-manager-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable-v1,stable-v1.10
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable-v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,6 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: cert-manager-operator
   operators.operatorframework.io.bundle.channels.v1: stable-v1,stable-v1.10
+  operators.operatorframework.io.bundle.channel.default.v1: stable-v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3


### PR DESCRIPTION
Add default channel as `stable-v1`

This is required for `index-image-build` make target, it fails without the `operators.operatorframework.io.bundle.channel.default.v1` label on Dockerfile &/ same annotation in metadata/annotations.yaml.

Signed-off-by: Swarup Ghosh <swghosh@redhat.com>