### PR TITLE
Implements rand deprecation by removing seed initializer

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	goflag "flag"
-	"math/rand"
 	"os"
-	"time"
 
 	"k8s.io/component-base/cli"
 	utilflag "k8s.io/component-base/cli/flag"
@@ -16,8 +14,6 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 


### PR DESCRIPTION
Go 1.20 automatically seeds the top-level generator and deprecated `rand.Seed`.  Read more [here](https://go.dev/blog/randv2#fix.v1).