### PR TITLE
Use ubi:9.2 base image for Dockerfile(s)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/cert-manager-operator
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.access.redhat.com/ubi9-minimal:9.1.0
+FROM registry.access.redhat.com/ubi9-minimal:9.2
 COPY --from=builder /go/src/github.com/openshift/cert-manager-operator/cert-manager-operator /usr/bin/
 
 USER 65532:65532

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/cert-manager-operator
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.access.redhat.com/ubi9-minimal:9.1.0
+FROM registry.access.redhat.com/ubi9-minimal:9.2
 COPY --from=builder /go/src/github.com/openshift/cert-manager-operator/cert-manager-operator /usr/bin/
 
 USER 65532:65532


### PR DESCRIPTION
Bump to ubi:9.2 from 9.1

Signed-off-by: Swarup Ghosh <swghosh@redhat.com>