### PR TITLE
Fix proxy.md

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -18,9 +18,9 @@ Follow the instructions below to let Cert Manager Operator trust a custom Certif
 
 2.  Consume the created configmap in Cert Manager Operator's deployment by updating its subscription:
 
-        ```bash
-        oc -n cert-manager-operator patch subscription cert-manager-operator --type='merge' -p '{"spec":{"config":{"env":[{"name":"TRUSTED_CA_CONFIGMAP_NAME","value":"trusted-ca"}]}}}'
-        ```
+    ```bash
+    oc -n cert-manager-operator patch subscription <subscription_name> --type='merge' -p '{"spec":{"config":{"env":[{"name":"TRUSTED_CA_CONFIGMAP_NAME","value":"trusted-ca"}]}}}'
+    ```
 
     _Note_: Alternatively, you can also patch the `cert-manager-operator-controller-manager` deployment in the `cert-manager-operator` namespace.
     `bash


### PR DESCRIPTION
/cc @swghosh @thejasn 
The display in https://github.com/openshift/cert-manager-operator/blob/master/docs/proxy.md does not hide ```bash, it displays as:

        ```bash
        oc -n cert-manager-operator patch subscription cert-manager-operator ...
        ```

Also, the subscription name (if installed via web) is `openshift-cert-manager-operator` instead. https://docs.openshift.com/container-platform/4.12/security/cert_manager_operator/cert-manager-operator-proxy.html needs update to be `subscription openshift-cert-manager-operator` as well (didn't catch this when GA sorry), CC @bergerhoffer .