### PR TITLE
OCPBUGS-9960: Add disable operand delete annotation

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -209,6 +209,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Security
+    console.openshift.io/disable-operand-delete: "true"
     containerImage: openshift.io/cert-manager-operator:latest
     createdAt: 2023-03-03T00:00:00
     olm.skipRange: <1.11.1

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
     categories: Security
+    console.openshift.io/disable-operand-delete: "true"
     containerImage: ""
     createdAt: 2023-03-03T00:00:00
     olm.skipRange: <1.11.1


### PR DESCRIPTION
Description
---
Add annotation to disable operand delete option on console. This acts as a check, to ensure deletion is done manually. 

cc: @xenolinux docs updated required for manual deletion 
