### PR TITLE
OCPBUGS-24193: Use `imagePullPolicy: IfNotPresent` for operator deployment

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -672,7 +672,7 @@ spec:
                 - name: TRUSTED_CA_CONFIGMAP_NAME
                 - name: CLOUD_CREDENTIALS_SECRET_NAME
                 image: openshift.io/cert-manager-operator:latest
-                imagePullPolicy: Always
+                imagePullPolicy: IfNotPresent
                 name: cert-manager-operator
                 resources:
                   requests:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,7 +74,7 @@ spec:
             - name: TRUSTED_CA_CONFIGMAP_NAME
             - name: CLOUD_CREDENTIALS_SECRET_NAME
           image: controller:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           name: cert-manager-operator
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
This avoids blocking upgrades in a limited connectivity/airgapped env where on prior images are pulled before an upgrade, which is per [the related enhancement guidance](https://github.com/openshift/enhancements/blob/master/enhancements/update/dont-require-registry-during-reboot-and-upgrade.md#dont-use-the-always-pull-policy).