### PR TITLE
CM-201,CM-208: add CSV labels for non-amd64 architectures

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -230,6 +230,8 @@ metadata:
     support: Red Hat, Inc.
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
   name: cert-manager-operator.v1.12.0
   namespace: cert-manager-operator

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -230,6 +230,7 @@ metadata:
     support: Red Hat, Inc.
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -25,6 +25,7 @@ metadata:
     support: Red Hat, Inc.
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -25,6 +25,8 @@ metadata:
     support: Red Hat, Inc.
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
   name: cert-manager-operator.v1.12.0
   namespace: cert-manager-operator


### PR DESCRIPTION
[CM-208](https://issues.redhat.com/browse/CM-208) / [CM-201](https://issues.redhat.com/browse/CM-201) CSV labels to support arm64, ppc64le and s390x architectures. 

```
  operatorframework.io/arch.arm64: supported
  operatorframework.io/arch.ppc64le: supported
  operatorframework.io/arch.s390x: supported
```