### PR TITLE
Add env vars for local-run make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ verify-deps:
 	hack/verify-deps.sh
 
 local-run: build
-	./cert-manager-operator start --config=./hack/local-run-config.yaml --kubeconfig=$${KUBECONFIG:-$$HOME/.kube/config} --namespace=cert-manager-operator
+	OPERATOR_NAME=cert-manager-operator OPERAND_IMAGE_VERSION=$(BUNDLE_VERSION) OPERATOR_IMAGE_VERSION=$(BUNDLE_VERSION) ./cert-manager-operator start --config=./hack/local-run-config.yaml --kubeconfig=$${KUBECONFIG:-$$HOME/.kube/config} --namespace=cert-manager-operator
 .PHONY: local-run
 
 ##@ Build


### PR DESCRIPTION
Add env vars needed in local-run make target which fixes an issue with operatorclient.EnsureFinalizer that was failing locally.

Helps avoid the following error (which was prevalent with `make local-run` during local debugging):
```
E0411 18:47:02.864606  215588 base_controller.go:272] cert-manager-controller-deployment reconciliation failed: CertManager.operator.openshift.io "cluster" is invalid: metadata.finalizers: Invalid value: "./cert-manager-operator.operator.openshift.io/cert-manager-controller-deployment": a qualified name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
E0411 18:47:03.062372  215588 base_controller.go:272] cert-manager-cainjector-deployment reconciliation failed: CertManager.operator.openshift.io "cluster" is invalid: metadata.finalizers: Invalid value: "./cert-manager-operator.operator.openshift.io/cert-manager-cainjector-deployment": a qualified name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
E0411 18:47:03.264785  215588 base_controller.go:272] cert-manager-webhook-deployment reconciliation failed: CertManager.operator.openshift.io "cluster" is invalid: metadata.finalizers: Invalid value: "./cert-manager-operator.operator.openshift.io/cert-manager-webhook-deployment": a qualified name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
```

Which was a result of finalizer name being set as `./cert-manager-operator.operator.openshift.io/...` cause: https://github.com/openshift/cert-manager-operator/blob/70e39c50c56a5819e05b46b6d34be53d7fef0951/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go#L266-L271
since local-run currently uses `"./cert-manager-operator ..."` inferred as `os.Args[0]`. 

Setting `OPERATOR_NAME` env var would fix the finalizer problem. Subsequently, also added env vars: `OPERAND_IMAGE_VERSION` and `OPERATOR_IMAGE_VERSION` that are used elsewhere in libary-go code.

Signed-off-by: Swarup Ghosh <swghosh@redhat.com>