### PR TITLE
CNF-22826: Consolidate context usage around context.TODO()

### DIFF
--- a/pkg/controller/istiocsr/certificates_test.go
+++ b/pkg/controller/istiocsr/certificates_test.go
@@ -217,7 +217,7 @@ func TestCreateOrApplyCertificates(t *testing.T) {
 			}
 			r.CtrlClient = mock
 			istiocsr := &v1alpha1.IstioCSR{}
-			if err := r.Get(context.Background(), types.NamespacedName{
+			if err := r.Get(context.TODO(), types.NamespacedName{
 				Namespace: testIstioCSR().Namespace,
 				Name:      testIstioCSR().Name,
 			}, istiocsr); err != nil {

--- a/pkg/controller/istiocsr/controller.go
+++ b/pkg/controller/istiocsr/controller.go
@@ -58,7 +58,7 @@ func New(mgr ctrl.Manager) (*Reconciler, error) {
 	}
 	return &Reconciler{
 		CtrlClient:    c,
-		ctx:           context.Background(),
+		ctx:           context.TODO(),
 		eventRecorder: mgr.GetEventRecorderFor(ControllerName),
 		log:           ctrl.Log.WithName(ControllerName),
 		scheme:        mgr.GetScheme(),

--- a/pkg/controller/istiocsr/controller_test.go
+++ b/pkg/controller/istiocsr/controller_test.go
@@ -417,7 +417,7 @@ func TestReconcile(t *testing.T) {
 			}
 			r.CtrlClient = mock
 			istiocsr := testIstioCSR()
-			result, err := r.Reconcile(context.Background(),
+			result, err := r.Reconcile(context.TODO(),
 				ctrl.Request{
 					NamespacedName: types.NamespacedName{Name: istiocsr.GetName(), Namespace: istiocsr.GetNamespace()},
 				},

--- a/pkg/controller/istiocsr/test_utils.go
+++ b/pkg/controller/istiocsr/test_utils.go
@@ -44,7 +44,7 @@ type CertificateTweak func(*x509.Certificate)
 
 func testReconciler(t *testing.T) *Reconciler {
 	return &Reconciler{
-		ctx:           context.Background(),
+		ctx:           context.TODO(),
 		eventRecorder: record.NewFakeRecorder(100),
 		log:           testr.New(t),
 		scheme:        testutil.Scheme,

--- a/pkg/controller/trustmanager/controller.go
+++ b/pkg/controller/trustmanager/controller.go
@@ -68,7 +68,7 @@ func New(mgr ctrl.Manager) (*Reconciler, error) {
 	}
 	return &Reconciler{
 		CtrlClient:    c,
-		ctx:           context.Background(),
+		ctx:           context.TODO(),
 		eventRecorder: mgr.GetEventRecorderFor(ControllerName),
 		log:           ctrl.Log.WithName(ControllerName),
 		scheme:        mgr.GetScheme(),

--- a/pkg/controller/trustmanager/controller_test.go
+++ b/pkg/controller/trustmanager/controller_test.go
@@ -126,7 +126,7 @@ func TestReconcile(t *testing.T) {
 			}
 			r.CtrlClient = mock
 
-			_, err := r.Reconcile(context.Background(),
+			_, err := r.Reconcile(context.TODO(),
 				ctrl.Request{
 					NamespacedName: types.NamespacedName{Name: trustManagerObjectName},
 				},

--- a/pkg/controller/trustmanager/test_utils.go
+++ b/pkg/controller/trustmanager/test_utils.go
@@ -108,7 +108,7 @@ func (b *trustManagerBuilder) Build() *v1alpha1.TrustManager {
 
 func testReconciler(t *testing.T) *Reconciler {
 	return &Reconciler{
-		ctx:           context.Background(),
+		ctx:           context.TODO(),
 		eventRecorder: record.NewFakeRecorder(100),
 		log:           testr.New(t),
 		scheme:        testutil.Scheme,

--- a/test/apis/vars.go
+++ b/test/apis/vars.go
@@ -17,7 +17,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 var testScheme *runtime.Scheme
-var ctx = context.Background()
+var ctx = context.TODO()
 var suites []SuiteSpec
 
 // SuiteSpec defines a test suite specification.

--- a/test/e2e/issuer_acme_dns01_test.go
+++ b/test/e2e/issuer_acme_dns01_test.go
@@ -71,7 +71,7 @@ var _ = Describe("ACME Issuer DNS01 solver", Ordered, func() {
 	var baseDomain string
 
 	BeforeAll(func() {
-		ctx = context.Background()
+		ctx = context.TODO()
 		var err error
 
 		By("getting cluster base domain and construct app domain")
@@ -138,14 +138,14 @@ var _ = Describe("ACME Issuer DNS01 solver", Ordered, func() {
 
 		DeferCleanup(func() {
 			By("resetting cert-manager state")
-			err = resetCertManagerState(context.Background(), certmanageroperatorclient, loader)
+			err = resetCertManagerState(context.TODO(), certmanageroperatorclient, loader)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
 	BeforeEach(func() {
 		var err error
-		ctx, cancel = context.WithTimeout(context.Background(), highTimeout)
+		ctx, cancel = context.WithTimeout(context.TODO(), highTimeout)
 		DeferCleanup(cancel)
 
 		By("waiting for operator status to become available")

--- a/test/e2e/issuer_acme_http01_test.go
+++ b/test/e2e/issuer_acme_http01_test.go
@@ -35,7 +35,7 @@ var _ = Describe("ACME Issuer HTTP01 solver", Label("Platform:Generic"), Ordered
 	var baseDomain string
 
 	BeforeAll(func() {
-		ctx = context.Background()
+		ctx = context.TODO()
 		By("getting cluster base domain")
 		var err error
 		baseDomain, err = library.GetClusterBaseDomain(ctx, configClient)
@@ -103,7 +103,7 @@ var _ = Describe("ACME Issuer HTTP01 solver", Label("Platform:Generic"), Ordered
 	})
 
 	BeforeEach(func() {
-		ctx, cancel = context.WithTimeout(context.Background(), 15*time.Minute)
+		ctx, cancel = context.WithTimeout(context.TODO(), 15*time.Minute)
 		DeferCleanup(cancel)
 
 		By("waiting for operator status to become available")

--- a/test/e2e/issuer_selfsigned_ca_test.go
+++ b/test/e2e/issuer_selfsigned_ca_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Self-signed Issuer", Label("Platform:Generic"), Ordered, func(
 
 	BeforeAll(func() {
 		var err error
-		ctx = context.Background()
+		ctx = context.TODO()
 
 		By("creating a test namespace")
 		ns, err = loader.CreateTestingNS("e2e-selfsigned-ca", false)
@@ -142,7 +142,7 @@ var _ = Describe("Self-signed Issuer", Label("Platform:Generic"), Ordered, func(
 	})
 
 	BeforeEach(func() {
-		ctx, cancel = context.WithTimeout(context.Background(), highTimeout)
+		ctx, cancel = context.WithTimeout(context.TODO(), highTimeout)
 		DeferCleanup(cancel)
 
 		By("waiting for operator status to become available")

--- a/test/e2e/issuer_vault_test.go
+++ b/test/e2e/issuer_vault_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Vault Issuer", Ordered, Label("Platform:Generic"), func() {
 	}
 
 	BeforeEach(func() {
-		ctx, cancel = context.WithTimeout(context.Background(), highTimeout)
+		ctx, cancel = context.WithTimeout(context.TODO(), highTimeout)
 		DeferCleanup(cancel)
 
 		By("waiting for operator status to become available")
@@ -126,7 +126,7 @@ var _ = Describe("Vault Issuer", Ordered, Label("Platform:Generic"), func() {
 		Expect(clusterRoleBindingName).NotTo(BeEmpty())
 		DeferCleanup(func() {
 			By("cleaning up ClusterRoleBinding for Vault installer")
-			err := loader.KubeClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), clusterRoleBindingName, metav1.DeleteOptions{})
+			err := loader.KubeClient.RbacV1().ClusterRoleBindings().Delete(context.TODO(), clusterRoleBindingName, metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				log.Printf("Warning: failed to delete ClusterRoleBinding %s: %v", clusterRoleBindingName, err)
 			}

--- a/test/e2e/observe_test.go
+++ b/test/e2e/observe_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Logging Configuration", Label("Platform:Generic"), Ordered, fu
 	var ctx context.Context
 
 	BeforeAll(func() {
-		ctx = context.Background()
+		ctx = context.TODO()
 	})
 
 	BeforeEach(func() {
@@ -268,7 +268,7 @@ var _ = Describe("Monitoring and Metrics", Label("Platform:Generic"), Ordered, f
 	}
 
 	BeforeAll(func() {
-		ctx = context.Background()
+		ctx = context.TODO()
 
 		By("waiting for operator status to become available")
 		err := VerifyHealthyOperatorConditions(certmanageroperatorclient.OperatorV1alpha1())

--- a/test/e2e/overrides_test.go
+++ b/test/e2e/overrides_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Overrides test", Ordered, Label("Platform:Generic"), func() {
 
 	BeforeEach(func() {
 		By("Reset cert-manager state")
-		err := resetCertManagerState(context.Background(), certmanageroperatorclient, loader)
+		err := resetCertManagerState(context.TODO(), certmanageroperatorclient, loader)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for operator status to become available")
@@ -621,7 +621,7 @@ var _ = Describe("Overrides test", Ordered, Label("Platform:Generic"), func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the cert-manager controller deployment to be Available")
-			err = pollTillDeploymentAvailable(context.Background(), k8sClientSet, operandNamespace, certmanagerControllerDeployment)
+			err = pollTillDeploymentAvailable(context.TODO(), k8sClientSet, operandNamespace, certmanagerControllerDeployment)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Removing override replicas for cert-manager controller")
@@ -639,7 +639,7 @@ var _ = Describe("Overrides test", Ordered, Label("Platform:Generic"), func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the cert-manager controller deployment to be Available after rollback")
-			err = pollTillDeploymentAvailable(context.Background(), k8sClientSet, operandNamespace, certmanagerControllerDeployment)
+			err = pollTillDeploymentAvailable(context.TODO(), k8sClientSet, operandNamespace, certmanagerControllerDeployment)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -664,7 +664,7 @@ var _ = Describe("Overrides test", Ordered, Label("Platform:Generic"), func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the cert-manager webhook deployment to be Available")
-			err = pollTillDeploymentAvailable(context.Background(), k8sClientSet, operandNamespace, certmanagerWebhookDeployment)
+			err = pollTillDeploymentAvailable(context.TODO(), k8sClientSet, operandNamespace, certmanagerWebhookDeployment)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Removing override replicas for cert-manager webhook")
@@ -682,7 +682,7 @@ var _ = Describe("Overrides test", Ordered, Label("Platform:Generic"), func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the cert-manager webhook deployment to be Available after rollback")
-			err = pollTillDeploymentAvailable(context.Background(), k8sClientSet, operandNamespace, certmanagerWebhookDeployment)
+			err = pollTillDeploymentAvailable(context.TODO(), k8sClientSet, operandNamespace, certmanagerWebhookDeployment)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -707,7 +707,7 @@ var _ = Describe("Overrides test", Ordered, Label("Platform:Generic"), func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the cert-manager cainjector deployment to be Available")
-			err = pollTillDeploymentAvailable(context.Background(), k8sClientSet, operandNamespace, certmanagerCAinjectorDeployment)
+			err = pollTillDeploymentAvailable(context.TODO(), k8sClientSet, operandNamespace, certmanagerCAinjectorDeployment)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Removing override replicas for cert-manager cainjector")
@@ -725,14 +725,14 @@ var _ = Describe("Overrides test", Ordered, Label("Platform:Generic"), func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the cert-manager cainjector deployment to be Available after rollback")
-			err = pollTillDeploymentAvailable(context.Background(), k8sClientSet, operandNamespace, certmanagerCAinjectorDeployment)
+			err = pollTillDeploymentAvailable(context.TODO(), k8sClientSet, operandNamespace, certmanagerCAinjectorDeployment)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
 	AfterAll(func() {
 		By("Reset cert-manager state")
-		err := resetCertManagerState(context.Background(), certmanageroperatorclient, loader)
+		err := resetCertManagerState(context.TODO(), certmanageroperatorclient, loader)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for operator status to become available")

--- a/test/e2e/trustmanager_test.go
+++ b/test/e2e/trustmanager_test.go
@@ -60,7 +60,7 @@ const (
 // Cluster must have an allowed feature set (e.g. TechPreviewNoUpgrade). TrustManager is deployed and reconciled.
 var _ = Describe("TrustManager", Ordered, Label("Platform:Generic", "Feature:TrustManager", "TechPreview"), func() {
 	var (
-		ctx = context.Background()
+		ctx = context.TODO()
 
 		clientset                        *kubernetes.Clientset
 		originalUnsupportedAddonFeatures string
@@ -1468,7 +1468,7 @@ var _ = Describe("TrustManager", Ordered, Label("Platform:Generic", "Feature:Tru
 // TechPreview:Inverted labels test scenarios that invert the TechPreview test suite—validating behavior when Tech Preview feature is not enabled.
 var _ = Describe("TrustManager with Default feature set", Ordered, Label("Platform:Generic", "Feature:TrustManager", "TechPreview:Inverted"), func() {
 	var (
-		ctx = context.Background()
+		ctx = context.TODO()
 
 		clientset                        *kubernetes.Clientset
 		originalUnsupportedAddonFeatures string

--- a/test/library/utils.go
+++ b/test/library/utils.go
@@ -42,7 +42,7 @@ func (d DynamicResourceLoader) CreateTestingNS(namespacePrefix string, noSuffix 
 	var got *corev1.Namespace
 	if err := wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 30*time.Second, true, func(context.Context) (bool, error) {
 		var err error
-		got, err = d.KubeClient.CoreV1().Namespaces().Create(context.Background(), namespace, metav1.CreateOptions{})
+		got, err = d.KubeClient.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
 		if err != nil {
 			log.Printf("Error creating namespace: %v", err)
 			return false, nil
@@ -55,7 +55,7 @@ func (d DynamicResourceLoader) CreateTestingNS(namespacePrefix string, noSuffix 
 }
 
 func (d DynamicResourceLoader) DeleteTestingNS(name string, shouldDumpEvents func() bool) (bool, error) {
-	ctx := context.Background()
+	ctx := context.TODO()
 	if shouldDumpEvents() {
 		d.DumpEventsInNamespace(name)
 	}


### PR DESCRIPTION
There were `14` instances of `context.Background` and `20` instances of `context.TODO()`.  Since there were more `TODO()` references, I'm ensuring all of the references to context are the same.

Similar to: 
- https://github.com/openshift-kni/eco-goinfra/pull/680
- https://github.com/openshift-kni/eco-goinfra/pull/329
- https://github.com/redhat-best-practices-for-k8s/certsuite/pull/1216
- https://github.com/redhat-best-practices-for-k8s/certsuite/pull/681