### PR TITLE
CM-132: Add skips to allow older installations

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -750,4 +750,8 @@ spec:
     name: cert-manager-controller
   - image: quay.io/jetstack/cert-manager-acmesolver:v1.11.4
     name: cert-manager-acmesolver
+  skips:
+  - cert-manager-operator.v1.11.1
+  - cert-manager-operator.v1.10.3
+  - cert-manager-operator.v1.10.2
   version: 1.11.4

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -92,4 +92,8 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
+  skips:
+  - cert-manager-operator.v1.11.1
+  - cert-manager-operator.v1.10.3
+  - cert-manager-operator.v1.10.2
   version: 1.11.4


### PR DESCRIPTION
Description
---
Allow installing older versions of the operator that are available on the same channel. Skips allows users to install versions lower than the channel head.

After this fix users will be able to install older versions but there is a small caveat w.r.r `InstallPlanApproval`.
Users who are installing older versions will need to set `installPlanApproval: Manual` without which they can install the older version but OLM will automatically upgrade it to the latest supported version in that channel. Meaning in our case if they install `1.10.2` or `1.11.1` (both are in the `stable-v1`) channel, they will get upgraded to the `1.11.4` release.

Current state of bundles in the stable-v1 channel,
- cert-manager-1.10.2 has no skips (older releases)
- cert-manager-1.11.1 has no skips (older releases)
- we release a new version cert-manager-1.11.4 with skips (skips: ["1.10.2", "1.11.1"])

After the new release on stable-v1, users can install:
- 1.10.2 from stable-v1 (from subscription object, w/ install approval manual)
- 1.11.1 from stable-v1 (from subscription object, w/ install approval manual)
- 1.11.4 from stable-v1 (from console & from subscription object irrespective of install approval)


Related to: OCPBUGS-16393