### PR TITLE
CM-119: Bump cert manager operator 1.10.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the BUNDLE_VERSION as arg of the bundle target (e.g make bundle BUNDLE_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export BUNDLE_VERSION=0.0.2)
-BUNDLE_VERSION ?= 1.10.2
+BUNDLE_VERSION ?= 1.10.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -211,6 +211,7 @@ metadata:
     categories: Security
     containerImage: openshift.io/cert-manager-operator:latest
     createdAt: 2023-03-03T00:00:00
+    olm.skipRange: <1.10.3
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: cert-manager-operator
     operators.openshift.io/infrastructure-features: '["proxy-aware"]'
@@ -223,7 +224,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: cert-manager-operator.v1.10.2
+  name: cert-manager-operator.v1.10.3
   namespace: cert-manager-operator
 spec:
   apiservicedefinitions: {}
@@ -733,4 +734,4 @@ spec:
     name: cert-manager-ca-injector
   - image: quay.io/jetstack/cert-manager-controller:v1.10.2
     name: cert-manager-controller
-  version: 1.10.2
+  version: 1.10.3

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -7,6 +7,7 @@ metadata:
     categories: Security
     containerImage: ""
     createdAt: 2023-03-03T00:00:00
+    olm.skipRange: <1.10.3
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: cert-manager-operator
     operators.openshift.io/infrastructure-features: '["proxy-aware"]'
@@ -18,7 +19,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: cert-manager-operator.v1.10.2
+  name: cert-manager-operator.v1.10.3
   namespace: cert-manager-operator
 spec:
   apiservicedefinitions: {}
@@ -84,4 +85,4 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
-  version: 1.10.2
+  version: 1.10.3


### PR DESCRIPTION
Description
---
This PR creates a new operator version v1.10.3 while retaining the operand version at v1.10.2. This z-stream bump is required in order to bump dependencies in operator/operand that are present during the build process on CPaaS. 

- Current Go Version in 1.10.2
  - cert-manager-operator-container-v1.10.2-16 : openshift-golang-builder-container-v1.19.2-202210260124.el9.g6fef344
  - jetstack-cert-manager-container-v1.10.2-15 : openshift-golang-builder-container-v1.19.2-202210260124.el9.g6fef344
- Need to bump to 1.19.9 golang builder for 1.10.3 (z-stream bump for bug fixes)
  - [x] https://gitlab.cee.redhat.com/cpaas-midstream-cfe/openshift-cert-manager/-/commit/17cb5523e4528bf8964fa85bf9522e3a11626c79


Corresponding CPaaS bump: https://gitlab.cee.redhat.com/cpaas-midstream-cfe/openshift-cert-manager/-/merge_requests/120

