### PR TITLE
Fix link to metrics documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,4 +163,4 @@ spec:
 ```
 ## Metrics and Monitoring
 
-The guide to [enable the cert-manager metrics and monitoring](https://github.com/openshift/cert-manager-operator/tree/master/docs/OPERAND_METRICS.md) will help you get started.
+The guide to [enable the cert-manager metrics and monitoring](https://github.com/openshift/cert-manager-operator/tree/master/docs/operand_metrics.md) will help you get started.


### PR DESCRIPTION
The link returns 404 Not Found, the resource was renamed in 7e670e4. This Pull Request fixes the link in README.md.