### PR TITLE
CM-424: Allow experimental features to be turned on from `--unsupported-addon-features`

### DIFF
--- a/api/operator/v1alpha1/features.go
+++ b/api/operator/v1alpha1/features.go
@@ -1,0 +1,22 @@
+package v1alpha1
+
+import (
+	"k8s.io/component-base/featuregate"
+)
+
+var (
+	// TechPreview: v1.15
+	//
+	// IstioCSR enables the controller for istiocsr.operator.openshift.io resource,
+	// which extends cert-manager-operator to deploy and manage the istio-csr agent.
+	// OpenShift Service Mesh facilitates the integration and istio-csr is an agent that
+	// allows Istio workload and control plane components to be secured using cert-manager.
+	//
+	// For more details,
+	// https://github.com/openshift/enhancements/blob/master/enhancements/cert-manager/istio-csr-controller.md
+	FeatureIstioCSR featuregate.Feature = "IstioCSR"
+)
+
+var OperatorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	FeatureIstioCSR: {Default: false, PreRelease: "TechPreview"},
+}

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -673,6 +673,7 @@ spec:
                 - --v=$(OPERATOR_LOG_LEVEL)
                 - --trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)
                 - --cloud-credentials-secret=$(CLOUD_CREDENTIALS_SECRET_NAME)
+                - --unsupported-addon-features=$(UNSUPPORTED_ADDON_FEATURES)
                 command:
                 - /usr/bin/cert-manager-operator
                 env:
@@ -706,6 +707,7 @@ spec:
                   value: "2"
                 - name: TRUSTED_CA_CONFIGMAP_NAME
                 - name: CLOUD_CREDENTIALS_SECRET_NAME
+                - name: UNSUPPORTED_ADDON_FEATURES
                 image: openshift.io/cert-manager-operator:latest
                 imagePullPolicy: IfNotPresent
                 name: cert-manager-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,6 +62,7 @@ spec:
             - '--v=$(OPERATOR_LOG_LEVEL)'
             - '--trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)'
             - '--cloud-credentials-secret=$(CLOUD_CREDENTIALS_SECRET_NAME)'
+            - '--unsupported-addon-features=$(UNSUPPORTED_ADDON_FEATURES)'
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -93,6 +94,7 @@ spec:
               value: '2'
             - name: TRUSTED_CA_CONFIGMAP_NAME
             - name: CLOUD_CREDENTIALS_SECRET_NAME
+            - name: UNSUPPORTED_ADDON_FEATURES
           image: controller:latest
           imagePullPolicy: IfNotPresent
           name: cert-manager-operator

--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -20,5 +20,16 @@ func NewOperator() *cobra.Command {
 	cmd.Short = "Start the cert-manager Operator"
 	cmd.Flags().StringVar(&operator.TrustedCAConfigMapName, "trusted-ca-configmap", "", "The name of the config map containing TLS CA(s) which should be trusted by the controller's containers. PEM encoded file under \"ca-bundle.crt\" key is expected.")
 	cmd.Flags().StringVar(&operator.CloudCredentialSecret, "cloud-credentials-secret", "", "The name of the secret containing cloud credentials for authenticating using cert-manager ambient credentials mode.")
+
+	cmd.Flags().StringVar(&operator.UnsupportedAddonFeatures, "unsupported-addon-features", "",
+		`List of unsupported addon features that the operator optionally enables.
+		
+eg. --unsupported-addon-features="IstioCSR=true"
+		
+Note: Technology Preview features are not supported with Red Hat production service level agreements (SLAs)
+and might not be functionally complete. Red Hat does not recommend using them in production.
+
+These features provide early access to upcoming product features,
+enabling customers to test functionality and provide feedback during the development process.`)
 	return cmd
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,24 @@
+package features
+
+import (
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+
+	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
+)
+
+var (
+	// mutableFeatureGate is the top-level FeatureGate with mutability (read/write).
+	mutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+
+	// DefaultFeatureGate is the top-level shared global FeatureGate (read-only).
+	DefaultFeatureGate featuregate.FeatureGate = mutableFeatureGate
+)
+
+func init() {
+	utilruntime.Must(mutableFeatureGate.Add(v1alpha1.OperatorFeatureGates))
+}
+
+func SetupWithFlagValue(flagValue string) error {
+	return mutableFeatureGate.Set(flagValue)
+}

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -1,0 +1,93 @@
+package features
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/featuregate"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// expectedDefaultFeatureState is a map of features with known states
+//
+// Always update this test map when adding a new FeatureName to the api,
+// a test is added below to enforce this.
+var expectedDefaultFeatureState = map[bool][]featuregate.Feature{
+	// features ENABLED by default,
+	// list of features which are expected to be enabled at runtime.
+	true: {},
+
+	// features DISABLED by default,
+	// list of features which are expected to be disabled at runtime.
+	false: {
+		featuregate.Feature("IstioCSR"),
+	},
+}
+
+func TestFeatureGates(t *testing.T) {
+	t.Run("runtime features to test should be identical with operator features", func(t *testing.T) {
+		testFeatureNames := make([]featuregate.Feature, 0)
+		for _, featureNames := range expectedDefaultFeatureState {
+			testFeatureNames = append(testFeatureNames, featureNames...)
+		}
+
+		knownOperatorFeatures := make([]featuregate.Feature, 0)
+		feats := mutableFeatureGate.GetAll()
+		for feat := range feats {
+			// skip "AllBeta", "AllAlpha": our operator does not use those
+			if feat == "AllBeta" || feat == "AllAlpha" {
+				continue
+			}
+			knownOperatorFeatures = append(knownOperatorFeatures, feat)
+		}
+
+		assert.Equal(t, knownOperatorFeatures, testFeatureNames,
+			`the list of features known to the operator differ from what is being tested here,
+			it could be that there was a new Feature added to the api which wasn't added to the tests.
+			Please verify "api/operator/v1alpha1" and "pkg/operator/features" have identical features.`)
+	})
+
+	t.Run("all runtime features should honor expected default feature state", func(t *testing.T) {
+		for expectedDefaultState, features := range expectedDefaultFeatureState {
+			for _, featureName := range features {
+				assert.Equal(t, expectedDefaultState, DefaultFeatureGate.Enabled(featureName),
+					"violated by feature=%s", featureName)
+			}
+		}
+	})
+
+	t.Run("all TechPreview features should be disabled by default", func(t *testing.T) {
+		feats := mutableFeatureGate.GetAll()
+		for feat, spec := range feats {
+			// skip "AllBeta", "AllAlpha": our operator does not use those
+			if feat == "AllBeta" || feat == "AllAlpha" {
+				continue
+			}
+
+			assert.Equal(t, spec.PreRelease == "TechPreview", !spec.Default,
+				"prerelease TechPreview %q feature should default to disabled",
+				feat)
+		}
+	})
+
+	t.Run("runtime features should allow enabling all feature gates that are disabled by default", func(t *testing.T) {
+		// enable all disabled features
+		defaultDisabledFeatures := expectedDefaultFeatureState[false]
+
+		featVals := make([]string, len(defaultDisabledFeatures))
+		for i := range featVals {
+			featVals[i] = fmt.Sprintf("%s=true", defaultDisabledFeatures[i])
+		}
+
+		err := mutableFeatureGate.Set(strings.Join(featVals, ","))
+		assert.NoError(t, err)
+
+		// check if all those features were enabled successfully
+		for _, featureName := range defaultDisabledFeatures {
+			assert.Equal(t, true, DefaultFeatureGate.Enabled(featureName),
+				"violated by feature=%s", featureName)
+		}
+	})
+}

--- a/test/e2e/certificates_test.go
+++ b/test/e2e/certificates_test.go
@@ -205,8 +205,9 @@ var _ = Describe("ACME Certificate", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("setting cloud credential secret name in subscription object")
-			credentialSecret := "aws-creds"
-			err = patchSubscriptionWithCloudCredential(ctx, loader, credentialSecret)
+			err = patchSubscriptionWithEnvVars(ctx, loader, map[string]string{
+				"CLOUD_CREDENTIALS_SECRET_NAME": "aws-creds",
+			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("getting AWS zone from Infrastructure object")
@@ -297,8 +298,9 @@ var _ = Describe("ACME Certificate", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("setting cloud credential secret name in subscription object")
-			credentialSecret := "aws-creds"
-			err = patchSubscriptionWithCloudCredential(ctx, loader, credentialSecret)
+			err = patchSubscriptionWithEnvVars(ctx, loader, map[string]string{
+				"CLOUD_CREDENTIALS_SECRET_NAME": "aws-creds",
+			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("getting AWS zone from Infrastructure object")
@@ -496,7 +498,9 @@ var _ = Describe("ACME Certificate", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Configure cert-manager to use credential, setting this credential secret name in subscription object")
-			err = patchSubscriptionWithCloudCredential(ctx, loader, credentialSecret)
+			err = patchSubscriptionWithEnvVars(ctx, loader, map[string]string{
+				"CLOUD_CREDENTIALS_SECRET_NAME": credentialSecret,
+			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Getting GCP project ID from Infrastructure object")

--- a/test/e2e/istio_csr_test.go
+++ b/test/e2e/istio_csr_test.go
@@ -46,6 +46,12 @@ var _ = Describe("Istio-CSR", Ordered, Label("TechPreview", "Feature:IstioCSR"),
 
 		dynamicClient, err = dynamic.NewForConfig(cfg)
 		Expect(err).Should(BeNil())
+
+		By("enable IstioCSR addon feature by patching subscription object")
+		err = patchSubscriptionWithEnvVars(ctx, loader, map[string]string{
+			"UNSUPPORTED_ADDON_FEATURES": "IstioCSR=true",
+		})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	var ns *corev1.Namespace


### PR DESCRIPTION
Adds `--unsupported-addon-features` arg to the operator binary, which when contains `"IstioCSR=true"` turns on the controller-runtime based istio-csr controller (which was added in #220).

From a user perspective, if they wish to use unsupported addons they can patch the OLM Subscription object with the `UNSUPPORTED_ADDON_FEATURES` env variable for it to get enabled at operator startup.