### PR TITLE
CM-98: Add --enable-certificate-owner-ref as supported cert-manager controller arg

### DIFF
--- a/pkg/controller/deployment/deployment_overrides_validation.go
+++ b/pkg/controller/deployment/deployment_overrides_validation.go
@@ -43,6 +43,10 @@ func withContainerArgsValidateHook(certmanagerinformer certmanagerinformer.CertM
 		// Application Default Credentials (ADC) per
 		// https://cloud.google.com/docs/authentication/application-default-credentials#search_order
 		"--issuer-ambient-credentials",
+		// Whether to set the certificate resource as an owner of secret where the tls certificate
+		// is stored. When this flag is enabled, the secret will be automatically removed when the
+		// certificate resource is deleted.
+		"--enable-certificate-owner-ref",
 	}
 	supportedCertManagerWebhookArgs := []string{
 		// Log Level

--- a/test/e2e/cert_manager_deployment_test.go
+++ b/test/e2e/cert_manager_deployment_test.go
@@ -375,7 +375,7 @@ func verifyValidControllerOperatorStatus(t *testing.T, client *certmanoperatorcl
 
 func addValidControlleDeploymentConfig(operator *v1alpha1.CertManager) {
 	operator.Spec.ControllerConfig = &v1alpha1.DeploymentConfig{
-		OverrideArgs: []string{"--dns01-recursive-nameservers=10.10.10.10:53", "--dns01-recursive-nameservers-only"},
+		OverrideArgs: []string{"--dns01-recursive-nameservers=10.10.10.10:53", "--dns01-recursive-nameservers-only", "--enable-certificate-owner-ref"},
 		OverrideEnv: []corev1.EnvVar{
 			{
 				Name:  "HTTP_PROXY",


### PR DESCRIPTION
This PR adds the support for the flag `--enable-certificate-owner-ref`. This flag can be enabled by adding it to the `spec.controllerConfig.overrideArgs` field of the CertManager `cluster` object. When the flag is enabled the certificate resource is set as an owner of secret where the tls certificate is stored and the secret will be automatically removed when the certificate resource is deleted.