### PR TITLE
CM-215: add nodeaffinity for non-x86 archs

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -592,6 +592,9 @@ spec:
                         operator: In
                         values:
                         - amd64
+                        - arm64
+                        - ppc64le
+                        - s390x
                       - key: kubernetes.io/os
                         operator: In
                         values:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -17,6 +17,9 @@ spec:
                   operator: In
                   values:
                     - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
                 - key: kubernetes.io/os
                   operator: In
                   values:


### PR DESCRIPTION
add nodeaffinity for non-x86 archs

 - arm64
  - ppc64le
  - s390x

https://issues.redhat.com/browse/CM-215
