### PR TITLE
[cert-manager-1.11] Bump golang to 1.20

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: builder
   namespace: ocp
-  tag: rhel-9-golang-1.19-openshift-4.13
+  tag: rhel-9-golang-1.20-openshift-4.14

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ SHELL = /usr/bin/env bash -o pipefail
 CONTAINER_ENGINE ?= docker
 CONTAINER_PUSH_ARGS ?= $(if $(filter ${CONTAINER_ENGINE}, docker), , --tls-verify=${TLS_VERIFY})
 TLS_VERIFY ?= true
-CONTAINER_IMAGE_NAME ?= registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.13
+CONTAINER_IMAGE_NAME ?= registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14
 
 BUNDLE_DIR := bundle
 BUNDLE_MANIFEST_DIR := $(BUNDLE_DIR)/manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cert-manager-operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cert-manager/cert-manager v1.11.5

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.13 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/openshift/cert-manager-operator
 COPY . .
 RUN make build --warn-undefined-variables


### PR DESCRIPTION
- Bump builder to golang-1.20-openshift-4.14
- Update go.mod to go=1.20