### PR TITLE
CM-331: Disable kube-rbac-proxy http2

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -611,11 +611,12 @@ spec:
                         - linux
               containers:
               - args:
+                - --http2-disable
                 - --secure-listen-address=0.0.0.0:9443
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 9443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -35,8 +35,9 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: "RuntimeDefault"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
         args:
+        - "--http2-disable"
         - "--secure-listen-address=0.0.0.0:9443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"


### PR DESCRIPTION
kube-rbac-proxy:latest image from [RH catalog](https://catalog.redhat.com/software/containers/openshift4/ose-kube-rbac-proxy/5cdb2634dd19c778293b4d98?architecture=amd64&image=664e863c3ac7bfa8cd232e43&container-tabs=overview) still do not have the bumped `golang.org/x/net` with remediated CVE for http2.

Hence, disabling http2 on the kube-rbac-proxy.