### PR TITLE
CM-261: utilize ginkgo label filter to differentiate cloud platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,9 @@ SHORTCOMMIT ?= $(shell git rev-parse --short HEAD)
 GOBUILD_VERSION_ARGS = -ldflags "-X $(PACKAGE)/pkg/version.SHORTCOMMIT=$(SHORTCOMMIT) -X $(PACKAGE)/pkg/version.COMMIT=$(COMMIT)"
 
 E2E_TIMEOUT ?= 1h
+# E2E_GINKGO_LABEL_FILTER is ginkgo label query for selecting tests. See
+# https://onsi.github.io/ginkgo/#spec-labels. The default is to run tests on the AWS platform.
+E2E_GINKGO_LABEL_FILTER ?= "Platform: isSubsetOf {AWS}"
 
 MANIFEST_SOURCE = https://github.com/cert-manager/cert-manager/releases/download/v1.15.2/cert-manager.yaml
 
@@ -246,7 +249,8 @@ test-e2e: test-e2e-wait-for-stable-state
 	-p 1 \
 	-tags e2e \
 	-run "$(TEST)" \
-	./test/e2e
+	./test/e2e \
+	-ginkgo.label-filter=$(E2E_GINKGO_LABEL_FILTER)
 
 test-e2e-wait-for-stable-state:
 	@echo "---- Waiting for stable state ----"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-jsonnet v0.17.0
 	github.com/mogensen/kubernetes-split-yaml v0.3.0
-	github.com/onsi/ginkgo/v2 v2.17.2
+	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/openshift/api v0.0.0-20240812094746-86145edb40cf
 	github.com/openshift/build-machinery-go v0.0.0-20240419090851-af9c868bcf52

--- a/go.sum
+++ b/go.sum
@@ -500,8 +500,8 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
-github.com/onsi/ginkgo/v2 v2.17.2 h1:7eMhcy3GimbsA3hEnVKdw/PQM9XN9krpKVXsZdph0/g=
-github.com/onsi/ginkgo/v2 v2.17.2/go.mod h1:nP2DPOQoNsQmsVyv5rDA8JkXQoCs6goXIvr/PRJ1eCc=
+github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA=
+github.com/onsi/ginkgo/v2 v2.19.0/go.mod h1:rlwLi9PilAFJ8jCg9UE1QP6VBpd6/xj3SRC0d6TU0To=
 github.com/onsi/gomega v1.33.1 h1:dsYjIxxSR755MDmKVsaFQTE22ChNBcuuTWgkUDSubOk=
 github.com/onsi/gomega v1.33.1/go.mod h1:U4R44UsT+9eLIaYRB2a5qajjtQYn0hauxvRm16AVYg0=
 github.com/openshift/api v0.0.0-20240812094746-86145edb40cf h1:MB0TCPkvxj80Ucj7w6xArL4StOrQBMN7AvGYtsP5t2M=

--- a/vendor/github.com/onsi/ginkgo/v2/CHANGELOG.md
+++ b/vendor/github.com/onsi/ginkgo/v2/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 2.19.0
+
+### Features
+
+[Label Sets](https://onsi.github.io/ginkgo/#label-sets) allow for more expressive and flexible label filtering.
+
+## 2.18.0
+
+### Features
+- Add --slience-skips and --force-newlines [f010b65]
+- fail when no tests were run and --fail-on-empty was set [d80eebe]
+
+### Fixes
+- Fix table entry context edge case [42013d6]
+
+### Maintenance
+- Bump golang.org/x/tools from 0.20.0 to 0.21.0 (#1406) [fcf1fd7]
+- Bump github.com/onsi/gomega from 1.33.0 to 1.33.1 (#1399) [8bb14fd]
+- Bump golang.org/x/net from 0.24.0 to 0.25.0 (#1407) [04bfad7]
+
+## 2.17.3
+
+### Fixes
+`ginkgo watch` now ignores hidden files [bde6e00]
+
 ## 2.17.2
 
 ### Fixes

--- a/vendor/github.com/onsi/ginkgo/v2/CONTRIBUTING.md
+++ b/vendor/github.com/onsi/ginkgo/v2/CONTRIBUTING.md
@@ -6,8 +6,10 @@ Your contributions to Ginkgo are essential for its long-term maintenance and imp
 - Ensure adequate test coverage:
     - When adding to the Ginkgo library, add unit and/or integration tests (under the `integration` folder).
     - When adding to the Ginkgo CLI, note that there are very few unit tests.  Please add an integration test.
-- Make sure all the tests succeed via `ginkgo -r -p`
-- Vet your changes via `go vet ./...`
-- Update the documentation. Ginkgo uses `godoc` comments and documentation in `docs/index.md`.  You can run `bundle exec jekyll serve` in the `docs` directory to preview your changes.
+- Run `make` or:
+  - Install ginkgo locally via `go install ./...`
+  - Make sure all the tests succeed via `ginkgo -r -p`
+  - Vet your changes via `go vet ./...`
+- Update the documentation. Ginkgo uses `godoc` comments and documentation in `docs/index.md`.  You can run `bundle && bundle exec jekyll serve` in the `docs` directory to preview your changes.
 
 Thanks for supporting Ginkgo!

--- a/vendor/github.com/onsi/ginkgo/v2/Makefile
+++ b/vendor/github.com/onsi/ginkgo/v2/Makefile
@@ -1,0 +1,11 @@
+# default task since it's first
+.PHONY: all
+all:  vet test
+
+.PHONY: test
+test:
+	go run github.com/onsi/ginkgo/v2/ginkgo -r -p
+
+.PHONY: vet
+vet:
+	go vet ./...

--- a/vendor/github.com/onsi/ginkgo/v2/ginkgo/watch/package_hash.go
+++ b/vendor/github.com/onsi/ginkgo/v2/ginkgo/watch/package_hash.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -79,6 +80,10 @@ func (p *PackageHash) computeHashes() (codeHash string, codeModifiedTime time.Ti
 			continue
 		}
 
+		if isHiddenFile(info) {
+			continue
+		}
+
 		if goTestRegExp.MatchString(info.Name()) {
 			testHash += p.hashForFileInfo(info)
 			if info.ModTime().After(testModifiedTime) {
@@ -101,6 +106,10 @@ func (p *PackageHash) computeHashes() (codeHash string, codeModifiedTime time.Ti
 	}
 
 	return
+}
+
+func isHiddenFile(info os.FileInfo) bool {
+	return strings.HasPrefix(info.Name(), ".") || strings.HasPrefix(info.Name(), "_")
 }
 
 func (p *PackageHash) hashForFileInfo(info os.FileInfo) string {

--- a/vendor/github.com/onsi/ginkgo/v2/internal/suite.go
+++ b/vendor/github.com/onsi/ginkgo/v2/internal/suite.go
@@ -489,8 +489,13 @@ func (suite *Suite) runSpecs(description string, suiteLabels Labels, suitePath s
 			newGroup(suite).run(specs.AtIndices(groupedSpecIndices[groupedSpecIdx]))
 		}
 
-		if specs.HasAnySpecsMarkedPending() && suite.config.FailOnPending {
+		if suite.config.FailOnPending && specs.HasAnySpecsMarkedPending() {
 			suite.report.SpecialSuiteFailureReasons = append(suite.report.SpecialSuiteFailureReasons, "Detected pending specs and --fail-on-pending is set")
+			suite.report.SuiteSucceeded = false
+		}
+
+		if suite.config.FailOnEmpty && specs.CountWithoutSkip() == 0 {
+			suite.report.SpecialSuiteFailureReasons = append(suite.report.SpecialSuiteFailureReasons, "Detected no specs ran and --fail-on-empty is set")
 			suite.report.SuiteSucceeded = false
 		}
 	}

--- a/vendor/github.com/onsi/ginkgo/v2/reporters/default_reporter.go
+++ b/vendor/github.com/onsi/ginkgo/v2/reporters/default_reporter.go
@@ -202,6 +202,11 @@ func (r *DefaultReporter) DidRun(report types.SpecReport) {
 	v := r.conf.Verbosity()
 	inParallel := report.RunningInParallel
 
+	//should we completely omit this spec?
+	if report.State.Is(types.SpecStateSkipped) && r.conf.SilenceSkips {
+		return
+	}
+
 	header := r.specDenoter
 	if report.LeafNodeType.Is(types.NodeTypesForSuiteLevelNodes) {
 		header = fmt.Sprintf("[%s]", report.LeafNodeType)
@@ -278,9 +283,12 @@ func (r *DefaultReporter) DidRun(report types.SpecReport) {
 		}
 	}
 
-	// If we have no content to show, jsut emit the header and return
+	// If we have no content to show, just emit the header and return
 	if !reportHasContent {
 		r.emit(r.f(highlightColor + header + "{{/}}"))
+		if r.conf.ForceNewlines {
+			r.emit("\n")
+		}
 		return
 	}
 

--- a/vendor/github.com/onsi/ginkgo/v2/reporters/junit_report.go
+++ b/vendor/github.com/onsi/ginkgo/v2/reporters/junit_report.go
@@ -177,6 +177,7 @@ func GenerateJUnitReportWithConfig(report types.Report, dst string, config Junit
 				{"FocusFiles", strings.Join(report.SuiteConfig.FocusFiles, ";")},
 				{"SkipFiles", strings.Join(report.SuiteConfig.SkipFiles, ";")},
 				{"FailOnPending", fmt.Sprintf("%t", report.SuiteConfig.FailOnPending)},
+				{"FailOnEmpty", fmt.Sprintf("%t", report.SuiteConfig.FailOnEmpty)},
 				{"FailFast", fmt.Sprintf("%t", report.SuiteConfig.FailFast)},
 				{"FlakeAttempts", fmt.Sprintf("%d", report.SuiteConfig.FlakeAttempts)},
 				{"DryRun", fmt.Sprintf("%t", report.SuiteConfig.DryRun)},

--- a/vendor/github.com/onsi/ginkgo/v2/table_dsl.go
+++ b/vendor/github.com/onsi/ginkgo/v2/table_dsl.go
@@ -269,11 +269,15 @@ func generateTable(description string, isSubtree bool, args ...interface{}) {
 			internalNodeArgs = append(internalNodeArgs, entry.decorations...)
 
 			hasContext := false
-			if internalBodyType.NumIn() > 0. {
+			if internalBodyType.NumIn() > 0 {
 				if internalBodyType.In(0).Implements(specContextType) {
 					hasContext = true
-				} else if internalBodyType.In(0).Implements(contextType) && (len(entry.parameters) == 0 || !reflect.TypeOf(entry.parameters[0]).Implements(contextType)) {
+				} else if internalBodyType.In(0).Implements(contextType) {
 					hasContext = true
+					if len(entry.parameters) > 0 && reflect.TypeOf(entry.parameters[0]) != nil && reflect.TypeOf(entry.parameters[0]).Implements(contextType) {
+						// we allow you to pass in a non-nil context
+						hasContext = false
+					}
 				}
 			}
 

--- a/vendor/github.com/onsi/ginkgo/v2/types/config.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/config.go
@@ -25,6 +25,7 @@ type SuiteConfig struct {
 	SkipFiles             []string
 	LabelFilter           string
 	FailOnPending         bool
+	FailOnEmpty           bool
 	FailFast              bool
 	FlakeAttempts         int
 	MustPassRepeatedly    int
@@ -90,6 +91,8 @@ type ReporterConfig struct {
 	FullTrace      bool
 	ShowNodeEvents bool
 	GithubOutput   bool
+	SilenceSkips   bool
+	ForceNewlines  bool
 
 	JSONReport     string
 	JUnitReport    string
@@ -275,6 +278,8 @@ var SuiteConfigFlags = GinkgoFlags{
 		Usage: "If set, ginkgo will stop running a test suite after a failure occurs."},
 	{KeyPath: "S.FlakeAttempts", Name: "flake-attempts", SectionKey: "failure", UsageDefaultValue: "0 - failed tests are not retried", DeprecatedName: "flakeAttempts", DeprecatedDocLink: "changed-command-line-flags",
 		Usage: "Make up to this many attempts to run each spec. If any of the attempts succeed, the suite will not be failed."},
+	{KeyPath: "S.FailOnEmpty", Name: "fail-on-empty", SectionKey: "failure",
+		Usage: "If set, ginkgo will mark the test suite as failed if no specs are run."},
 
 	{KeyPath: "S.DryRun", Name: "dry-run", SectionKey: "debug", DeprecatedName: "dryRun", DeprecatedDocLink: "changed-command-line-flags",
 		Usage: "If set, ginkgo will walk the test hierarchy without actually running anything.  Best paired with -v."},
@@ -334,6 +339,10 @@ var ReporterConfigFlags = GinkgoFlags{
 		Usage: "If set, default reporter prints node > Enter and < Exit events when specs fail"},
 	{KeyPath: "R.GithubOutput", Name: "github-output", SectionKey: "output",
 		Usage: "If set, default reporter prints easier to manage output in Github Actions."},
+	{KeyPath: "R.SilenceSkips", Name: "silence-skips", SectionKey: "output",
+		Usage: "If set, default reporter will not print out skipped tests."},
+	{KeyPath: "R.ForceNewlines", Name: "force-newlines", SectionKey: "output",
+		Usage: "If set, default reporter will ensure a newline appears after each test."},
 
 	{KeyPath: "R.JSONReport", Name: "json-report", UsageArgument: "filename.json", SectionKey: "output",
 		Usage: "If set, Ginkgo will generate a JSON-formatted test report at the specified location."},

--- a/vendor/github.com/onsi/ginkgo/v2/types/label_filter.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/label_filter.go
@@ -45,6 +45,83 @@ func orAction(a, b LabelFilter) LabelFilter {
 	return func(labels []string) bool { return a(labels) || b(labels) }
 }
 
+func labelSetFor(key string, labels []string) map[string]bool {
+	key = strings.ToLower(strings.TrimSpace(key))
+	out := map[string]bool{}
+	for _, label := range labels {
+		components := strings.SplitN(label, ":", 2)
+		if len(components) < 2 {
+			continue
+		}
+		if key == strings.ToLower(strings.TrimSpace(components[0])) {
+			out[strings.ToLower(strings.TrimSpace(components[1]))] = true
+		}
+	}
+
+	return out
+}
+
+func isEmptyLabelSetAction(key string) LabelFilter {
+	return func(labels []string) bool {
+		return len(labelSetFor(key, labels)) == 0
+	}
+}
+
+func containsAnyLabelSetAction(key string, expectedValues []string) LabelFilter {
+	return func(labels []string) bool {
+		set := labelSetFor(key, labels)
+		for _, value := range expectedValues {
+			if set[value] {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func containsAllLabelSetAction(key string, expectedValues []string) LabelFilter {
+	return func(labels []string) bool {
+		set := labelSetFor(key, labels)
+		for _, value := range expectedValues {
+			if !set[value] {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+func consistsOfLabelSetAction(key string, expectedValues []string) LabelFilter {
+	return func(labels []string) bool {
+		set := labelSetFor(key, labels)
+		if len(set) != len(expectedValues) {
+			return false
+		}
+		for _, value := range expectedValues {
+			if !set[value] {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+func isSubsetOfLabelSetAction(key string, expectedValues []string) LabelFilter {
+	expectedSet := map[string]bool{}
+	for _, value := range expectedValues {
+		expectedSet[value] = true
+	}
+	return func(labels []string) bool {
+		set := labelSetFor(key, labels)
+		for value := range set {
+			if !expectedSet[value] {
+				return false
+			}
+		}
+		return true
+	}
+}
+
 type lfToken uint
 
 const (
@@ -58,6 +135,9 @@ const (
 	lfTokenOr
 	lfTokenRegexp
 	lfTokenLabel
+	lfTokenSetKey
+	lfTokenSetOperation
+	lfTokenSetArgument
 	lfTokenEOF
 )
 
@@ -71,6 +151,8 @@ func (l lfToken) Precedence() int {
 		return 2
 	case lfTokenNot:
 		return 3
+	case lfTokenSetOperation:
+		return 4
 	}
 	return -1
 }
@@ -93,6 +175,12 @@ func (l lfToken) String() string {
 		return "/regexp/"
 	case lfTokenLabel:
 		return "label"
+	case lfTokenSetKey:
+		return "set_key"
+	case lfTokenSetOperation:
+		return "set_operation"
+	case lfTokenSetArgument:
+		return "set_argument"
 	case lfTokenEOF:
 		return "EOF"
 	}
@@ -148,6 +236,35 @@ func (tn *treeNode) constructLabelFilter(input string) (LabelFilter, error) {
 			return nil, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, tn.location, fmt.Sprintf("RegExp compilation error: %s", err))
 		}
 		return matchLabelRegexAction(re), nil
+	case lfTokenSetOperation:
+		tokenSetOperation := strings.ToLower(tn.value)
+		if tokenSetOperation == "isempty" {
+			return isEmptyLabelSetAction(tn.leftNode.value), nil
+		}
+		if tn.rightNode == nil {
+			return nil, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, tn.location, fmt.Sprintf("Set operation '%s' is missing an argument.", tn.value))
+		}
+
+		rawValues := strings.Split(tn.rightNode.value, ",")
+		values := make([]string, len(rawValues))
+		for i := range rawValues {
+			values[i] = strings.ToLower(strings.TrimSpace(rawValues[i]))
+			if strings.ContainsAny(values[i], "&|!,()/") {
+				return nil, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, tn.rightNode.location, fmt.Sprintf("Invalid label value '%s' in set operation argument.", values[i]))
+			} else if values[i] == "" {
+				return nil, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, tn.rightNode.location, "Empty label value in set operation argument.")
+			}
+		}
+		switch tokenSetOperation {
+		case "containsany":
+			return containsAnyLabelSetAction(tn.leftNode.value, values), nil
+		case "containsall":
+			return containsAllLabelSetAction(tn.leftNode.value, values), nil
+		case "consistsof":
+			return consistsOfLabelSetAction(tn.leftNode.value, values), nil
+		case "issubsetof":
+			return isSubsetOfLabelSetAction(tn.leftNode.value, values), nil
+		}
 	}
 
 	if tn.rightNode == nil {
@@ -203,7 +320,17 @@ func (tn *treeNode) toString(indent int) string {
 	return out
 }
 
+var validSetOperations = map[string]string{
+	"containsany": "containsAny",
+	"containsall": "containsAll",
+	"consistsof":  "consistsOf",
+	"issubsetof":  "isSubsetOf",
+	"isempty":     "isEmpty",
+}
+
 func tokenize(input string) func() (*treeNode, error) {
+	lastToken := lfTokenInvalid
+	lastValue := ""
 	runes, i := []rune(input), 0
 
 	peekIs := func(r rune) bool {
@@ -233,6 +360,53 @@ func tokenize(input string) func() (*treeNode, error) {
 		}
 
 		node := &treeNode{location: i}
+		defer func() {
+			lastToken = node.token
+			lastValue = node.value
+		}()
+
+		if lastToken == lfTokenSetKey {
+			//we should get a valid set operation next
+			value, n := consumeUntil(" )")
+			if validSetOperations[strings.ToLower(value)] == "" {
+				return &treeNode{}, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, i, fmt.Sprintf("Invalid set operation '%s'.", value))
+			}
+			i += n
+			node.token, node.value = lfTokenSetOperation, value
+			return node, nil
+		}
+		if lastToken == lfTokenSetOperation {
+			//we should get an argument next, if we aren't isempty
+			var arg = ""
+			origI := i
+			if runes[i] == '{' {
+				i += 1
+				value, n := consumeUntil("}")
+				if i+n >= len(runes) {
+					return &treeNode{}, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, i-1, "Missing closing '}' in set operation argument?")
+				}
+				i += n + 1
+				arg = value
+			} else {
+				value, n := consumeUntil("&|!,()/")
+				i += n
+				arg = strings.TrimSpace(value)
+			}
+			if strings.ToLower(lastValue) == "isempty" && arg != "" {
+				return &treeNode{}, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, origI, fmt.Sprintf("isEmpty does not take arguments, was passed '%s'.", arg))
+			}
+			if arg == "" && strings.ToLower(lastValue) != "isempty" {
+				if i < len(runes) && runes[i] == '/' {
+					return &treeNode{}, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, origI, "Set operations do not support regular expressions.")
+				} else {
+					return &treeNode{}, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, origI, fmt.Sprintf("Set operation '%s' requires an argument.", lastValue))
+				}
+			}
+			// note that we sent an empty SetArgument token if we are isempty
+			node.token, node.value = lfTokenSetArgument, arg
+			return node, nil
+		}
+
 		switch runes[i] {
 		case '&':
 			if !peekIs('&') {
@@ -264,8 +438,38 @@ func tokenize(input string) func() (*treeNode, error) {
 			i += n + 1
 			node.token, node.value = lfTokenRegexp, value
 		default:
-			value, n := consumeUntil("&|!,()/")
+			value, n := consumeUntil("&|!,()/:")
 			i += n
+			value = strings.TrimSpace(value)
+
+			//are we the beginning of a set operation?
+			if i < len(runes) && runes[i] == ':' {
+				if peekIs(' ') {
+					if value == "" {
+						return &treeNode{}, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, i, "Missing set key.")
+					}
+					i += 1
+					//we are the beginning of a set operation
+					node.token, node.value = lfTokenSetKey, value
+					return node, nil
+				}
+				additionalValue, n := consumeUntil("&|!,()/")
+				additionalValue = strings.TrimSpace(additionalValue)
+				if additionalValue == ":" {
+					return &treeNode{}, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, i, "Missing set operation.")
+				}
+				i += n
+				value += additionalValue
+			}
+
+			valueToCheckForSetOperation := strings.ToLower(value)
+			for setOperation := range validSetOperations {
+				idx := strings.Index(valueToCheckForSetOperation, " "+setOperation)
+				if idx > 0 {
+					return &treeNode{}, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, i-n+idx+1, fmt.Sprintf("Looks like you are using the set operator '%s' but did not provide a set key.  Did you forget the ':'?", validSetOperations[setOperation]))
+				}
+			}
+
 			node.token, node.value = lfTokenLabel, strings.TrimSpace(value)
 		}
 		return node, nil
@@ -307,7 +511,7 @@ LOOP:
 		switch node.token {
 		case lfTokenEOF:
 			break LOOP
-		case lfTokenLabel, lfTokenRegexp:
+		case lfTokenLabel, lfTokenRegexp, lfTokenSetKey:
 			if current.rightNode != nil {
 				return nil, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, node.location, "Found two adjacent labels.  You need an operator between them.")
 			}
@@ -326,6 +530,18 @@ LOOP:
 			node.setLeftNode(nodeToStealFrom.rightNode)
 			nodeToStealFrom.setRightNode(node)
 			current = node
+		case lfTokenSetOperation:
+			if current.rightNode == nil {
+				return nil, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, node.location, fmt.Sprintf("Set operation '%s' missing left hand operand.", node.value))
+			}
+			node.setLeftNode(current.rightNode)
+			current.setRightNode(node)
+			current = node
+		case lfTokenSetArgument:
+			if current.rightNode != nil {
+				return nil, GinkgoErrors.SyntaxErrorParsingLabelFilter(input, node.location, fmt.Sprintf("Unexpected set argument '%s'.", node.token))
+			}
+			current.setRightNode(node)
 		case lfTokenCloseGroup:
 			firstUnmatchedOpenNode := current.firstUnmatchedOpenNode()
 			if firstUnmatchedOpenNode == nil {
@@ -353,6 +569,15 @@ func ValidateAndCleanupLabel(label string, cl CodeLocation) (string, error) {
 	}
 	if strings.ContainsAny(out, "&|!,()/") {
 		return "", GinkgoErrors.InvalidLabel(label, cl)
+	}
+	if out[0] == ':' {
+		return "", GinkgoErrors.InvalidLabel(label, cl)
+	}
+	if strings.Contains(out, ":") {
+		components := strings.SplitN(out, ":", 2)
+		if len(components) < 2 || components[1] == "" {
+			return "", GinkgoErrors.InvalidLabel(label, cl)
+		}
 	}
 	return out, nil
 }

--- a/vendor/github.com/onsi/ginkgo/v2/types/version.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/version.go
@@ -1,3 +1,3 @@
 package types
 
-const VERSION = "2.17.2"
+const VERSION = "2.19.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -599,7 +599,7 @@ github.com/nishanths/predeclared/passes/predeclared
 # github.com/olekukonko/tablewriter v0.0.5
 ## explicit; go 1.12
 github.com/olekukonko/tablewriter
-# github.com/onsi/ginkgo/v2 v2.17.2
+# github.com/onsi/ginkgo/v2 v2.19.0
 ## explicit; go 1.20
 github.com/onsi/ginkgo/v2
 github.com/onsi/ginkgo/v2/config


### PR DESCRIPTION
Main changes:
- Bump onsi/gingko/v2 to [v2.19](https://github.com/onsi/ginkgo/releases/tag/v2.19.0).
  - To make use of the newly introduced [Label Sets](https://onsi.github.io/ginkgo/#label-sets) feature. Benefits:
    - It is more expressive and human-readable than regexp combining `--focus` and `--skip`.
    - It extends the current `--label-filter` to support filtering by key-value pairs, with the contains and not contains operations for the labels that have values. (more example usages can be found in the [doc](https://onsi.github.io/ginkgo/#label-sets))
    - It gives more flexibility in filtering and sorting tests based on labels. As the test suite grows, we might apply more label types to identify Serial/Disruptive, Alpha/Beta, Conformance/MinVersion:xxx, etc.
- Add an env variable `E2E_GINKGO_LABEL_FILTER` in the Makefile. Append `-ginkgo.label-filter=$(E2E_GINKGO_LABEL_FILTER)` to the go test command.
- Apply labels `"Platform:AWS"`, `"Platform:GCP"` and `"Platform:IBM"` to cases description accordingly.
- Set the default value of `E2E_GINKGO_LABEL_FILTER` in the Makefile to `"Platform: isSubsetOf {AWS}"`.
  - It would then select and run both non-platform-specific and AWS-only cases.

Other changes:
- Remove some hardcoded skipping logic. 
- Regroup ACME dns-01 cases by their provider platform. Each dns-01 provider now will have a dedicated `Context()`.

I've tested on the GCP cluster. It shows: (skipped 3 cases labeled `"Platform:AWS"`, 1 labeled `"Platform:IBM"`)

```
go test \
-timeout 1h \
-count 1 \
-v \
-p 1 \
-tags e2e \
-run "" \
./test/e2e \
-ginkgo.label-filter="Platform: isSubsetOf {GCP}"

...

Ran 17 of 21 Specs in 524.481 seconds
SUCCESS! -- 17 Passed | 0 Failed | 0 Pending | 4 Skipped
--- PASS: TestAll (524.49s)
PASS
ok  	github.com/openshift/cert-manager-operator/test/e2e	846.604s
```