### PR TITLE
fix: allow `make build` to run w/o strictfipsruntime (locally)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,10 +179,10 @@ local-run: build
 .PHONY: local-run
 
 ##@ Build
-GO=GO111MODULE=on GOFLAGS="-mod=vendor -tags=strictfipsruntime,openssl" CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go
+GO=GO111MODULE=on CGO_ENABLED=1 go
 
 build-operator: ## Build operator binary, no additional checks or code generation
-	$(GO) build $(GOBUILD_VERSION_ARGS) -o $(BIN)
+	@GOFLAGS="-mod=vendor" source hack/go-fips.sh && $(GO) build $(GOBUILD_VERSION_ARGS) -o $(BIN)
 
 build: generate fmt vet build-operator ## Build operator binary.
 
@@ -286,5 +286,5 @@ $(OPERATOR_SDK_BIN):
 	hack/operator-sdk.sh $(OPERATOR_SDK_BIN)
 
 clean:
-	$(GO) clean
+	go clean
 	rm -f $(BIN)

--- a/hack/go-fips.sh
+++ b/hack/go-fips.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if GOEXPERIMENT="strictfipsruntime" go build ./tools; then
+    echo "INFO: building with FIPS support"
+
+    export GOEXPERIMENT="strictfipsruntime"
+    export GOFLAGS="${GOFLAGS} -tags=strictfipsruntime,openssl"
+else
+    echo "WARN: building without FIPS support, GOEXPERIMENT strictfipsruntime is not available in the go compiler"
+    echo "WARN: this build cannot be used in CI or production, due to lack of FIPS!!"
+fi


### PR DESCRIPTION
checks for availability of GOEXPERIMENT strictfipsruntime before `go build`, 

warns the user and proceeds, 

without this change operator cannot be built for local testing/debugging.