### PR TITLE
CM-180: Rebase 1.11.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the BUNDLE_VERSION as arg of the bundle target (e.g make bundle BUNDLE_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export BUNDLE_VERSION=0.0.2)
-BUNDLE_VERSION ?= 1.11.4
+BUNDLE_VERSION ?= 1.11.5
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -103,7 +103,7 @@ GOBUILD_VERSION_ARGS = -ldflags "-X $(PACKAGE)/pkg/version.SHORTCOMMIT=$(SHORTCO
 
 E2E_TIMEOUT ?= 1h
 
-MANIFEST_SOURCE = https://github.com/cert-manager/cert-manager/releases/download/v1.11.4/cert-manager.yaml
+MANIFEST_SOURCE = https://github.com/cert-manager/cert-manager/releases/download/v1.11.5/cert-manager.yaml
 
 
 ##@ Development

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains Cert Manager Operator designed for OpenShift. The opera
 
 ## The operator architecture and design assumptions
 
-The Operator uses the [upstream deployment manifests](https://github.com/jetstack/cert-manager/releases/download/v1.11.4/cert-manager.yaml). It divides them into separate files and deploys using 3 controllers:
+The Operator uses the [upstream deployment manifests](https://github.com/jetstack/cert-manager/releases/download/v1.11.5/cert-manager.yaml). It divides them into separate files and deploys using 3 controllers:
 - [cert_manager_cainjector_deployment.go](pkg/controller/deployment/cert_manager_cainjector_deployment.go)
 - [cert_manager_controller_deployment.go](pkg/controller/deployment/cert_manager_controller_deployment.go)
 - [cert_manager_webhook_deployment.go](pkg/controller/deployment/cert_manager_webhook_deployment.go)

--- a/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-cr.yaml
+++ b/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-cainjector
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-crb.yaml
+++ b/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-deployment.yaml
+++ b/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-cainjector
   namespace: cert-manager
 spec:
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.11.4
+        app.kubernetes.io/version: v1.11.5
     spec:
       containers:
         - args:
@@ -36,7 +36,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: quay.io/jetstack/cert-manager-cainjector:v1.11.4
+          image: quay.io/jetstack/cert-manager-cainjector:v1.11.5
           imagePullPolicy: IfNotPresent
           name: cert-manager-cainjector
           securityContext:

--- a/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-leaderelection-rb.yaml
+++ b/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-leaderelection-rb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:

--- a/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-leaderelection-role.yaml
+++ b/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-leaderelection-role.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:

--- a/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-sa.yaml
+++ b/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-sa.yaml
@@ -7,6 +7,6 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-cainjector
   namespace: cert-manager

--- a/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-approve-cert-manager-io-cr.yaml
+++ b/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-approve-cert-manager-io-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-approve:cert-manager-io
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-approve-cert-manager-io-crb.yaml
+++ b/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-approve-cert-manager-io-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-certificatesigningrequests-cr.yaml
+++ b/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-certificatesigningrequests-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-certificatesigningrequests
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-certificatesigningrequests-crb.yaml
+++ b/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-certificatesigningrequests-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-certificates-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-certificates-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-certificates
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-certificates-crb.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-certificates-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-challenges-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-challenges-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-challenges
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-challenges-crb.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-challenges-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-clusterissuers-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-clusterissuers-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-clusterissuers
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-clusterissuers-crb.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-clusterissuers-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-ingress-shim-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-ingress-shim-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-ingress-shim
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-ingress-shim-crb.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-ingress-shim-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-issuers-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-issuers-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-issuers
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-issuers-crb.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-issuers-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-orders-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-orders-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-orders
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-orders-crb.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-orders-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/controller/cert-manager-deployment.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager
   namespace: cert-manager
 spec:
@@ -27,14 +27,14 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.11.4
+        app.kubernetes.io/version: v1.11.5
     spec:
       containers:
         - args:
             - --v=2
             - --cluster-resource-namespace=$(POD_NAMESPACE)
             - --leader-election-namespace=kube-system
-            - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.11.4
+            - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.11.5
             - --max-concurrent-challenges=60
           command:
             - /app/cmd/controller/controller
@@ -43,7 +43,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: quay.io/jetstack/cert-manager-controller:v1.11.4
+          image: quay.io/jetstack/cert-manager-controller:v1.11.5
           imagePullPolicy: IfNotPresent
           name: cert-manager-controller
           ports:

--- a/bindata/cert-manager-deployment/controller/cert-manager-edit-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-edit-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit

--- a/bindata/cert-manager-deployment/controller/cert-manager-leaderelection-rb.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-leaderelection-rb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:

--- a/bindata/cert-manager-deployment/controller/cert-manager-leaderelection-role.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-leaderelection-role.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:

--- a/bindata/cert-manager-deployment/controller/cert-manager-sa.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-sa.yaml
@@ -7,6 +7,6 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager
   namespace: cert-manager

--- a/bindata/cert-manager-deployment/controller/cert-manager-svc.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-svc.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager
   namespace: cert-manager
 spec:

--- a/bindata/cert-manager-deployment/controller/cert-manager-view-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-view-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-configmap.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-configmap.yaml
@@ -7,6 +7,6 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook
   namespace: cert-manager

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-deployment.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook
   namespace: cert-manager
 spec:
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.11.4
+        app.kubernetes.io/version: v1.11.5
     spec:
       containers:
         - args:
@@ -39,7 +39,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: quay.io/jetstack/cert-manager-webhook:v1.11.4
+          image: quay.io/jetstack/cert-manager-webhook:v1.11.5
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-dynamic-serving-rb.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-dynamic-serving-rb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook:dynamic-serving
   namespace: cert-manager
 roleRef:

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-dynamic-serving-role.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-dynamic-serving-role.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook:dynamic-serving
   namespace: cert-manager
 rules:

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-mutatingwebhookconfiguration.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-mutatingwebhookconfiguration.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook
 webhooks:
   - admissionReviewVersions:

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-sa.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-sa.yaml
@@ -7,6 +7,6 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook
   namespace: cert-manager

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-subjectaccessreviews-cr.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-subjectaccessreviews-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook:subjectaccessreviews
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-subjectaccessreviews-crb.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-subjectaccessreviews-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-svc.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-svc.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook
   namespace: cert-manager
 spec:

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-validatingwebhookconfiguration.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-validatingwebhookconfiguration.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook
 webhooks:
   - admissionReviewVersions:

--- a/bundle/manifests/acme.cert-manager.io_challenges.yaml
+++ b/bundle/manifests/acme.cert-manager.io_challenges.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/bundle/manifests/acme.cert-manager.io_orders.yaml
+++ b/bundle/manifests/acme.cert-manager.io_orders.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -212,7 +212,7 @@ metadata:
     console.openshift.io/disable-operand-delete: "true"
     containerImage: openshift.io/cert-manager-operator:latest
     createdAt: 2023-03-03T00:00:00
-    olm.skipRange: <1.11.4
+    olm.skipRange: '>=1.11.4 <1.11.5'
     operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
       OpenShift will be removed from cert-manager-operator namespace. If your Operator
       configured any off-cluster resources, these will continue to run and require
@@ -750,8 +750,5 @@ spec:
     name: cert-manager-controller
   - image: quay.io/jetstack/cert-manager-acmesolver:v1.11.4
     name: cert-manager-acmesolver
-  skips:
-  - cert-manager-operator.v1.11.1
-  - cert-manager-operator.v1.10.3
-  - cert-manager-operator.v1.10.2
+  replaces: cert-manager-operator.v1.11.4
   version: 1.11.5

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -261,7 +261,7 @@ spec:
       name: orders.acme.cert-manager.io
       version: v1
   description: |
-    The cert-manager Operator for Red Hat OpenShift provides seamless support for cert-manager, which automates certificate management.
+    The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.11.5](https://github.com/cert-manager/cert-manager/tree/v1.11.5), which automates certificate management.
     For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
   displayName: cert-manager Operator for Red Hat OpenShift
   icon:

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -231,7 +231,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: cert-manager-operator.v1.11.4
+  name: cert-manager-operator.v1.11.5
   namespace: cert-manager-operator
 spec:
   apiservicedefinitions: {}
@@ -754,4 +754,4 @@ spec:
   - cert-manager-operator.v1.11.1
   - cert-manager-operator.v1.10.3
   - cert-manager-operator.v1.10.2
-  version: 1.11.4
+  version: 1.11.5

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -646,17 +646,17 @@ spec:
                 - name: OPERATOR_NAME
                   value: cert-manager-operator
                 - name: RELATED_IMAGE_CERT_MANAGER_WEBHOOK
-                  value: quay.io/jetstack/cert-manager-webhook:v1.11.4
+                  value: quay.io/jetstack/cert-manager-webhook:v1.11.5
                 - name: RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR
-                  value: quay.io/jetstack/cert-manager-cainjector:v1.11.4
+                  value: quay.io/jetstack/cert-manager-cainjector:v1.11.5
                 - name: RELATED_IMAGE_CERT_MANAGER_CONTROLLER
-                  value: quay.io/jetstack/cert-manager-controller:v1.11.4
+                  value: quay.io/jetstack/cert-manager-controller:v1.11.5
                 - name: RELATED_IMAGE_CERT_MANAGER_ACMESOLVER
-                  value: quay.io/jetstack/cert-manager-acmesolver:v1.11.4
+                  value: quay.io/jetstack/cert-manager-acmesolver:v1.11.5
                 - name: OPERAND_IMAGE_VERSION
-                  value: 1.11.4
+                  value: 1.11.5
                 - name: OPERATOR_IMAGE_VERSION
-                  value: 1.11.4
+                  value: 1.11.5
                 - name: OPERATOR_LOG_LEVEL
                   value: "2"
                 - name: TRUSTED_CA_CONFIGMAP_NAME
@@ -742,13 +742,13 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: quay.io/jetstack/cert-manager-webhook:v1.11.4
+  - image: quay.io/jetstack/cert-manager-webhook:v1.11.5
     name: cert-manager-webhook
-  - image: quay.io/jetstack/cert-manager-cainjector:v1.11.4
+  - image: quay.io/jetstack/cert-manager-cainjector:v1.11.5
     name: cert-manager-ca-injector
-  - image: quay.io/jetstack/cert-manager-controller:v1.11.4
+  - image: quay.io/jetstack/cert-manager-controller:v1.11.5
     name: cert-manager-controller
-  - image: quay.io/jetstack/cert-manager-acmesolver:v1.11.4
+  - image: quay.io/jetstack/cert-manager-acmesolver:v1.11.5
     name: cert-manager-acmesolver
   replaces: cert-manager-operator.v1.11.4
   version: 1.11.5

--- a/bundle/manifests/cert-manager.io_certificaterequests.yaml
+++ b/bundle/manifests/cert-manager.io_certificaterequests.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io

--- a/bundle/manifests/cert-manager.io_certificates.yaml
+++ b/bundle/manifests/cert-manager.io_certificates.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io

--- a/bundle/manifests/cert-manager.io_clusterissuers.yaml
+++ b/bundle/manifests/cert-manager.io_clusterissuers.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/bundle/manifests/cert-manager.io_issuers.yaml
+++ b/bundle/manifests/cert-manager.io_issuers.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/config/crd/bases/certificaterequests.cert-manager.io-crd.yaml
+++ b/config/crd/bases/certificaterequests.cert-manager.io-crd.yaml
@@ -7,7 +7,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io

--- a/config/crd/bases/certificates.cert-manager.io-crd.yaml
+++ b/config/crd/bases/certificates.cert-manager.io-crd.yaml
@@ -7,7 +7,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io

--- a/config/crd/bases/challenges.acme.cert-manager.io-crd.yaml
+++ b/config/crd/bases/challenges.acme.cert-manager.io-crd.yaml
@@ -7,7 +7,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/config/crd/bases/clusterissuers.cert-manager.io-crd.yaml
+++ b/config/crd/bases/clusterissuers.cert-manager.io-crd.yaml
@@ -7,7 +7,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/config/crd/bases/issuers.cert-manager.io-crd.yaml
+++ b/config/crd/bases/issuers.cert-manager.io-crd.yaml
@@ -7,7 +7,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/config/crd/bases/orders.acme.cert-manager.io-crd.yaml
+++ b/config/crd/bases/orders.acme.cert-manager.io-crd.yaml
@@ -7,7 +7,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,17 +58,17 @@ spec:
             - name: OPERATOR_NAME
               value: cert-manager-operator
             - name: RELATED_IMAGE_CERT_MANAGER_WEBHOOK
-              value: quay.io/jetstack/cert-manager-webhook:v1.11.4
+              value: quay.io/jetstack/cert-manager-webhook:v1.11.5
             - name: RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR
-              value: quay.io/jetstack/cert-manager-cainjector:v1.11.4
+              value: quay.io/jetstack/cert-manager-cainjector:v1.11.5
             - name: RELATED_IMAGE_CERT_MANAGER_CONTROLLER
-              value: quay.io/jetstack/cert-manager-controller:v1.11.4
+              value: quay.io/jetstack/cert-manager-controller:v1.11.5
             - name: RELATED_IMAGE_CERT_MANAGER_ACMESOLVER
-              value: quay.io/jetstack/cert-manager-acmesolver:v1.11.4
+              value: quay.io/jetstack/cert-manager-acmesolver:v1.11.5
             - name: OPERAND_IMAGE_VERSION
-              value: 1.11.4
+              value: 1.11.5
             - name: OPERATOR_IMAGE_VERSION
-              value: 1.11.4
+              value: 1.11.5
             - name: OPERATOR_LOG_LEVEL
               value: '2'
             - name: TRUSTED_CA_CONFIGMAP_NAME

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ spec:
       name: certmanagers.operator.openshift.io
       version: v1alpha1
   description: |
-    The cert-manager Operator for Red Hat OpenShift provides seamless support for cert-manager, which automates certificate management.
+    The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.11.5](https://github.com/cert-manager/cert-manager/tree/v1.11.5), which automates certificate management.
     For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
   displayName: cert-manager Operator for Red Hat OpenShift
   icon:

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     console.openshift.io/disable-operand-delete: "true"
     containerImage: ""
     createdAt: 2023-03-03T00:00:00
-    olm.skipRange: <1.11.4
+    olm.skipRange: '>=1.11.4 <1.11.5'
     operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
       OpenShift will be removed from cert-manager-operator namespace. If your Operator
       configured any off-cluster resources, these will continue to run and require
@@ -26,7 +26,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: cert-manager-operator.v1.11.4
+  name: cert-manager-operator.v1.11.5
   namespace: cert-manager-operator
 spec:
   apiservicedefinitions: {}
@@ -92,8 +92,5 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
-  skips:
-  - cert-manager-operator.v1.11.1
-  - cert-manager-operator.v1.10.3
-  - cert-manager-operator.v1.10.2
-  version: 1.11.4
+  replaces: cert-manager-operator.v1.11.4
+  version: 1.11.5

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openshift/cert-manager-operator
 go 1.19
 
 require (
-	github.com/cert-manager/cert-manager v1.11.4
+	github.com/cert-manager/cert-manager v1.11.5
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/golangci/golangci-lint v1.50.1
 	github.com/google/go-cmp v0.5.9
@@ -283,4 +283,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/cert-manager/cert-manager => github.com/openshift/jetstack-cert-manager v1.11.4
+replace github.com/cert-manager/cert-manager => github.com/openshift/jetstack-cert-manager v1.11.5

--- a/go.sum
+++ b/go.sum
@@ -672,8 +672,8 @@ github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084 h1:66uaqNwA+qYyQDwsMWUfjjau8ezmg1dzCqub13KZOcE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084/go.mod h1:M3h9m001PWac3eAudGG3isUud6yBjr5XpzLYLLTlHKo=
-github.com/openshift/jetstack-cert-manager v1.11.4 h1:pwlDbZrbx02CHDXCA2uGcRvtD6Uep1WLYsFCi90k3xg=
-github.com/openshift/jetstack-cert-manager v1.11.4/go.mod h1:ataBWLyUn2vVqGLud6JThOAVIbNKz72cZgnt7cBlajk=
+github.com/openshift/jetstack-cert-manager v1.11.5 h1:E6c7h/S+8Wk4GRqeOWSPFW31foMJatJG6G0df+qVXIE=
+github.com/openshift/jetstack-cert-manager v1.11.5/go.mod h1:zNOyoTEwdn9Rtj5Or2pjBY1Bqwtw4vBElP2fKSP8/g8=
 github.com/openshift/library-go v0.0.0-20230405224819-c1e9763926fb h1:yv/0B9Km8VD1ch9nYuzPVkWVtG2nVZa3IOrj89sTKR0=
 github.com/openshift/library-go v0.0.0-20230405224819-c1e9763926fb/go.mod h1:tedJaJsajpyrlPVNoSfjOst6w2HHvvR4VPqKWeZzrbY=
 github.com/operator-framework/operator-lib v0.11.0 h1:eYzqpiOfq9WBI4Trddisiq/X9BwCisZd3rIzmHRC9Z8=

--- a/pkg/controller/deployment/deployment_overrides_test.go
+++ b/pkg/controller/deployment/deployment_overrides_test.go
@@ -33,7 +33,7 @@ func TestUnsupportedConfigOverrides(t *testing.T) {
 			"--v=2",
 			"--cluster-resource-namespace=$(POD_NAMESPACE)",
 			"--leader-election-namespace=kube-system",
-			"--acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.11.4",
+			"--acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.11.5",
 			"--max-concurrent-challenges=60",
 		},
 		"cert-manager-cainjector": {
@@ -120,7 +120,7 @@ func TestUnsupportedConfigOverrides(t *testing.T) {
 				},
 			},
 			wantArgs: []string{
-				"--acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.11.4",
+				"--acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.11.5",
 				"--cluster-resource-namespace=$(POD_NAMESPACE)",
 				"--featureX=enable",
 				"--leader-election-namespace=kube-system",
@@ -171,7 +171,7 @@ func TestUnsupportedConfigOverrides(t *testing.T) {
 				},
 			},
 			wantArgs: []string{
-				"--acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.11.4",
+				"--acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.11.5",
 				"--cluster-resource-namespace=$(POD_NAMESPACE)",
 				"--featureY=disable",
 				"--leader-election-namespace=kube-system",

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -101,7 +101,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-cainjector
 rules:
   - apiGroups:
@@ -182,7 +182,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -217,7 +217,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-cainjector
   namespace: cert-manager
 spec:
@@ -234,7 +234,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.11.4
+        app.kubernetes.io/version: v1.11.5
     spec:
       containers:
         - args:
@@ -247,7 +247,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: quay.io/jetstack/cert-manager-cainjector:v1.11.4
+          image: quay.io/jetstack/cert-manager-cainjector:v1.11.5
           imagePullPolicy: IfNotPresent
           name: cert-manager-cainjector
           securityContext:
@@ -287,7 +287,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -323,7 +323,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -370,7 +370,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-cainjector
   namespace: cert-manager
 `)
@@ -398,7 +398,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-approve:cert-manager-io
 rules:
   - apiGroups:
@@ -435,7 +435,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -470,7 +470,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-certificatesigningrequests
 rules:
   - apiGroups:
@@ -529,7 +529,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -587,7 +587,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-certificates
 rules:
   - apiGroups:
@@ -672,7 +672,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -707,7 +707,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-challenges
 rules:
   - apiGroups:
@@ -828,7 +828,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -863,7 +863,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-clusterissuers
 rules:
   - apiGroups:
@@ -925,7 +925,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -960,7 +960,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-ingress-shim
 rules:
   - apiGroups:
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1080,7 +1080,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-issuers
 rules:
   - apiGroups:
@@ -1142,7 +1142,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1177,7 +1177,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-orders
 rules:
   - apiGroups:
@@ -1259,7 +1259,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1294,7 +1294,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager
   namespace: cert-manager
 spec:
@@ -1315,14 +1315,14 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.11.4
+        app.kubernetes.io/version: v1.11.5
     spec:
       containers:
         - args:
             - --v=2
             - --cluster-resource-namespace=$(POD_NAMESPACE)
             - --leader-election-namespace=kube-system
-            - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.11.4
+            - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.11.5
             - --max-concurrent-challenges=60
           command:
             - /app/cmd/controller/controller
@@ -1331,7 +1331,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: quay.io/jetstack/cert-manager-controller:v1.11.4
+          image: quay.io/jetstack/cert-manager-controller:v1.11.5
           imagePullPolicy: IfNotPresent
           name: cert-manager-controller
           ports:
@@ -1375,7 +1375,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -1434,7 +1434,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -1471,7 +1471,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -1517,7 +1517,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager
   namespace: cert-manager
 `)
@@ -1545,7 +1545,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager
   namespace: cert-manager
 spec:
@@ -1584,7 +1584,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1635,7 +1635,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook
   namespace: cert-manager
 `)
@@ -1663,7 +1663,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook
   namespace: cert-manager
 spec:
@@ -1680,7 +1680,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.11.4
+        app.kubernetes.io/version: v1.11.5
     spec:
       containers:
         - args:
@@ -1696,7 +1696,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: quay.io/jetstack/cert-manager-webhook:v1.11.4
+          image: quay.io/jetstack/cert-manager-webhook:v1.11.5
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -1763,7 +1763,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook:dynamic-serving
   namespace: cert-manager
 roleRef:
@@ -1800,7 +1800,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook:dynamic-serving
   namespace: cert-manager
 rules:
@@ -1848,7 +1848,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook
 webhooks:
   - admissionReviewVersions:
@@ -1900,7 +1900,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook
   namespace: cert-manager
 `)
@@ -1928,7 +1928,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook:subjectaccessreviews
 rules:
   - apiGroups:
@@ -1962,7 +1962,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1998,7 +1998,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook
   namespace: cert-manager
 spec:
@@ -2039,7 +2039,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.11.4
+    app.kubernetes.io/version: v1.11.5
   name: cert-manager-webhook
 webhooks:
   - admissionReviewVersions:

--- a/vendor/github.com/cert-manager/cert-manager/LICENSES
+++ b/vendor/github.com/cert-manager/cert-manager/LICENSES
@@ -15,7 +15,7 @@ github.com/Masterminds/semver/v3,https://github.com/Masterminds/semver/blob/v3.2
 github.com/Masterminds/sprig/v3,https://github.com/Masterminds/sprig/blob/v3.2.3/LICENSE.txt,MIT
 github.com/Masterminds/squirrel,https://github.com/Masterminds/squirrel/blob/v1.5.3/LICENSE.txt,MIT
 github.com/NYTimes/gziphandler,https://github.com/NYTimes/gziphandler/blob/v1.1.1/LICENSE,Apache-2.0
-github.com/Venafi/vcert/v4,https://github.com/jetstack/vcert/blob/3aa3dfd6613d/LICENSE,Apache-2.0
+github.com/Venafi/vcert/v4,https://github.com/Venafi/vcert/blob/69f417ae176d/LICENSE,Apache-2.0
 github.com/akamai/AkamaiOPEN-edgegrid-golang,https://github.com/akamai/AkamaiOPEN-edgegrid-golang/blob/v1.2.1/LICENSE,Apache-2.0
 github.com/antlr/antlr4/runtime/Go/antlr,https://github.com/antlr/antlr4/blob/runtime/Go/antlr/v1.4.10/runtime/Go/antlr/LICENSE,BSD-3-Clause
 github.com/armon/go-metrics,https://github.com/armon/go-metrics/blob/v0.3.9/LICENSE,MIT

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -76,7 +76,7 @@ github.com/butuzov/ireturn/types
 # github.com/cenkalti/backoff/v4 v4.1.3
 ## explicit; go 1.13
 github.com/cenkalti/backoff/v4
-# github.com/cert-manager/cert-manager v1.11.4 => github.com/openshift/jetstack-cert-manager v1.11.4
+# github.com/cert-manager/cert-manager v1.11.5 => github.com/openshift/jetstack-cert-manager v1.11.5
 ## explicit; go 1.19
 github.com/cert-manager/cert-manager/pkg/apis/acme
 github.com/cert-manager/cert-manager/pkg/apis/acme/v1
@@ -2221,4 +2221,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/cert-manager/cert-manager => github.com/openshift/jetstack-cert-manager v1.11.4
+# github.com/cert-manager/cert-manager => github.com/openshift/jetstack-cert-manager v1.11.5


### PR DESCRIPTION
[[v1.11.5](https://github.com/cert-manager/cert-manager/releases/tag/v1.11.5)] Rebase Checklist:

- [x] go dependencies

```
go get github.com/cert-manager/cert-manager@v1.11.5
go mod tidy
go mod vendor

go mod edit -replace github.com/cert-manager/cert-manager=github.com/openshift/jetstack-cert-manager@b1d501c85d97afd2adde2e86c2b119ac060caece # v1.11.5
go mod tidy
go mod vendor
```
- [x] push commit b1d501c85d97afd2adde2e86c2b119ac060caece to openshift/jetstack-cert-manager release-1.11 branch
- [x] openshift/release CI update related PRs
    - [x] operand image mirroring with new tag, https://github.com/openshift/release/pull/43286/
    - [x] ci pipeline use updated operand image tags. https://github.com/openshift/release/pull/43445
- [x] update bundle description to include upstream version of cert-manager (similar to #145) 


Signed-off-by: Swarup Ghosh <swghosh@redhat.com>

## cert-manager changelog (since v1.11.4)

### v1.11.5
> Important security fix that addresses [CVE-2023-29409](https://cve.report/CVE-2023-29409).
> 
> **Others**: https://github.com/cert-manager/cert-manager/pull/6317
