### PR TITLE
CM-333: Go build(s) with strictfipsruntime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ local-run: build
 .PHONY: local-run
 
 ##@ Build
-GO=GO111MODULE=on GOFLAGS=-mod=vendor CGO_ENABLED=0 go
+GO=GO111MODULE=on GOFLAGS="-mod=vendor -tags=strictfipsruntime,openssl" CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go
 
 build-operator: ## Build operator binary, no additional checks or code generation
 	$(GO) build $(GOBUILD_VERSION_ARGS) -o $(BIN)

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -213,7 +213,7 @@ metadata:
     containerImage: openshift.io/cert-manager-operator:latest
     createdAt: 2023-03-03T00:00:00
     features.operators.openshift.io/disconnected: "false"
-    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "true"

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     containerImage: ""
     createdAt: 2023-03-03T00:00:00
     features.operators.openshift.io/disconnected: "false"
-    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "true"

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -1,12 +1,13 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/cert-manager-operator
+
+# build operator
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.access.redhat.com/ubi9-minimal:9.2
+FROM registry.access.redhat.com/ubi9-minimal:9.4
 COPY --from=builder /go/src/github.com/openshift/cert-manager-operator/cert-manager-operator /usr/bin/
 
 USER 65532:65532
 
 ENTRYPOINT ["/usr/bin/cert-manager-operator"]
-

--- a/images/ci/operand.Dockerfile
+++ b/images/ci/operand.Dockerfile
@@ -1,0 +1,43 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+
+ARG RELEASE_BRANCH=release-1.14
+
+ARG GO_BUILD_TAGS=strictfipsruntime,openssl
+ENV GOEXPERIMENT strictfipsruntime 
+ENV CGO_ENABLED 1
+
+RUN mkdir -p /go/src/github.com/cert-manager
+RUN git clone --depth 1 --branch $RELEASE_BRANCH https://github.com/openshift/jetstack-cert-manager.git /go/src/github.com/cert-manager/cert-manager
+WORKDIR /go/src/github.com/cert-manager/cert-manager
+
+RUN mkdir /app
+
+# build acmesolver
+WORKDIR /go/src/github.com/cert-manager/cert-manager/cmd/acmesolver
+RUN go mod vendor
+RUN go build -mod=vendor -tags $GO_BUILD_TAGS -o /app/_output/acmesolver main.go
+
+# build cainjector
+WORKDIR /go/src/github.com/cert-manager/cert-manager/cmd/cainjector
+RUN go mod vendor
+RUN go build -mod=vendor -tags $GO_BUILD_TAGS -o /app/_output/cainjector main.go
+
+# build controller
+WORKDIR /go/src/github.com/cert-manager/cert-manager/cmd/controller
+RUN go mod vendor
+RUN go build -mod=vendor -tags $GO_BUILD_TAGS -o /app/_output/controller main.go
+
+# build webhook
+WORKDIR /go/src/github.com/cert-manager/cert-manager/cmd/webhook
+RUN go mod vendor
+RUN go build -mod=vendor -tags $GO_BUILD_TAGS -o /app/_output/webhook main.go
+
+
+FROM registry.access.redhat.com/ubi9-minimal:9.4
+
+COPY --from=builder /app/_output/acmesolver /app/cmd/acmesolver/acmesolver
+COPY --from=builder /app/_output/cainjector /app/cmd/cainjector/cainjector
+COPY --from=builder /app/_output/controller /app/cmd/controller/controller
+COPY --from=builder /app/_output/webhook /app/cmd/webhook/webhook
+
+USER 65532:65532


### PR DESCRIPTION
- `strictfipsruntime` mode for Go build
- build operand on CI (instead of mirroring from jetstack upstream)
- enable `features.operators.openshift.io/fips-compliant` in CSV

Refer https://github.com/openshift/release/pull/51700 for rehearsed PoC.