### PR TITLE
 NO-JIRA: add helper func to dump events while e2e cases are failing

### DIFF
--- a/test/e2e/cert_manager_deployment_test.go
+++ b/test/e2e/cert_manager_deployment_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	PollInterval = time.Second
+	PollInterval = 5 * time.Second
 	TestTimeout  = 10 * time.Minute
 )
 
@@ -44,7 +44,7 @@ func TestSelfSignedCerts(t *testing.T) {
 
 	ns, err := loader.CreateTestingNS("e2e-self-signed-cert")
 	require.NoError(t, err)
-	defer loader.DeleteTestingNS(ns.Name)
+	defer loader.DeleteTestingNS(ns.Name, t.Failed)
 	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "cluster_issuer.yaml"), ns.Name)
 	defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "cluster_issuer.yaml"), ns.Name)
 	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "issuer.yaml"), ns.Name)
@@ -75,7 +75,7 @@ func TestACMECertsIngress(t *testing.T) {
 
 	ns, err := loader.CreateTestingNS("e2e-acme-ingress-cert")
 	require.NoError(t, err)
-	defer loader.DeleteTestingNS(ns.Name)
+	defer loader.DeleteTestingNS(ns.Name, t.Failed)
 	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "acme", "clusterissuer.yaml"), ns.Name)
 	defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "acme", "clusterissuer.yaml"), ns.Name)
 	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "acme", "deployment.yaml"), ns.Name)
@@ -161,7 +161,7 @@ func TestCertRenew(t *testing.T) {
 
 	ns, err := loader.CreateTestingNS("e2e-cert-renew")
 	require.NoErrorf(t, err, "failed to create namespace: %v", err)
-	defer loader.DeleteTestingNS(ns.Name)
+	defer loader.DeleteTestingNS(ns.Name, t.Failed)
 	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "cluster_issuer.yaml"), ns.Name)
 	defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "cluster_issuer.yaml"), ns.Name)
 	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "issuer.yaml"), ns.Name)

--- a/test/library/utils.go
+++ b/test/library/utils.go
@@ -6,7 +6,7 @@ package library
 import (
 	"context"
 	"fmt"
-	"testing"
+	"log"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -18,7 +18,6 @@ import (
 )
 
 func (d DynamicResourceLoader) CreateTestingNS(namespacePrefix string) (*v1.Namespace, error) {
-	t := testing.T{}
 	namespace := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%v-", namespacePrefix),
@@ -34,44 +33,52 @@ func (d DynamicResourceLoader) CreateTestingNS(namespacePrefix string) (*v1.Name
 		var err error
 		got, err = d.KubeClient.CoreV1().Namespaces().Create(context.Background(), namespace, metav1.CreateOptions{})
 		if err != nil {
-			t.Logf("Error creating namespace: %v", err)
+			log.Printf("Error creating namespace: %v", err)
 			return false, nil
 		}
 		return true, nil
 	}); err != nil {
 		return nil, err
 	}
-
 	return got, nil
 }
 
-func (d DynamicResourceLoader) DeleteTestingNS(name string) (bool, error) {
-	t := testing.T{}
+func (d DynamicResourceLoader) DeleteTestingNS(name string, shouldDumpEvents func() bool) (bool, error) {
 	ctx := context.Background()
+	if shouldDumpEvents() {
+		d.DumpEventsInNamespace(name)
+	}
 
 	err := d.KubeClient.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
-		t.Logf("Namespace: %v not found, err: %v", name, err)
+		log.Printf("Error deleting namespace %v, err: %v", name, err)
 	}
 
 	if err := wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
-
 		// Poll until namespace is deleted
-		ns, err := d.KubeClient.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
-		t.Logf("Namespace: %v", ns)
-		if err != nil {
-			t.Logf("Error getting namespace: %v", err)
-			if k8serrors.IsNotFound(err) {
-				return true, err
-			}
-			return false, nil
+		_, err := d.KubeClient.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
+		if err != nil && k8serrors.IsNotFound(err) {
+			return true, nil
 		}
 		return false, nil
 	}); err != nil {
-		t.Logf("Error getting namespace: %v", err)
-		return true, err
+		log.Printf("Timed out after 30s waiting for namespace %v to become deleted", name)
+		return false, err
 	}
 	return false, nil
+}
+
+func (d DynamicResourceLoader) DumpEventsInNamespace(name string) {
+	log.Printf("Dumping events in namespace %s...", name)
+	events, err := d.KubeClient.CoreV1().Events(name).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		log.Printf("Error listing events in namespace %s: %v", name, err)
+		return
+	}
+
+	for _, e := range events.Items {
+		log.Printf("At %v - event for %v %v: %v %v: %v", e.FirstTimestamp, e.InvolvedObject.Kind, e.InvolvedObject.Name, e.Source, e.Reason, e.Message)
+	}
 }
 
 func GetClusterBaseDomain(ctx context.Context, configClient configv1.ConfigV1Interface) (string, error) {


### PR DESCRIPTION
Main changes:

- Add a helper func `DumpEventsInNamespace()` for e2e tests to log namespaced events before each testing namespace is destroyed.  (inspired by [dumpEventsInNamespace](https://github.com/kubernetes/kubernetes/blob/d9b95ea94f41b942440adbdfdbe35fb78a2ed6f7/test/e2e/framework/debug/dump.go#L41)) It'd be invoked when e2e cases are failing (applicable to both go-testing and Ginkgo suite). Example logs:
```
2024/10/25 14:37:06 Dumping events in namespace e2e-acme-certs-nrz8v...
2024/10/25 14:37:07 At 2024-10-25 14:27:05 +0800 CST - event for CertificateRequest letsencrypt-cert-1: {cert-manager-certificaterequests-issuer-acme } WaitingForApproval: Not signing CertificateRequest until it is Approved
2024/10/25 14:37:07 At 2024-10-25 14:27:05 +0800 CST - event for CertificateRequest letsencrypt-cert-1: {cert-manager-certificaterequests-issuer-vault } WaitingForApproval: Not signing CertificateRequest until it is Approved
2024/10/25 14:37:07 At 2024-10-25 14:27:05 +0800 CST - event for CertificateRequest letsencrypt-cert-1: {cert-manager-certificaterequests-issuer-selfsigned } WaitingForApproval: Not signing CertificateRequest until it is Approved
2024/10/25 14:37:07 At 2024-10-25 14:27:05 +0800 CST - event for CertificateRequest letsencrypt-cert-1: {cert-manager-certificaterequests-issuer-ca } WaitingForApproval: Not signing CertificateRequest until it is Approved
2024/10/25 14:37:07 At 2024-10-25 14:27:05 +0800 CST - event for CertificateRequest letsencrypt-cert-1: {cert-manager-certificaterequests-issuer-venafi } WaitingForApproval: Not signing CertificateRequest until it is Approved
2024/10/25 14:37:07 At 2024-10-25 14:27:05 +0800 CST - event for CertificateRequest letsencrypt-cert-1: {cert-manager-certificaterequests-approver } cert-manager.io: Certificate request has been approved by cert-manager.io
2024/10/25 14:37:07 At 2024-10-25 14:27:05 +0800 CST - event for CertificateRequest letsencrypt-cert-1: {cert-manager-certificaterequests-issuer-acme } IssuerNotReady: Referenced issuer does not have a Ready status condition
2024/10/25 14:37:07 At 2024-10-25 14:27:05 +0800 CST - event for Certificate letsencrypt-cert: {cert-manager-certificates-trigger } Issuing: Issuing certificate as Secret does not exist
2024/10/25 14:37:07 At 2024-10-25 14:27:05 +0800 CST - event for Certificate letsencrypt-cert: {cert-manager-certificates-key-manager } Generated: Stored new private key in temporary Secret resource "letsencrypt-cert-tdxkz"
2024/10/25 14:37:07 At 2024-10-25 14:27:05 +0800 CST - event for Certificate letsencrypt-cert: {cert-manager-certificates-request-manager } Requested: Created new CertificateRequest resource "letsencrypt-cert-1"
2024/10/25 14:37:07 At 2024-10-25 14:27:05 +0800 CST - event for Issuer letsencrypt-dns01: {cert-manager-issuers } ErrInitIssuer: Error initializing issuer: Get "https://acme-staging-v12.api.letsencrypt.org/directory": dial tcp: lookup acme-staging-v12.api.letsencrypt.org on 172.30.0.10:53: no such host
2024/10/25 14:37:07 At 2024-10-25 14:27:24 +0800 CST - event for Issuer letsencrypt-dns01: {cert-manager-issuers } ErrInitIssuer: Error initializing issuer: Get "https://acme-staging-v12.api.letsencrypt.org/directory": dial tcp: lookup acme-staging-v12.api.letsencrypt.org on 172.30.0.10:53: no such host
```
- Move Ginkgo suite's every single `CreateTestingNS` + defer `DeleteTestingNS` into `BeforeEach()`.
- Update the utils func `CreateTestingNS`, `DeleteTestingNS` for better logging.
