### PR TITLE
CM-230: Add e2e test for operands override resources

### DIFF
--- a/test/e2e/overrides_test.go
+++ b/test/e2e/overrides_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Overrides test", Ordered, func() {
 
 		It("should add the resources to the cert-manager controller deployment", func() {
 
-			By("Adding cert-manager controller override resources to the cert-managaer operator object")
+			By("Adding cert-manager controller override resources to the certmanagaer.operator object")
 			res := v1alpha1.CertManagerResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    k8sresource.MustParse("500m"),
@@ -175,7 +175,7 @@ var _ = Describe("Overrides test", Ordered, func() {
 
 		It("should add the resources to the cert-manager webhook deployment", func() {
 
-			By("Adding cert-manager webhook override resources to the cert-managaer operator object")
+			By("Adding cert-manager webhook override resources to the certmanagaer.operator object")
 			res := v1alpha1.CertManagerResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    k8sresource.MustParse("500m"),
@@ -203,7 +203,7 @@ var _ = Describe("Overrides test", Ordered, func() {
 
 		It("should add the resources to the cert-manager cainjector deployment", func() {
 
-			By("Adding cert-manager cainjector override resources to the cert-managaer operator object")
+			By("Adding cert-manager cainjector override resources to the certmanagaer.operator object")
 			res := v1alpha1.CertManagerResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    k8sresource.MustParse("500m"),
@@ -231,7 +231,7 @@ var _ = Describe("Overrides test", Ordered, func() {
 
 		It("should not add the resources to the cert-manager controller deployment", func() {
 
-			By("Adding cert-manager controller override resources to the cert-managaer operator object")
+			By("Adding cert-manager controller override resources to the certmanagaer.operator object")
 			res := v1alpha1.CertManagerResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceEphemeralStorage: k8sresource.MustParse("2Gi"),
@@ -257,7 +257,7 @@ var _ = Describe("Overrides test", Ordered, func() {
 
 		It("should not add the resources to the cert-manager webhook deployment", func() {
 
-			By("Adding cert-manager webhook override resources to the cert-managaer operator object")
+			By("Adding cert-manager webhook override resources to the certmanagaer.operator object")
 			res := v1alpha1.CertManagerResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceEphemeralStorage: k8sresource.MustParse("2Gi"),
@@ -283,7 +283,7 @@ var _ = Describe("Overrides test", Ordered, func() {
 
 		It("should not add the resources to the cert-manager cainjector deployment", func() {
 
-			By("Adding cert-manager cainjector override resources to the cert-managaer operator object")
+			By("Adding cert-manager cainjector override resources to the certmanagaer.operator object")
 			res := v1alpha1.CertManagerResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceEphemeralStorage: k8sresource.MustParse("2Gi"),

--- a/test/e2e/overrides_test.go
+++ b/test/e2e/overrides_test.go
@@ -8,6 +8,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 )
 
 var _ = Describe("Overrides test", Ordered, func() {
@@ -136,6 +139,168 @@ var _ = Describe("Overrides test", Ordered, func() {
 
 			By("Checking if the args are not added to the cert-manager cainjector deployment")
 			err = verifyDeploymentArgs(k8sClientSet, certmanagerCAinjectorDeployment, args, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("When adding valid cert-manager controller override resources", func() {
+
+		It("should add the resources to the cert-manager controller deployment", func() {
+
+			By("Adding cert-manager controller override resources to the cert-managaer operator object")
+			res := v1alpha1.CertManagerResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    k8sresource.MustParse("500m"),
+					corev1.ResourceMemory: k8sresource.MustParse("128Mi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    k8sresource.MustParse("20m"),
+					corev1.ResourceMemory: k8sresource.MustParse("64Mi"),
+				},
+			}
+			err := addOverrideResources(certmanageroperatorclient, certmanagerControllerDeployment, res)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for cert-manager controller status to become available")
+			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerControllerDeploymentControllerName}, validOperatorStatusConditions)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the resources to be added to the cert-manager controller deployment")
+			err = verifyDeploymentResources(k8sClientSet, certmanagerControllerDeployment, res, true)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("When adding valid cert-manager webhook override resources", func() {
+
+		It("should add the resources to the cert-manager webhook deployment", func() {
+
+			By("Adding cert-manager webhook override resources to the cert-managaer operator object")
+			res := v1alpha1.CertManagerResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    k8sresource.MustParse("500m"),
+					corev1.ResourceMemory: k8sresource.MustParse("128Mi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    k8sresource.MustParse("20m"),
+					corev1.ResourceMemory: k8sresource.MustParse("64Mi"),
+				},
+			}
+			err := addOverrideResources(certmanageroperatorclient, certmanagerWebhookDeployment, res)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for cert-manager webhook controller status to become available")
+			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerWebhookDeploymentControllerName}, validOperatorStatusConditions)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the resources to be added to the cert-manager webhook deployment")
+			err = verifyDeploymentResources(k8sClientSet, certmanagerWebhookDeployment, res, true)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("When adding valid cert-manager cainjector override resources", func() {
+
+		It("should add the resources to the cert-manager cainjector deployment", func() {
+
+			By("Adding cert-manager cainjector override resources to the cert-managaer operator object")
+			res := v1alpha1.CertManagerResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    k8sresource.MustParse("500m"),
+					corev1.ResourceMemory: k8sresource.MustParse("128Mi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    k8sresource.MustParse("20m"),
+					corev1.ResourceMemory: k8sresource.MustParse("64Mi"),
+				},
+			}
+			err := addOverrideResources(certmanageroperatorclient, certmanagerCAinjectorDeployment, res)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for cert-manager cainjector controller status to become available")
+			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerCAInjectorDeploymentControllerName}, validOperatorStatusConditions)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the resources to be added to the cert-manager cainjector deployment")
+			err = verifyDeploymentResources(k8sClientSet, certmanagerCAinjectorDeployment, res, true)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("When adding invalid cert-manager controller override resources", func() {
+
+		It("should not add the resources to the cert-manager controller deployment", func() {
+
+			By("Adding cert-manager controller override resources to the cert-managaer operator object")
+			res := v1alpha1.CertManagerResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceEphemeralStorage: k8sresource.MustParse("2Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceEphemeralStorage: k8sresource.MustParse("1Gi"),
+				},
+			}
+			err := addOverrideResources(certmanageroperatorclient, certmanagerControllerDeployment, res)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for cert-manager controller status to become degraded")
+			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerControllerDeploymentControllerName}, invalidOperatorStatusConditions)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking if the resources are not added to the cert-manager controller deployment")
+			err = verifyDeploymentResources(k8sClientSet, certmanagerControllerDeployment, res, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("When adding invalid cert-manager webhook override resources", func() {
+
+		It("should not add the resources to the cert-manager webhook deployment", func() {
+
+			By("Adding cert-manager webhook override resources to the cert-managaer operator object")
+			res := v1alpha1.CertManagerResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceEphemeralStorage: k8sresource.MustParse("2Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceEphemeralStorage: k8sresource.MustParse("1Gi"),
+				},
+			}
+			err := addOverrideResources(certmanageroperatorclient, certmanagerWebhookDeployment, res)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for cert-manager webhook controller status to become degraded")
+			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerWebhookDeploymentControllerName}, invalidOperatorStatusConditions)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking if the resources are not added to the cert-manager webhook deployment")
+			err = verifyDeploymentResources(k8sClientSet, certmanagerWebhookDeployment, res, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("When adding invalid cert-manager cainjector override resources", func() {
+
+		It("should not add the resources to the cert-manager cainjector deployment", func() {
+
+			By("Adding cert-manager cainjector override resources to the cert-managaer operator object")
+			res := v1alpha1.CertManagerResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceEphemeralStorage: k8sresource.MustParse("2Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceEphemeralStorage: k8sresource.MustParse("1Gi"),
+				},
+			}
+			err := addOverrideResources(certmanageroperatorclient, certmanagerCAinjectorDeployment, res)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for cert-manager cainjector controller status to become degraded")
+			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerCAInjectorDeploymentControllerName}, invalidOperatorStatusConditions)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking if the resources are not added to the cert-manager cainjector deployment")
+			err = verifyDeploymentResources(k8sClientSet, certmanagerCAinjectorDeployment, res, false)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/test/e2e/overrides_test.go
+++ b/test/e2e/overrides_test.go
@@ -8,7 +8,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
+	
 	corev1 "k8s.io/api/core/v1"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 )
@@ -147,7 +149,7 @@ var _ = Describe("Overrides test", Ordered, func() {
 
 		It("should add the resources to the cert-manager controller deployment", func() {
 
-			By("Adding cert-manager controller override resources to the certmanagaer.operator object")
+			By("Adding cert-manager controller override resources to the certmanager.operator object")
 			res := v1alpha1.CertManagerResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    k8sresource.MustParse("500m"),
@@ -175,7 +177,7 @@ var _ = Describe("Overrides test", Ordered, func() {
 
 		It("should add the resources to the cert-manager webhook deployment", func() {
 
-			By("Adding cert-manager webhook override resources to the certmanagaer.operator object")
+			By("Adding cert-manager webhook override resources to the certmanager.operator object")
 			res := v1alpha1.CertManagerResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    k8sresource.MustParse("500m"),
@@ -203,7 +205,7 @@ var _ = Describe("Overrides test", Ordered, func() {
 
 		It("should add the resources to the cert-manager cainjector deployment", func() {
 
-			By("Adding cert-manager cainjector override resources to the certmanagaer.operator object")
+			By("Adding cert-manager cainjector override resources to the certmanager.operator object")
 			res := v1alpha1.CertManagerResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    k8sresource.MustParse("500m"),
@@ -231,7 +233,7 @@ var _ = Describe("Overrides test", Ordered, func() {
 
 		It("should not add the resources to the cert-manager controller deployment", func() {
 
-			By("Adding cert-manager controller override resources to the certmanagaer.operator object")
+			By("Adding cert-manager controller override resources to the certmanager.operator object")
 			res := v1alpha1.CertManagerResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceEphemeralStorage: k8sresource.MustParse("2Gi"),
@@ -257,7 +259,7 @@ var _ = Describe("Overrides test", Ordered, func() {
 
 		It("should not add the resources to the cert-manager webhook deployment", func() {
 
-			By("Adding cert-manager webhook override resources to the certmanagaer.operator object")
+			By("Adding cert-manager webhook override resources to the certmanager.operator object")
 			res := v1alpha1.CertManagerResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceEphemeralStorage: k8sresource.MustParse("2Gi"),
@@ -283,7 +285,7 @@ var _ = Describe("Overrides test", Ordered, func() {
 
 		It("should not add the resources to the cert-manager cainjector deployment", func() {
 
-			By("Adding cert-manager cainjector override resources to the certmanagaer.operator object")
+			By("Adding cert-manager cainjector override resources to the certmanager.operator object")
 			res := v1alpha1.CertManagerResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceEphemeralStorage: k8sresource.MustParse("2Gi"),

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -205,7 +205,7 @@ func verifyDeploymentArgs(k8sclient *kubernetes.Clientset, deploymentName string
 	})
 }
 
-// addOverrideResources adds the override resources to specific the cert-manager operand. The update process
+// addOverrideResources adds the override resources to the specific cert-manager operand. The update process
 // is retried if a conflict error is encountered.
 func addOverrideResources(client *certmanoperatorclient.Clientset, deploymentName string, res v1alpha1.CertManagerResourceRequirements) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -238,12 +238,12 @@ func addOverrideResources(client *certmanoperatorclient.Clientset, deploymentNam
 	})
 }
 
-// verifyDeploymentResources polls every 1 second to check if the deployment resources is updated to contain
+// verifyDeploymentResources polls every 10 seconds to check if the deployment resources is updated to contain
 // the passed resources. It returns an error if a timeout (5 mins) occurs or an error was encountered while
 // polling the deployment resources.
 func verifyDeploymentResources(k8sclient *kubernetes.Clientset, deploymentName string, res v1alpha1.CertManagerResourceRequirements, added bool) error {
 
-	return wait.PollImmediate(time.Second*5, time.Minute*5, func() (done bool, err error) {
+	return wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
 		controllerDeployment, err := k8sclient.AppsV1().Deployments(operandNamespace).Get(context.TODO(), deploymentName, v1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -19,6 +19,7 @@ import (
 	certmanoperatorclient "github.com/openshift/cert-manager-operator/pkg/operator/clientset/versioned"
 	"github.com/openshift/cert-manager-operator/test/library"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -196,6 +197,77 @@ func verifyDeploymentArgs(k8sclient *kubernetes.Clientset, deploymentName string
 			}
 		} else {
 			if containerArgsSet.HasAll(args...) {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+}
+
+// addOverrideResources adds the override resources to specific the cert-manager operand. The update process
+// is retried if a conflict error is encountered.
+func addOverrideResources(client *certmanoperatorclient.Clientset, deploymentName string, res v1alpha1.CertManagerResourceRequirements) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		operator, err := client.OperatorV1alpha1().CertManagers().Get(context.TODO(), "cluster", v1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		updatedOperator := operator.DeepCopy()
+
+		switch deploymentName {
+		case certmanagerControllerDeployment:
+			updatedOperator.Spec.ControllerConfig = &v1alpha1.DeploymentConfig{
+				OverrideResources: res,
+			}
+		case certmanagerWebhookDeployment:
+			updatedOperator.Spec.WebhookConfig = &v1alpha1.DeploymentConfig{
+				OverrideResources: res,
+			}
+		case certmanagerCAinjectorDeployment:
+			updatedOperator.Spec.CAInjectorConfig = &v1alpha1.DeploymentConfig{
+				OverrideResources: res,
+			}
+		default:
+			return fmt.Errorf("unsupported deployment name: %s", deploymentName)
+		}
+
+		_, err = client.OperatorV1alpha1().CertManagers().Update(context.TODO(), updatedOperator, v1.UpdateOptions{})
+		return err
+	})
+}
+
+// verifyDeploymentResources polls every 1 second to check if the deployment resources is updated to contain
+// the passed resources. It returns an error if a timeout (5 mins) occurs or an error was encountered while
+// polling the deployment resources.
+func verifyDeploymentResources(k8sclient *kubernetes.Clientset, deploymentName string, res v1alpha1.CertManagerResourceRequirements, added bool) error {
+
+	return wait.PollImmediate(time.Second*5, time.Minute*5, func() (done bool, err error) {
+		controllerDeployment, err := k8sclient.AppsV1().Deployments(operandNamespace).Get(context.TODO(), deploymentName, v1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		if len(controllerDeployment.Spec.Template.Spec.Containers) == 0 {
+			return false, fmt.Errorf("%s deployment spec does not have container information", deploymentName)
+		}
+
+		containerResourcesLimits := controllerDeployment.Spec.Template.Spec.Containers[0].Resources.Limits
+		equalityLimits := equality.Semantic.DeepEqual(containerResourcesLimits, res.Limits)
+
+		containerResourcesRequests := controllerDeployment.Spec.Template.Spec.Containers[0].Resources.Requests
+		equalityRequests := equality.Semantic.DeepEqual(containerResourcesRequests, res.Requests)
+
+		if added {
+			if !equalityLimits || !equalityRequests {
+				return false, nil
+			}
+		} else {
+			if equalityLimits && equalityRequests {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
Mainly refer to override args logic.
* add util funcs `addOverrideResources` and `verifyDeploymentResources `
* add 1 valid and 1 invalid cases for each operand: controller, cainjector, webhook

It's the initial attempt to add new e2e test in dev's repo.

Test profile: [aos-4_14/ipi-on-aws/versioned-installer-ci](https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-common/job/Flexy-install/249313/)

<details>
<summary>Pass log</summary>

```
Overrides test
/Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:16
  When adding valid cert-manager controller override resources
  /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:146
    should add the resources to the cert-manager controller deployment
    /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:148
  > Enter [BeforeEach] Overrides test - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:18 @ 11/30/23 00:04:25.332
  STEP: Reset cert-manager state - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:19 @ 11/30/23 00:04:25.332
  STEP: Waiting for operator status to become available - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:23 @ 11/30/23 00:04:26.399
  < Exit [BeforeEach] Overrides test - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:18 @ 11/30/23 00:04:26.874 (1.54s)
  > Enter [It] should add the resources to the cert-manager controller deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:148 @ 11/30/23 00:04:26.874
  STEP: Adding cert-manager controller override resources to the cert-managaer operator object - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:150 @ 11/30/23 00:04:26.874
  STEP: Waiting for cert-manager controller status to become available - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:164 @ 11/30/23 00:04:27.359
  STEP: Waiting for the resources to be added to the cert-manager controller deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:168 @ 11/30/23 00:04:27.601
  < Exit [It] should add the resources to the cert-manager controller deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:148 @ 11/30/23 00:04:27.84 (965ms)
• [2.505 seconds]
------------------------------
Overrides test
/Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:16
  When adding valid cert-manager webhook override resources
  /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:174
    should add the resources to the cert-manager webhook deployment
    /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:176
  > Enter [BeforeEach] Overrides test - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:18 @ 11/30/23 00:04:27.84
  STEP: Reset cert-manager state - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:19 @ 11/30/23 00:04:27.84
  STEP: Waiting for operator status to become available - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:23 @ 11/30/23 00:04:28.918
  < Exit [BeforeEach] Overrides test - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:18 @ 11/30/23 00:04:31.667 (3.825s)
  > Enter [It] should add the resources to the cert-manager webhook deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:176 @ 11/30/23 00:04:31.667
  STEP: Adding cert-manager webhook override resources to the cert-managaer operator object - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:178 @ 11/30/23 00:04:31.668
  STEP: Waiting for cert-manager webhook controller status to become available - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:192 @ 11/30/23 00:04:32.468
  STEP: Waiting for the resources to be added to the cert-manager webhook deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:196 @ 11/30/23 00:04:44.045
  < Exit [It] should add the resources to the cert-manager webhook deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:176 @ 11/30/23 00:04:44.284 (12.612s)
• [16.437 seconds]
------------------------------
Overrides test
/Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:16
  When adding valid cert-manager cainjector override resources
  /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:202
    should add the resources to the cert-manager cainjector deployment
    /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:204
  > Enter [BeforeEach] Overrides test - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:18 @ 11/30/23 00:04:44.284
  STEP: Reset cert-manager state - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:19 @ 11/30/23 00:04:44.284
  STEP: Waiting for operator status to become available - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:23 @ 11/30/23 00:04:45.493
  < Exit [BeforeEach] Overrides test - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:18 @ 11/30/23 00:04:56.339 (12.053s)
  > Enter [It] should add the resources to the cert-manager cainjector deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:204 @ 11/30/23 00:04:56.339
  STEP: Adding cert-manager cainjector override resources to the cert-managaer operator object - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:206 @ 11/30/23 00:04:56.339
  STEP: Waiting for cert-manager cainjector controller status to become available - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:220 @ 11/30/23 00:04:56.817
  STEP: Waiting for the resources to be added to the cert-manager cainjector deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:224 @ 11/30/23 00:05:00.297
  < Exit [It] should add the resources to the cert-manager cainjector deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:204 @ 11/30/23 00:05:00.635 (4.296s)
• [16.349 seconds]
------------------------------
Overrides test
/Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:16
  When adding invalid cert-manager controller override resources
  /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:230
    should not add the resources to the cert-manager controller deployment
    /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:232
  > Enter [BeforeEach] Overrides test - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:18 @ 11/30/23 00:05:00.636
  STEP: Reset cert-manager state - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:19 @ 11/30/23 00:05:00.636
  STEP: Waiting for operator status to become available - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:23 @ 11/30/23 00:05:02.048
  < Exit [BeforeEach] Overrides test - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:18 @ 11/30/23 00:05:04.628 (3.992s)
  > Enter [It] should not add the resources to the cert-manager controller deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:232 @ 11/30/23 00:05:04.628
  STEP: Adding cert-manager controller override resources to the cert-managaer operator object - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:234 @ 11/30/23 00:05:04.628
  STEP: Waiting for cert-manager controller status to become degraded - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:246 @ 11/30/23 00:05:05.245
  STEP: Checking if the resources are not added to the cert-manager controller deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:250 @ 11/30/23 00:05:05.551
  < Exit [It] should not add the resources to the cert-manager controller deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:232 @ 11/30/23 00:05:05.799 (1.171s)
• [5.163 seconds]
------------------------------
Overrides test
/Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:16
  When adding invalid cert-manager webhook override resources
  /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:256
    should not add the resources to the cert-manager webhook deployment
    /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:258
  > Enter [BeforeEach] Overrides test - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:18 @ 11/30/23 00:05:05.799
  STEP: Reset cert-manager state - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:19 @ 11/30/23 00:05:05.799
  STEP: Waiting for operator status to become available - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:23 @ 11/30/23 00:05:06.82
  < Exit [BeforeEach] Overrides test - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:18 @ 11/30/23 00:05:07.395 (1.595s)
  > Enter [It] should not add the resources to the cert-manager webhook deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:258 @ 11/30/23 00:05:07.395
  STEP: Adding cert-manager webhook override resources to the cert-managaer operator object - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:260 @ 11/30/23 00:05:07.395
  STEP: Waiting for cert-manager webhook controller status to become degraded - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:272 @ 11/30/23 00:05:08.012
  STEP: Checking if the resources are not added to the cert-manager webhook deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:276 @ 11/30/23 00:05:08.251
  < Exit [It] should not add the resources to the cert-manager webhook deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:258 @ 11/30/23 00:05:08.492 (1.098s)
• [2.693 seconds]
------------------------------
Overrides test
/Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:16
  When adding invalid cert-manager cainjector override resources
  /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:282
    should not add the resources to the cert-manager cainjector deployment
    /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:284
  > Enter [BeforeEach] Overrides test - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:18 @ 11/30/23 00:05:08.493
  STEP: Reset cert-manager state - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:19 @ 11/30/23 00:05:08.493
  STEP: Waiting for operator status to become available - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:23 @ 11/30/23 00:05:09.464
  < Exit [BeforeEach] Overrides test - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:18 @ 11/30/23 00:05:09.954 (1.461s)
  > Enter [It] should not add the resources to the cert-manager cainjector deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:284 @ 11/30/23 00:05:09.954
  STEP: Adding cert-manager cainjector override resources to the cert-managaer operator object - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:286 @ 11/30/23 00:05:09.954
  STEP: Waiting for cert-manager cainjector controller status to become degraded - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:298 @ 11/30/23 00:05:10.442
  STEP: Checking if the resources are not added to the cert-manager cainjector deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:302 @ 11/30/23 00:05:10.681
  < Exit [It] should not add the resources to the cert-manager cainjector deployment - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:284 @ 11/30/23 00:05:10.978 (1.025s)
  > Enter [AfterAll] Overrides test - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:308 @ 11/30/23 00:05:10.979
  STEP: Reset cert-manager state - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:309 @ 11/30/23 00:05:10.979
  STEP: Waiting for operator status to become available - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:313 @ 11/30/23 00:05:12.076
  < Exit [AfterAll] Overrides test - /Users/yuewu/Documents/workspace/fork/cert-manager-operator/test/e2e/overrides_test.go:308 @ 11/30/23 00:05:12.727 (1.749s)
• [4.235 seconds]
------------------------------
```

</details>