### PR TITLE
CM-262: Updates for Azure ambient credentials

### DIFF
--- a/docs/cloud_credentials.md
+++ b/docs/cloud_credentials.md
@@ -76,15 +76,15 @@ ls <output-dir>/manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
 oc delete pods --all -n cert-manager
 ```
 
-Wait for the pods to come up in running state.
-
-```sh
-oc get pods -n cert-manager -w
-```
-
 7. Patch the subscription object on the cluster to inject the secret name in the operator deployment.
 ```sh
 oc -n cert-manager-operator patch subscription <subscription-name> --type='merge' -p '{"spec":{"config":{"env":[{"name":"CLOUD_CREDENTIALS_SECRET_NAME","value":"aws-creds"}]}}}'
+```
+
+8. Wait for new cert-manager pods to come up in running state.
+
+```sh
+oc get pods -n cert-manager -w
 ```
 
 ## GCP
@@ -129,3 +129,78 @@ ls manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
 ```sh
 oc -n cert-manager-operator patch subscription <subscription-name> --type='merge' -p '{"spec":{"config":{"env":[{"name":"CLOUD_CREDENTIALS_SECRET_NAME","value":"gcp-credentials"}]}}}'
 ```
+
+6. Wait for new cert-manager pods to come up in running state.
+
+```sh
+oc get pods -n cert-manager -w
+```
+
+## Azure
+
+1. Create the following yaml file for credentials request object and `oc apply -f <yaml-file>` on the cluster. 
+```yaml
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: cert-manager
+  namespace: openshift-cloud-credential-operator
+spec:
+  secretRef:
+    name: cloud-credentials
+    namespace: cert-manager
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AzureProviderSpec
+    roleBindings:
+      - role: DNS Zone Contributor
+  serviceAccountNames:
+  - cert-manager
+```
+2. Create a new directory `<cred-reqs-dir>` and place the `<yaml-file>` in that directory.
+
+3. If using Azure Workload Identity and or credentials mode as Manual on the cluster, use [`ccoctl`](https://github.com/openshift/cloud-credential-operator/blob/master/docs/ccoctl.md) to generate the secrets and apply it on the cluster.
+```sh
+ccoctl azure create-managed-identities --credentials-requests-dir <cred-reqs-dir> --dnszone-resource-group-name <az-dns-rg> --issuer-url <oidc-issuer-url> --name <cluster-oidc-name> --region <cluster-az-region> --subscription-id <az-subscription-id> --output-dir <output-dir>
+```
+
+The output of the previous ccoctl command would be similar to:
+
+```log
+2024/03/04 16:42:33 Found existing resource group /subscriptions/<az-subscription-id>/resourceGroups/<cluster-oidc-name>
+2024/03/04 16:42:33 Cluster installation resource group name is <cluster-oidc-name>. This resource group MUST be configured as the resource group used for cluster installation.
+2024/03/04 16:42:39 Created user-assigned managed identity /subscriptions/<az-subscription-id>/resourcegroups/<cluster-oidc-name>-oidc/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<cluster-oidc-name>-cert-manager-cloud-credentials
+
+
+2024/03/04 16:42:45 Created role assignment for role DNS Zone Contributor with user-assigned managed identity principal ID <az-wmanaged-identity-uuid> at scope /subscriptions/<az-subscription-id>/resourceGroups/<cluster-oidc-name>
+
+
+2024/03/04 16:42:45 Saved credentials configuration to: <output-dir>/manifests/cert-manager-cloud-credentials-credentials.yaml
+```
+
+Take a note of the `<az-wmanaged-identity-uuid>` of the form `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`.
+If not using Manual credentials mode, skip steps 3, 4, 5 and directly proceed to 6.
+
+4. Apply the generated secrets on the cluster 
+```sh
+ls manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
+```
+
+5. Patch the CertManager.operator object on the cluster to add override labels, so the cert-manager controller pod can add Azure Workload Identity required labels.
+
+```sh
+oc patch certmanager/cluster --type=merge -p='
+spec:
+  controllerConfig:
+    overrideLabels:
+      azure.workload.identity/use: "true"
+'
+```
+
+6. Wait for a new cert-manager controller pod to come up in running state, after the changes.
+
+```sh
+oc get pods -n cert-manager -l app=cert-manager -w
+```
+
+**Note:** Re-use the `<az-wmanaged-identity-uuid>` at the time of creating Issuer/ClusterIssuer **only if required**. Please refer to https://cert-manager.io/docs/configuration/acme/dns01/azuredns/#configure-a-clusterissuer for issuer examples that use ACME over Azure DNS.


### PR DESCRIPTION
- Update `docs/cloud_credentials.md` for adding Azure Workload Identity steps.
- Add ambient credentials support for Azure clusters without Workload Identity - allows cluster administrators to inject a specific (explicit) cloud credential secret for Azure clusters, similar to what we already do for AWS non-STS and GCP non-Workload Identity.