### PR TITLE
OCPBUGS-34698: Fix for TestCertRenew sporadic failures

### DIFF
--- a/test/e2e/testdata/acme/deployment.yaml
+++ b/test/e2e/testdata/acme/deployment.yaml
@@ -26,11 +26,11 @@ spec:
               protocol: TCP
             - containerPort: 8888
               protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            privileged: false
+            capabilities:
+              drop: [All]
       dnsPolicy: ClusterFirst
       restartPolicy: Always
-      securityContext:
-        allowPrivilegeEscalation: false
-        runAsNonRoot: true
-        privileged: false
-        capabilities:
-          drop: All

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -9,18 +9,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	certmanagerclientset "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	opv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
 	certmanoperatorclient "github.com/openshift/cert-manager-operator/pkg/operator/clientset/versioned"
 	"github.com/openshift/cert-manager-operator/test/library"
 
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -424,4 +427,46 @@ func replaceStrInFile(replaceStrMap map[string]string, fileName string) ([]byte,
 		fileContentsStr = strings.ReplaceAll(fileContentsStr, k, v)
 	}
 	return []byte(fileContentsStr), nil
+}
+
+// waitForCertificateReadinessWithClient polls the status of the Certificate object and returns non-nil error
+// once the Ready condition is true, otherwise should return a time-out error.
+func waitForCertificateReadinessWithClient(ctx context.Context, client *certmanagerclientset.Clientset, certName, namespace string) error {
+	return wait.PollUntilContextTimeout(ctx, PollInterval, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		cert, err := client.CertmanagerV1().Certificates(namespace).Get(ctx, certName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		for _, cond := range cert.Status.Conditions {
+			if cond.Type == cmv1.CertificateConditionReady {
+				return cond.Status == cmmetav1.ConditionTrue, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+// waitForIngressReadiness polls the status of the Ingress object and returns non-nil error
+// once the ingress endpoint is available, otherwise should return a time-out error.
+func waitForIngressReadiness(ctx context.Context, client kubernetes.Interface, ingressObj networkingv1.Ingress, domainName string) error {
+	return wait.PollUntilContextTimeout(ctx, PollInterval, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		ingress, err := client.NetworkingV1().Ingresses(ingressObj.Namespace).Get(ctx, ingressObj.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		endpoints := ingress.Status.LoadBalancer.Ingress
+		if endpoints == nil {
+			return false, nil
+		}
+		for _, endpoint := range endpoints {
+			matched, err := regexp.MatchString(fmt.Sprintf(".%s$", domainName), endpoint.Hostname)
+			if err != nil {
+				return false, nil
+			}
+			return matched, nil
+		}
+		return false, nil
+	})
 }


### PR DESCRIPTION
PR contain below changes:
- Moved securityContext properties in ACME deployment to container spec.
- Added debug logs on TestCertRenew.
- Changes variable names from snake case to camel case in TestCertRenew.
- Compare certificate's pre-fetched NotAfter value from status subresource against the dynamically fetched certificate in the poll block, which guess was causing the sporadic failures.