### PR TITLE
OCPBUGS-22911: remove replaces field from csv

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -756,5 +756,6 @@ spec:
     name: cert-manager-controller
   - image: quay.io/jetstack/cert-manager-acmesolver:v1.13.2
     name: cert-manager-acmesolver
-  replaces: cert-manager-operator.v1.12.1
+  skips: 
+    - cert-manager-operator.v1.12.1
   version: 1.13.0

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -756,6 +756,6 @@ spec:
     name: cert-manager-controller
   - image: quay.io/jetstack/cert-manager-acmesolver:v1.13.2
     name: cert-manager-acmesolver
-  skips: 
-    - cert-manager-operator.v1.12.1
+  skips:
+  - cert-manager-operator.v1.12.1
   version: 1.13.0

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -95,5 +95,6 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
-  replaces: cert-manager-operator.v1.12.1
+  skips:
+    - cert-manager-operator.v1.12.1
   version: 1.13.0

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -96,5 +96,5 @@ spec:
   provider:
     name: Red Hat
   skips:
-    - cert-manager-operator.v1.12.1
+  - cert-manager-operator.v1.12.1
   version: 1.13.0


### PR DESCRIPTION
cert-manager-operator.v1.13.0 should be able to be added to v4.15 index without replacing cert-manager-operator.v1.12.1

https://issues.redhat.com/browse/OCPBUGS-22911
