### PR TITLE
OCPBUGS-14129: Nil panic fix in validateLabels

### DIFF
--- a/pkg/controller/deployment/deployment_overrides_validation.go
+++ b/pkg/controller/deployment/deployment_overrides_validation.go
@@ -175,11 +175,11 @@ func withPodLabelsValidateHook(certmanagerinformer certmanagerinformer.CertManag
 			}
 		case certmanagerWebhookDeployment:
 			if certmanager.Spec.WebhookConfig != nil {
-				return validateLabels(certmanager.Spec.ControllerConfig.OverrideLabels, supportedCertManagerWebhookLabelKeys)
+				return validateLabels(certmanager.Spec.WebhookConfig.OverrideLabels, supportedCertManagerWebhookLabelKeys)
 			}
 		case certmanagerCAinjectorDeployment:
 			if certmanager.Spec.CAInjectorConfig != nil {
-				return validateLabels(certmanager.Spec.ControllerConfig.OverrideLabels, supportedCertManagerCainjectorLabelKeys)
+				return validateLabels(certmanager.Spec.CAInjectorConfig.OverrideLabels, supportedCertManagerCainjectorLabelKeys)
 			}
 		default:
 			return fmt.Errorf("unsupported deployment name %q provided", deploymentName)


### PR DESCRIPTION
Fixes a nil panic caused via deployment_overrides_validation.go due to incorrectly passing value of controllerConfig instead of webhookConfig/caInjectorConfig

Signed-off-by: Swarup Ghosh <swghosh@redhat.com>