### PR TITLE
CM-376: Remove angular brackets in config manifests

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -176,9 +176,9 @@ metadata:
                 {
                   "dns01": {
                     "route53": {
-                      "accessKeyID": "\u003cACCESS_KEY_ID\u003e",
-                      "hostedZoneID": "\u003cHOSTED_ZONE_ID\u003e",
-                      "region": "\u003cAWS_REGION\u003e",
+                      "accessKeyID": "ACCESS_KEY_ID",
+                      "hostedZoneID": "HOSTED_ZONE_ID",
+                      "region": "AWS_REGION",
                       "secretAccessKeySecretRef": {
                         "key": "access-key",
                         "name": "sample-aws-secret"

--- a/config/samples/letsencrypt/cert-manager.io_v1_issuer.yaml
+++ b/config/samples/letsencrypt/cert-manager.io_v1_issuer.yaml
@@ -13,9 +13,9 @@ spec:
     - dns01:
         route53:
           #❗Replace these with your own values
-          accessKeyID: "<ACCESS_KEY_ID>"
-          hostedZoneID: "<HOSTED_ZONE_ID>"
-          region: "<AWS_REGION>"
+          accessKeyID: "ACCESS_KEY_ID"
+          hostedZoneID: "HOSTED_ZONE_ID"
+          region: "AWS_REGION"
           secretAccessKeySecretRef:
             name: "sample-aws-secret"
             key: "access-key"


### PR DESCRIPTION
Remove angular brackets `< >` used in sample manifests which are escaped when bundle manifest is generated by operator-sdk. And the escape characters added is causing json unmarshling issue when validating the fbc image in konflux.

Check fbc build https://console.redhat.com/application-pipeline/workspaces/cert-manager-oape/applications/cert-manager-operator-fbc-1-15/pipelineruns/cert-manager-operator-fbc-1-15-on-pull-request-8t8cv/detail for validation error reported.