### PR TITLE
CM-358: Rebase upstream v1.15.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ E2E_TIMEOUT ?= 1h
 # https://onsi.github.io/ginkgo/#spec-labels. The default is to run tests on the AWS platform.
 E2E_GINKGO_LABEL_FILTER ?= "Platform: isSubsetOf {AWS}"
 
-MANIFEST_SOURCE = https://github.com/cert-manager/cert-manager/releases/download/v1.15.2/cert-manager.yaml
+MANIFEST_SOURCE = https://github.com/cert-manager/cert-manager/releases/download/v1.15.4/cert-manager.yaml
 
 
 ##@ Development

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains Cert Manager Operator designed for OpenShift. The opera
 
 ## The operator architecture and design assumptions
 
-The Operator uses the [upstream deployment manifests](https://github.com/jetstack/cert-manager/releases/download/v1.15.2/cert-manager.yaml). It divides them into separate files and deploys using 3 controllers:
+The Operator uses the [upstream deployment manifests](https://github.com/jetstack/cert-manager/releases/download/v1.15.4/cert-manager.yaml). It divides them into separate files and deploys using 3 controllers:
 - [cert_manager_cainjector_deployment.go](pkg/controller/deployment/cert_manager_cainjector_deployment.go)
 - [cert_manager_controller_deployment.go](pkg/controller/deployment/cert_manager_controller_deployment.go)
 - [cert_manager_webhook_deployment.go](pkg/controller/deployment/cert_manager_webhook_deployment.go)

--- a/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-cr.yaml
+++ b/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-cainjector
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-crb.yaml
+++ b/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-deployment.yaml
+++ b/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-cainjector
   namespace: cert-manager
 spec:
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.15.2
+        app.kubernetes.io/version: v1.15.4
     spec:
       containers:
         - args:
@@ -36,7 +36,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: quay.io/jetstack/cert-manager-cainjector:v1.15.2
+          image: quay.io/jetstack/cert-manager-cainjector:v1.15.4
           imagePullPolicy: IfNotPresent
           name: cert-manager-cainjector
           securityContext:

--- a/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-leaderelection-rb.yaml
+++ b/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-leaderelection-rb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:

--- a/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-leaderelection-role.yaml
+++ b/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-leaderelection-role.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:

--- a/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-sa.yaml
+++ b/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-sa.yaml
@@ -7,6 +7,6 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-cainjector
   namespace: cert-manager

--- a/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-approve-cert-manager-io-cr.yaml
+++ b/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-approve-cert-manager-io-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-approve:cert-manager-io
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-approve-cert-manager-io-crb.yaml
+++ b/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-approve-cert-manager-io-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-certificatesigningrequests-cr.yaml
+++ b/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-certificatesigningrequests-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-certificatesigningrequests
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-certificatesigningrequests-crb.yaml
+++ b/bindata/cert-manager-deployment/cert-manager/cert-manager-controller-certificatesigningrequests-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/controller/cert-manager-cluster-view-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-cluster-view-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   name: cert-manager-cluster-view
 rules:

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-certificates-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-certificates-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-certificates
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-certificates-crb.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-certificates-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-challenges-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-challenges-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-challenges
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-challenges-crb.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-challenges-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-clusterissuers-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-clusterissuers-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-clusterissuers
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-clusterissuers-crb.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-clusterissuers-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-ingress-shim-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-ingress-shim-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-ingress-shim
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-ingress-shim-crb.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-ingress-shim-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-issuers-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-issuers-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-issuers
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-issuers-crb.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-issuers-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-orders-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-orders-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-orders
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/controller/cert-manager-controller-orders-crb.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-controller-orders-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/controller/cert-manager-deployment.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager
   namespace: cert-manager
 spec:
@@ -27,14 +27,14 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.15.2
+        app.kubernetes.io/version: v1.15.4
     spec:
       containers:
         - args:
             - --v=2
             - --cluster-resource-namespace=$(POD_NAMESPACE)
             - --leader-election-namespace=kube-system
-            - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.2
+            - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.4
             - --max-concurrent-challenges=60
           command:
             - /app/cmd/controller/controller
@@ -43,7 +43,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: quay.io/jetstack/cert-manager-controller:v1.15.2
+          image: quay.io/jetstack/cert-manager-controller:v1.15.4
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8

--- a/bindata/cert-manager-deployment/controller/cert-manager-edit-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-edit-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit

--- a/bindata/cert-manager-deployment/controller/cert-manager-leaderelection-rb.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-leaderelection-rb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:

--- a/bindata/cert-manager-deployment/controller/cert-manager-leaderelection-role.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-leaderelection-role.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:

--- a/bindata/cert-manager-deployment/controller/cert-manager-sa.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-sa.yaml
@@ -7,6 +7,6 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager
   namespace: cert-manager

--- a/bindata/cert-manager-deployment/controller/cert-manager-svc.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-svc.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager
   namespace: cert-manager
 spec:

--- a/bindata/cert-manager-deployment/controller/cert-manager-view-cr.yaml
+++ b/bindata/cert-manager-deployment/controller/cert-manager-view-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-deployment.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook
   namespace: cert-manager
 spec:
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.15.2
+        app.kubernetes.io/version: v1.15.4
     spec:
       containers:
         - args:
@@ -39,7 +39,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: quay.io/jetstack/cert-manager-webhook:v1.15.2
+          image: quay.io/jetstack/cert-manager-webhook:v1.15.4
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-dynamic-serving-rb.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-dynamic-serving-rb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook:dynamic-serving
   namespace: cert-manager
 roleRef:

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-dynamic-serving-role.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-dynamic-serving-role.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook:dynamic-serving
   namespace: cert-manager
 rules:

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-mutatingwebhookconfiguration.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-mutatingwebhookconfiguration.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook
 webhooks:
   - admissionReviewVersions:

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-sa.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-sa.yaml
@@ -7,6 +7,6 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook
   namespace: cert-manager

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-subjectaccessreviews-cr.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-subjectaccessreviews-cr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook:subjectaccessreviews
 rules:
   - apiGroups:

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-subjectaccessreviews-crb.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-subjectaccessreviews-crb.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-svc.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-svc.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook
   namespace: cert-manager
 spec:

--- a/bindata/cert-manager-deployment/webhook/cert-manager-webhook-validatingwebhookconfiguration.yaml
+++ b/bindata/cert-manager-deployment/webhook/cert-manager-webhook-validatingwebhookconfiguration.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook
 webhooks:
   - admissionReviewVersions:

--- a/bundle/manifests/acme.cert-manager.io_challenges.yaml
+++ b/bundle/manifests/acme.cert-manager.io_challenges.yaml
@@ -9,7 +9,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/bundle/manifests/acme.cert-manager.io_orders.yaml
+++ b/bundle/manifests/acme.cert-manager.io_orders.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -274,7 +274,7 @@ spec:
       name: orders.acme.cert-manager.io
       version: v1
   description: |
-    The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.15.2](https://github.com/cert-manager/cert-manager/tree/v1.15.2), which automates certificate management.
+    The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.15.4](https://github.com/cert-manager/cert-manager/tree/v1.15.2), which automates certificate management.
     For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
   displayName: cert-manager Operator for Red Hat OpenShift
   icon:
@@ -632,15 +632,15 @@ spec:
                 - name: OPERATOR_NAME
                   value: cert-manager-operator
                 - name: RELATED_IMAGE_CERT_MANAGER_WEBHOOK
-                  value: quay.io/jetstack/cert-manager-webhook:v1.15.2
+                  value: quay.io/jetstack/cert-manager-webhook:v1.15.4
                 - name: RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR
-                  value: quay.io/jetstack/cert-manager-cainjector:v1.15.2
+                  value: quay.io/jetstack/cert-manager-cainjector:v1.15.4
                 - name: RELATED_IMAGE_CERT_MANAGER_CONTROLLER
-                  value: quay.io/jetstack/cert-manager-controller:v1.15.2
+                  value: quay.io/jetstack/cert-manager-controller:v1.15.4
                 - name: RELATED_IMAGE_CERT_MANAGER_ACMESOLVER
-                  value: quay.io/jetstack/cert-manager-acmesolver:v1.15.2
+                  value: quay.io/jetstack/cert-manager-acmesolver:v1.15.4
                 - name: OPERAND_IMAGE_VERSION
-                  value: 1.15.2
+                  value: 1.15.4
                 - name: OPERATOR_IMAGE_VERSION
                   value: 1.15.0
                 - name: OPERATOR_LOG_LEVEL
@@ -735,13 +735,13 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: quay.io/jetstack/cert-manager-webhook:v1.15.2
+  - image: quay.io/jetstack/cert-manager-webhook:v1.15.4
     name: cert-manager-webhook
-  - image: quay.io/jetstack/cert-manager-cainjector:v1.15.2
+  - image: quay.io/jetstack/cert-manager-cainjector:v1.15.4
     name: cert-manager-ca-injector
-  - image: quay.io/jetstack/cert-manager-controller:v1.15.2
+  - image: quay.io/jetstack/cert-manager-controller:v1.15.4
     name: cert-manager-controller
-  - image: quay.io/jetstack/cert-manager-acmesolver:v1.15.2
+  - image: quay.io/jetstack/cert-manager-acmesolver:v1.15.4
     name: cert-manager-acmesolver
   replaces: cert-manager-operator.v1.14.1
   version: 1.15.0

--- a/bundle/manifests/cert-manager.io_certificaterequests.yaml
+++ b/bundle/manifests/cert-manager.io_certificaterequests.yaml
@@ -9,7 +9,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io

--- a/bundle/manifests/cert-manager.io_certificates.yaml
+++ b/bundle/manifests/cert-manager.io_certificates.yaml
@@ -9,7 +9,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io

--- a/bundle/manifests/cert-manager.io_clusterissuers.yaml
+++ b/bundle/manifests/cert-manager.io_clusterissuers.yaml
@@ -9,7 +9,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/bundle/manifests/cert-manager.io_issuers.yaml
+++ b/bundle/manifests/cert-manager.io_issuers.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/config/crd/bases/certificaterequests.cert-manager.io-crd.yaml
+++ b/config/crd/bases/certificaterequests.cert-manager.io-crd.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io

--- a/config/crd/bases/certificates.cert-manager.io-crd.yaml
+++ b/config/crd/bases/certificates.cert-manager.io-crd.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io

--- a/config/crd/bases/challenges.acme.cert-manager.io-crd.yaml
+++ b/config/crd/bases/challenges.acme.cert-manager.io-crd.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/config/crd/bases/clusterissuers.cert-manager.io-crd.yaml
+++ b/config/crd/bases/clusterissuers.cert-manager.io-crd.yaml
@@ -8,7 +8,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/config/crd/bases/issuers.cert-manager.io-crd.yaml
+++ b/config/crd/bases/issuers.cert-manager.io-crd.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/config/crd/bases/orders.acme.cert-manager.io-crd.yaml
+++ b/config/crd/bases/orders.acme.cert-manager.io-crd.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,15 +74,15 @@ spec:
             - name: OPERATOR_NAME
               value: cert-manager-operator
             - name: RELATED_IMAGE_CERT_MANAGER_WEBHOOK
-              value: quay.io/jetstack/cert-manager-webhook:v1.15.2
+              value: quay.io/jetstack/cert-manager-webhook:v1.15.4
             - name: RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR
-              value: quay.io/jetstack/cert-manager-cainjector:v1.15.2
+              value: quay.io/jetstack/cert-manager-cainjector:v1.15.4
             - name: RELATED_IMAGE_CERT_MANAGER_CONTROLLER
-              value: quay.io/jetstack/cert-manager-controller:v1.15.2
+              value: quay.io/jetstack/cert-manager-controller:v1.15.4
             - name: RELATED_IMAGE_CERT_MANAGER_ACMESOLVER
-              value: quay.io/jetstack/cert-manager-acmesolver:v1.15.2
+              value: quay.io/jetstack/cert-manager-acmesolver:v1.15.4
             - name: OPERAND_IMAGE_VERSION
-              value: 1.15.2
+              value: 1.15.4
             - name: OPERATOR_IMAGE_VERSION
               value: 1.15.0
             - name: OPERATOR_LOG_LEVEL

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -69,7 +69,7 @@ spec:
       name: certmanagers.operator.openshift.io
       version: v1alpha1
   description: |
-    The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.15.2](https://github.com/cert-manager/cert-manager/tree/v1.15.2), which automates certificate management.
+    The cert-manager Operator for Red Hat OpenShift provides seamless support for [cert-manager v1.15.4](https://github.com/cert-manager/cert-manager/tree/v1.15.2), which automates certificate management.
     For more information, see the [cert-manager Operator for Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html).
   displayName: cert-manager Operator for Red Hat OpenShift
   icon:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.1
 
 require (
-	github.com/cert-manager/cert-manager v1.15.2
+	github.com/cert-manager/cert-manager v1.15.4
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/golangci/golangci-lint v1.50.1
 	github.com/google/go-cmp v0.6.0
@@ -291,4 +291,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/cert-manager/cert-manager => github.com/openshift/jetstack-cert-manager v1.15.2-0.20240724133510-48216fb20316
+replace github.com/cert-manager/cert-manager => github.com/openshift/jetstack-cert-manager v1.15.4

--- a/go.sum
+++ b/go.sum
@@ -514,8 +514,8 @@ github.com/openshift/build-machinery-go v0.0.0-20240419090851-af9c868bcf52 h1:bq
 github.com/openshift/build-machinery-go v0.0.0-20240419090851-af9c868bcf52/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87 h1:JtLhaGpSEconE+1IKmIgCOof/Len5ceG6H1pk43yv5U=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87/go.mod h1:3IPD4U0qyovZS4EFady2kqY32m8lGcbs/Wx+yprg9z8=
-github.com/openshift/jetstack-cert-manager v1.15.2-0.20240724133510-48216fb20316 h1:VTmXO4o+IqUg6By2E9q+AprpogP0ogRSDWify1X+OOI=
-github.com/openshift/jetstack-cert-manager v1.15.2-0.20240724133510-48216fb20316/go.mod h1:stBge/DTvrhfQMB/93+Y62s+gQgZBsfL1o0C/4AL/mI=
+github.com/openshift/jetstack-cert-manager v1.15.4 h1:hkWvMqZ8nyx4Vz3gpVScXBdAQjqUGxaN1v/p1DXeXgw=
+github.com/openshift/jetstack-cert-manager v1.15.4/go.mod h1:stBge/DTvrhfQMB/93+Y62s+gQgZBsfL1o0C/4AL/mI=
 github.com/openshift/library-go v0.0.0-20241118144106-bfd968d8eef4 h1:PMSC7hk/jrgRPztEw5kBonLZ5O/0NvhY8elZlZ9kvnE=
 github.com/openshift/library-go v0.0.0-20241118144106-bfd968d8eef4/go.mod h1:PdASVamWinll2BPxiUpXajTwZxV8A1pQbWEsCN1od7I=
 github.com/operator-framework/operator-lib v0.11.0 h1:eYzqpiOfq9WBI4Trddisiq/X9BwCisZd3rIzmHRC9Z8=

--- a/pkg/controller/deployment/deployment_overrides_test.go
+++ b/pkg/controller/deployment/deployment_overrides_test.go
@@ -33,7 +33,7 @@ func TestUnsupportedConfigOverrides(t *testing.T) {
 			"--v=2",
 			"--cluster-resource-namespace=$(POD_NAMESPACE)",
 			"--leader-election-namespace=kube-system",
-			"--acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.2",
+			"--acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.4",
 			"--max-concurrent-challenges=60",
 		},
 		"cert-manager-cainjector": {
@@ -120,7 +120,7 @@ func TestUnsupportedConfigOverrides(t *testing.T) {
 				},
 			},
 			wantArgs: []string{
-				"--acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.2",
+				"--acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.4",
 				"--cluster-resource-namespace=$(POD_NAMESPACE)",
 				"--featureX=enable",
 				"--leader-election-namespace=kube-system",
@@ -171,7 +171,7 @@ func TestUnsupportedConfigOverrides(t *testing.T) {
 				},
 			},
 			wantArgs: []string{
-				"--acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.2",
+				"--acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.4",
 				"--cluster-resource-namespace=$(POD_NAMESPACE)",
 				"--featureY=disable",
 				"--leader-election-namespace=kube-system",

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -101,7 +101,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-cainjector
 rules:
   - apiGroups:
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -220,7 +220,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-cainjector
   namespace: cert-manager
 spec:
@@ -237,7 +237,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.15.2
+        app.kubernetes.io/version: v1.15.4
     spec:
       containers:
         - args:
@@ -250,7 +250,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: quay.io/jetstack/cert-manager-cainjector:v1.15.2
+          image: quay.io/jetstack/cert-manager-cainjector:v1.15.4
           imagePullPolicy: IfNotPresent
           name: cert-manager-cainjector
           securityContext:
@@ -292,7 +292,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -328,7 +328,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -375,7 +375,7 @@ metadata:
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-cainjector
   namespace: cert-manager
 `)
@@ -403,7 +403,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-approve:cert-manager-io
 rules:
   - apiGroups:
@@ -440,7 +440,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-certificatesigningrequests
 rules:
   - apiGroups:
@@ -534,7 +534,7 @@ metadata:
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -592,7 +592,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   name: cert-manager-cluster-view
 rules:
@@ -629,7 +629,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-certificates
 rules:
   - apiGroups:
@@ -714,7 +714,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -749,7 +749,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-challenges
 rules:
   - apiGroups:
@@ -870,7 +870,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -905,7 +905,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-clusterissuers
 rules:
   - apiGroups:
@@ -967,7 +967,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1002,7 +1002,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-ingress-shim
 rules:
   - apiGroups:
@@ -1087,7 +1087,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1122,7 +1122,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-issuers
 rules:
   - apiGroups:
@@ -1184,7 +1184,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1219,7 +1219,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-orders
 rules:
   - apiGroups:
@@ -1301,7 +1301,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1336,7 +1336,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager
   namespace: cert-manager
 spec:
@@ -1357,14 +1357,14 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.15.2
+        app.kubernetes.io/version: v1.15.4
     spec:
       containers:
         - args:
             - --v=2
             - --cluster-resource-namespace=$(POD_NAMESPACE)
             - --leader-election-namespace=kube-system
-            - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.2
+            - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.4
             - --max-concurrent-challenges=60
           command:
             - /app/cmd/controller/controller
@@ -1373,7 +1373,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: quay.io/jetstack/cert-manager-controller:v1.15.2
+          image: quay.io/jetstack/cert-manager-controller:v1.15.4
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8
@@ -1432,7 +1432,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -1491,7 +1491,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -1528,7 +1528,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -1574,7 +1574,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager
   namespace: cert-manager
 `)
@@ -1602,7 +1602,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager
   namespace: cert-manager
 spec:
@@ -1641,7 +1641,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1692,7 +1692,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook
   namespace: cert-manager
 spec:
@@ -1709,7 +1709,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.15.2
+        app.kubernetes.io/version: v1.15.4
     spec:
       containers:
         - args:
@@ -1725,7 +1725,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: quay.io/jetstack/cert-manager-webhook:v1.15.2
+          image: quay.io/jetstack/cert-manager-webhook:v1.15.4
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -1794,7 +1794,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook:dynamic-serving
   namespace: cert-manager
 roleRef:
@@ -1831,7 +1831,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook:dynamic-serving
   namespace: cert-manager
 rules:
@@ -1879,7 +1879,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook
 webhooks:
   - admissionReviewVersions:
@@ -1929,7 +1929,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook
   namespace: cert-manager
 `)
@@ -1957,7 +1957,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook:subjectaccessreviews
 rules:
   - apiGroups:
@@ -1991,7 +1991,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2027,7 +2027,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook
   namespace: cert-manager
 spec:
@@ -2068,7 +2068,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.15.2
+    app.kubernetes.io/version: v1.15.4
   name: cert-manager-webhook
 webhooks:
   - admissionReviewVersions:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -76,7 +76,7 @@ github.com/butuzov/ireturn/types
 # github.com/cenkalti/backoff/v4 v4.3.0
 ## explicit; go 1.18
 github.com/cenkalti/backoff/v4
-# github.com/cert-manager/cert-manager v1.15.2 => github.com/openshift/jetstack-cert-manager v1.15.2-0.20240724133510-48216fb20316
+# github.com/cert-manager/cert-manager v1.15.4 => github.com/openshift/jetstack-cert-manager v1.15.4
 ## explicit; go 1.22.0
 github.com/cert-manager/cert-manager/pkg/apis/acme
 github.com/cert-manager/cert-manager/pkg/apis/acme/v1
@@ -2431,4 +2431,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# github.com/cert-manager/cert-manager => github.com/openshift/jetstack-cert-manager v1.15.2-0.20240724133510-48216fb20316
+# github.com/cert-manager/cert-manager => github.com/openshift/jetstack-cert-manager v1.15.4


### PR DESCRIPTION
- [x] bump go dependencies
- [x] update bundle description to include upstream version of cert-manager
- [x] downstream o/jetstack-cert-manager tag: https://github.com/openshift/jetstack-cert-manager/releases/tag/v1.15.4
- [x] CI updates: https://github.com/openshift/release/pull/60514