### PR TITLE
OCPBUGS-10821: Update ACME solver image to read from env 

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -643,6 +643,8 @@ spec:
                   value: quay.io/jetstack/cert-manager-cainjector:v1.11.0
                 - name: RELATED_IMAGE_CERT_MANAGER_CONTROLLER
                   value: quay.io/jetstack/cert-manager-controller:v1.11.0
+                - name: RELATED_IMAGE_CERT_MANAGER_ACMESOLVER
+                  value: quay.io/jetstack/cert-manager-acmesolver:v1.11.0
                 - name: OPERAND_IMAGE_VERSION
                   value: 1.11.0
                 - name: OPERATOR_IMAGE_VERSION
@@ -737,4 +739,6 @@ spec:
     name: cert-manager-ca-injector
   - image: quay.io/jetstack/cert-manager-controller:v1.11.0
     name: cert-manager-controller
+  - image: quay.io/jetstack/cert-manager-acmesolver:v1.11.0
+    name: cert-manager-acmesolver
   version: 1.11.0

--- a/bundle/manifests/operator.openshift.io_certmanagers.yaml
+++ b/bundle/manifests/operator.openshift.io_certmanagers.yaml
@@ -160,6 +160,10 @@ spec:
                       - name
                       type: object
                     type: array
+                  overrideLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                 type: object
               controllerConfig:
                 description: "ControllerConfig specifies further customization options
@@ -290,6 +294,10 @@ spec:
                       - name
                       type: object
                     type: array
+                  overrideLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                 type: object
               logLevel:
                 default: Normal
@@ -470,6 +478,10 @@ spec:
                       - name
                       type: object
                     type: array
+                  overrideLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                 type: object
             type: object
           status:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,47 +39,49 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
-      - command:
-          - /usr/bin/cert-manager-operator
-        args:
-          - start
-          - "--v=$(OPERATOR_LOG_LEVEL)"
-          - "--trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)"
-        env:
-          - name: WATCH_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.annotations['olm.targetNamespaces']
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: OPERATOR_NAME
-            value: cert-manager-operator
-          - name: RELATED_IMAGE_CERT_MANAGER_WEBHOOK
-            value: quay.io/jetstack/cert-manager-webhook:v1.11.0
-          - name: RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR
-            value: quay.io/jetstack/cert-manager-cainjector:v1.11.0
-          - name: RELATED_IMAGE_CERT_MANAGER_CONTROLLER
-            value: quay.io/jetstack/cert-manager-controller:v1.11.0
-          - name: OPERAND_IMAGE_VERSION
-            value: 1.11.0
-          - name: OPERATOR_IMAGE_VERSION
-            value: 1.11.0
-          - name: OPERATOR_LOG_LEVEL
-            value: "2"
-          - name: TRUSTED_CA_CONFIGMAP_NAME
-        image: controller:latest
-        imagePullPolicy: Always
-        name: cert-manager-operator
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - "ALL"
-          privileged: false
-          runAsNonRoot: true
-          seccompProfile:
-            type: "RuntimeDefault"
+        - command:
+            - /usr/bin/cert-manager-operator
+          args:
+            - start
+            - '--v=$(OPERATOR_LOG_LEVEL)'
+            - '--trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)'
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['olm.targetNamespaces']
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: cert-manager-operator
+            - name: RELATED_IMAGE_CERT_MANAGER_WEBHOOK
+              value: quay.io/jetstack/cert-manager-webhook:v1.11.0
+            - name: RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR
+              value: quay.io/jetstack/cert-manager-cainjector:v1.11.0
+            - name: RELATED_IMAGE_CERT_MANAGER_CONTROLLER
+              value: quay.io/jetstack/cert-manager-controller:v1.11.0
+            - name: RELATED_IMAGE_CERT_MANAGER_ACMESOLVER
+              value: quay.io/jetstack/cert-manager-acmesolver:v1.11.0
+            - name: OPERAND_IMAGE_VERSION
+              value: 1.11.0
+            - name: OPERATOR_IMAGE_VERSION
+              value: 1.11.0
+            - name: OPERATOR_LOG_LEVEL
+              value: '2'
+            - name: TRUSTED_CA_CONFIGMAP_NAME
+          image: controller:latest
+          imagePullPolicy: Always
+          name: cert-manager-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - 'ALL'
+            privileged: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: 'RuntimeDefault'
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/pkg/controller/deployment/deployment_overrides.go
+++ b/pkg/controller/deployment/deployment_overrides.go
@@ -49,6 +49,13 @@ func withOperandImageOverrideHook(operatorSpec *v1.OperatorSpec, deployment *app
 	for index := range deployment.Spec.Template.Spec.Containers {
 		deployment.Spec.Template.Spec.Containers[index].Image = certManagerImage(deployment.Spec.Template.Spec.Containers[index].Image)
 	}
+
+	// replace acme-http01-solver-image image from env variables
+	if len(deployment.Spec.Template.Spec.Containers) == 1 && deployment.Name == certManagerControllerDeploymentControllerName {
+		deployment.Spec.Template.Spec.Containers[0].Args = mergeContainerArgs(deployment.Spec.Template.Spec.Containers[0].Args,
+			[]string{fmt.Sprintf("--acme-http01-solver-image=%s", certManagerImage(deployment.Spec.Template.Spec.Containers[0].Image))})
+	}
+
 	return nil
 }
 

--- a/pkg/controller/deployment/related_images.go
+++ b/pkg/controller/deployment/related_images.go
@@ -9,6 +9,7 @@ var imageEnvMap = map[string]string{
 	"quay.io/jetstack/cert-manager-controller": "RELATED_IMAGE_CERT_MANAGER_CONTROLLER",
 	"quay.io/jetstack/cert-manager-webhook":    "RELATED_IMAGE_CERT_MANAGER_WEBHOOK",
 	"quay.io/jetstack/cert-manager-cainjector": "RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR",
+	"quay.io/jetstack/cert-manager-acmesolver": "RELATED_IMAGE_CERT_MANAGER_ACMESOLVER",
 }
 
 // Overrides provided image when envCertManagerControllerRelatedImage environment variable is specified.


### PR DESCRIPTION
Description
---

Adds a new ENV variable to read the ACME solver image at runtime. Related PR on midstream will update the image to reference Red Hat's image. 

Related Midstream PR: https://gitlab.cee.redhat.com/cpaas-midstream-cfe/openshift-cert-manager/-/merge_requests/96
