### PR TITLE
Import consistency

### DIFF
--- a/pkg/controller/deployment/credentials_request.go
+++ b/pkg/controller/deployment/credentials_request.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/cert-manager-operator/pkg/operator/operatorclient"
 	configinformersv1 "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 
-	v1 "github.com/openshift/api/operator/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 )
 
 const (
@@ -29,16 +29,16 @@ const (
 	cloudCredentialsVolumeName = "cloud-credentials"
 )
 
-func withCloudCredentials(secretsInformer coreinformersv1.SecretInformer, infraInformer configinformersv1.InfrastructureInformer, deploymentName, secretName string) func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withCloudCredentials(secretsInformer coreinformersv1.SecretInformer, infraInformer configinformersv1.InfrastructureInformer, deploymentName, secretName string) func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 	// cloud credentials is only required for the controller deployment,
 	// other deployments should be left untouched
 	if deploymentName != certmanagerControllerDeployment {
-		return func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+		return func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 			return nil
 		}
 	}
 
-	return func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+	return func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		if len(secretName) == 0 {
 			return nil
 		}

--- a/pkg/controller/deployment/deployment_log_level.go
+++ b/pkg/controller/deployment/deployment_log_level.go
@@ -3,19 +3,19 @@ package deployment
 import (
 	appsv1 "k8s.io/api/apps/v1"
 
-	v1 "github.com/openshift/api/operator/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 )
 
-var logLevels = map[v1.LogLevel]string{
-	v1.Normal:   "--v=2",
-	v1.Debug:    "--v=4",
-	v1.Trace:    "--v=6",
-	v1.TraceAll: "--v=8",
+var logLevels = map[operatorv1.LogLevel]string{
+	operatorv1.Normal:   "--v=2",
+	operatorv1.Debug:    "--v=4",
+	operatorv1.Trace:    "--v=6",
+	operatorv1.TraceAll: "--v=8",
 }
 
 // withLogLevel sets the values of verbosity --v arg using
 // logLevel specified in spec
-func withLogLevel(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withLogLevel(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 	verbosityArg := logLevels[operatorSpec.LogLevel]
 	if verbosityArg == "" {
 		return nil

--- a/pkg/controller/deployment/deployment_overrides.go
+++ b/pkg/controller/deployment/deployment_overrides.go
@@ -11,7 +11,7 @@ import (
 	coreinformersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/utils/pointer"
 
-	v1 "github.com/openshift/api/operator/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/operator-framework/operator-lib/proxy"
 
 	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
@@ -69,7 +69,7 @@ type overrideSchedulingFunc func(certmanagerinformer.CertManagerInformer, string
 
 // withOperandImageOverrideHook overrides the deployment image with
 // the operand images provided to the operator.
-func withOperandImageOverrideHook(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withOperandImageOverrideHook(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 	for index := range deployment.Spec.Template.Spec.Containers {
 		deployment.Spec.Template.Spec.Containers[index].Image = certManagerImage(deployment.Spec.Template.Spec.Containers[index].Image)
 	}
@@ -85,8 +85,8 @@ func withOperandImageOverrideHook(operatorSpec *v1.OperatorSpec, deployment *app
 
 // withContainerArgsOverrideHook overrides the container args with those provided by
 // the overrideArgsFunc function.
-func withContainerArgsOverrideHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string, fn overrideArgsFunc) func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
-	return func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withContainerArgsOverrideHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string, fn overrideArgsFunc) func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
+	return func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		overrideArgs, err := fn(certmanagerinformer, deploymentName)
 		if err != nil {
 			return err
@@ -103,8 +103,8 @@ func withContainerArgsOverrideHook(certmanagerinformer certmanagerinformer.CertM
 
 // withContainerEnvOverrideHook verrides the container env with those provided by
 // the overrideEnvFunc function.
-func withContainerEnvOverrideHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string, fn overrideEnvFunc) func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
-	return func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withContainerEnvOverrideHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string, fn overrideEnvFunc) func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
+	return func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		overrideEnv, err := fn(certmanagerinformer, deploymentName)
 		if err != nil {
 			return err
@@ -121,8 +121,8 @@ func withContainerEnvOverrideHook(certmanagerinformer certmanagerinformer.CertMa
 
 // withContainerResourcesOverrideHook overrides the container resources with those provided by
 // the overrideResourcesFunc function.
-func withContainerResourcesOverrideHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string, fn overrideResourcesFunc) func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
-	return func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withContainerResourcesOverrideHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string, fn overrideResourcesFunc) func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
+	return func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		overrideResources, err := fn(certmanagerinformer, deploymentName)
 		if err != nil {
 			return err
@@ -139,8 +139,8 @@ func withContainerResourcesOverrideHook(certmanagerinformer certmanagerinformer.
 
 // withPodSchedulingOverrideHook overrides the pod scheduling with those provided by
 // the overrideSchedulingFunc function.
-func withPodSchedulingOverrideHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string, fn overrideSchedulingFunc) func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
-	return func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withPodSchedulingOverrideHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string, fn overrideSchedulingFunc) func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
+	return func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		overrideScheduling, err := fn(certmanagerinformer, deploymentName)
 		if err != nil {
 			return err
@@ -160,15 +160,15 @@ func withPodSchedulingOverrideHook(certmanagerinformer certmanagerinformer.CertM
 
 // withProxyEnv patches the operand deployment if operator
 // has proxy variables set. Sets HTTPS_PROXY, HTTP_PROXY and NO_PROXY.
-func withProxyEnv(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withProxyEnv(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 	deployment.Spec.Template.Spec.Containers[0].Env = mergeContainerEnvs(deployment.Spec.Template.Spec.Containers[0].Env, proxy.ReadProxyVarsFromEnv())
 	return nil
 }
 
 // withCAConfigMap patches the operand deployment to include the custom
 // ca bundle as a volume. This is set when a trusted ca configmap is provided.
-func withCAConfigMap(configmapinformer coreinformersv1.ConfigMapInformer, deployment *appsv1.Deployment, trustedCAConfigmapName string) func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
-	return func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withCAConfigMap(configmapinformer coreinformersv1.ConfigMapInformer, deployment *appsv1.Deployment, trustedCAConfigmapName string) func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
+	return func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 
 		if len(trustedCAConfigmapName) == 0 {
 			return nil
@@ -205,8 +205,8 @@ func withCAConfigMap(configmapinformer coreinformersv1.ConfigMapInformer, deploy
 }
 
 // withPodLabels patches the operand deployment to include custom pod labels
-func withPodLabelsOverrideHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string, fn overrideLabelsFunc) func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
-	return func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withPodLabelsOverrideHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string, fn overrideLabelsFunc) func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
+	return func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		overrideLabels, err := fn(certmanagerinformer, deploymentName)
 		if err != nil {
 			return err
@@ -220,7 +220,7 @@ func withPodLabelsOverrideHook(certmanagerinformer certmanagerinformer.CertManag
 	}
 }
 
-func withSABoundToken(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withSABoundToken(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 	volume := corev1.Volume{
 		Name: boundSATokenVolumeName,
 		VolumeSource: corev1.VolumeSource{

--- a/pkg/controller/deployment/deployment_overrides_validation.go
+++ b/pkg/controller/deployment/deployment_overrides_validation.go
@@ -13,7 +13,7 @@ import (
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/utils/strings/slices"
 
-	v1 "github.com/openshift/api/operator/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
 	certmanagerinformer "github.com/openshift/cert-manager-operator/pkg/operator/informers/externalversions/operator/v1alpha1"
@@ -21,7 +21,7 @@ import (
 
 // withContainerArgsValidateHook validates the container args with those that
 // are supported by the operator.
-func withContainerArgsValidateHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string) func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withContainerArgsValidateHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string) func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 
 	supportedCertManagerArgs := []string{
 		// A list of comma separated dns server endpoints used for ACME HTTP01 check requests.
@@ -73,7 +73,7 @@ func withContainerArgsValidateHook(certmanagerinformer certmanagerinformer.CertM
 		return nil
 	}
 
-	return func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+	return func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		certmanager, err := certmanagerinformer.Lister().Get("cluster")
 		if err != nil {
 			return fmt.Errorf("failed to get certmanager %q due to %v", "cluster", err)
@@ -106,7 +106,7 @@ func withContainerArgsValidateHook(certmanagerinformer certmanagerinformer.CertM
 
 // withContainerEnvValidateHook validates the container env with those that
 // are supported by the operator.
-func withContainerEnvValidateHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string) func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withContainerEnvValidateHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string) func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 
 	supportedCertManagerEnv := []string{
 		"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
@@ -123,7 +123,7 @@ func withContainerEnvValidateHook(certmanagerinformer certmanagerinformer.CertMa
 		return nil
 	}
 
-	return func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+	return func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		certmanager, err := certmanagerinformer.Lister().Get("cluster")
 		if err != nil {
 			return fmt.Errorf("failed to get certmanager %q due to %v", "cluster", err)
@@ -156,7 +156,7 @@ func withContainerEnvValidateHook(certmanagerinformer certmanagerinformer.CertMa
 
 // withPodLabelsValidateHook validates the pod labels from specific deployment config
 // with those that are supported by the operator.
-func withPodLabelsValidateHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string) func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withPodLabelsValidateHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string) func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 
 	supportedCertManagerLabelKeys := []string{
 		"azure.workload.identity/use",
@@ -173,7 +173,7 @@ func withPodLabelsValidateHook(certmanagerinformer certmanagerinformer.CertManag
 		return nil
 	}
 
-	return func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+	return func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		certmanager, err := certmanagerinformer.Lister().Get("cluster")
 		if err != nil {
 			return fmt.Errorf("failed to get certmanager %q due to %v", "cluster", err)
@@ -202,7 +202,7 @@ func withPodLabelsValidateHook(certmanagerinformer certmanagerinformer.CertManag
 
 // withContainerResourcesValidateHook validates the container resources with those that
 // are supported by the operator.
-func withContainerResourcesValidateHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string) func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withContainerResourcesValidateHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string) func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 
 	supportedCertManagerResourceNames := []string{
 		string(corev1.ResourceCPU), string(corev1.ResourceMemory),
@@ -214,7 +214,7 @@ func withContainerResourcesValidateHook(certmanagerinformer certmanagerinformer.
 		string(corev1.ResourceCPU), string(corev1.ResourceMemory),
 	}
 
-	return func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+	return func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		certmanager, err := certmanagerinformer.Lister().Get("cluster")
 		if err != nil {
 			return fmt.Errorf("failed to get certmanager %q due to %v", "cluster", err)
@@ -258,9 +258,9 @@ func validateResources(resources v1alpha1.CertManagerResourceRequirements, suppo
 }
 
 // withPodSchedulingValidateHook validates the overrides scheduling field for each operand.
-func withPodSchedulingValidateHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string) func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withPodSchedulingValidateHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string) func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 
-	return func(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+	return func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		certmanager, err := certmanagerinformer.Lister().Get("cluster")
 		if err != nil {
 			return fmt.Errorf("failed to get certmanager %q due to %v", "cluster", err)

--- a/pkg/controller/deployment/deployment_unsupported_overrides.go
+++ b/pkg/controller/deployment/deployment_unsupported_overrides.go
@@ -5,7 +5,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 
-	v1 "github.com/openshift/api/operator/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
 )
@@ -36,7 +36,7 @@ func unsupportedConfigOverrides(deployment *appsv1.Deployment, unsupportedConfig
 
 // withUnsupportedArgsOverrideHook overrides the container args with those provided by
 // UnsupportedConfigOverrides in the operatorSpec.
-func withUnsupportedArgsOverrideHook(operatorSpec *v1.OperatorSpec, deployment *appsv1.Deployment) error {
+func withUnsupportedArgsOverrideHook(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 	cfg := &v1alpha1.UnsupportedConfigOverrides{}
 	if len(operatorSpec.UnsupportedConfigOverrides.Raw) != 0 {
 		err := json.Unmarshal(operatorSpec.UnsupportedConfigOverrides.Raw, cfg)

--- a/pkg/operator/clientset/versioned/fake/register.go
+++ b/pkg/operator/clientset/versioned/fake/register.go
@@ -4,7 +4,7 @@ package fake
 
 import (
 	operatorv1alpha1 "github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
@@ -35,6 +35,6 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
-	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
 	utilruntime.Must(AddToScheme(scheme))
 }

--- a/pkg/operator/clientset/versioned/scheme/register.go
+++ b/pkg/operator/clientset/versioned/scheme/register.go
@@ -4,7 +4,7 @@ package scheme
 
 import (
 	operatorv1alpha1 "github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
@@ -35,6 +35,6 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
-	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
 	utilruntime.Must(AddToScheme(Scheme))
 }

--- a/pkg/operator/clientset/versioned/typed/operator/v1alpha1/certmanager.go
+++ b/pkg/operator/clientset/versioned/typed/operator/v1alpha1/certmanager.go
@@ -8,7 +8,7 @@ import (
 
 	v1alpha1 "github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
 	scheme "github.com/openshift/cert-manager-operator/pkg/operator/clientset/versioned/scheme"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
@@ -22,15 +22,15 @@ type CertManagersGetter interface {
 
 // CertManagerInterface has methods to work with CertManager resources.
 type CertManagerInterface interface {
-	Create(ctx context.Context, certManager *v1alpha1.CertManager, opts v1.CreateOptions) (*v1alpha1.CertManager, error)
-	Update(ctx context.Context, certManager *v1alpha1.CertManager, opts v1.UpdateOptions) (*v1alpha1.CertManager, error)
-	UpdateStatus(ctx context.Context, certManager *v1alpha1.CertManager, opts v1.UpdateOptions) (*v1alpha1.CertManager, error)
-	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
-	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
-	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1alpha1.CertManager, error)
-	List(ctx context.Context, opts v1.ListOptions) (*v1alpha1.CertManagerList, error)
-	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.CertManager, err error)
+	Create(ctx context.Context, certManager *v1alpha1.CertManager, opts metav1.CreateOptions) (*v1alpha1.CertManager, error)
+	Update(ctx context.Context, certManager *v1alpha1.CertManager, opts metav1.UpdateOptions) (*v1alpha1.CertManager, error)
+	UpdateStatus(ctx context.Context, certManager *v1alpha1.CertManager, opts metav1.UpdateOptions) (*v1alpha1.CertManager, error)
+	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1alpha1.CertManager, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*v1alpha1.CertManagerList, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1alpha1.CertManager, err error)
 	CertManagerExpansion
 }
 
@@ -47,7 +47,7 @@ func newCertManagers(c *OperatorV1alpha1Client) *certManagers {
 }
 
 // Get takes name of the certManager, and returns the corresponding certManager object, and an error if there is any.
-func (c *certManagers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.CertManager, err error) {
+func (c *certManagers) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1alpha1.CertManager, err error) {
 	result = &v1alpha1.CertManager{}
 	err = c.client.Get().
 		Resource("certmanagers").
@@ -59,7 +59,7 @@ func (c *certManagers) Get(ctx context.Context, name string, options v1.GetOptio
 }
 
 // List takes label and field selectors, and returns the list of CertManagers that match those selectors.
-func (c *certManagers) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.CertManagerList, err error) {
+func (c *certManagers) List(ctx context.Context, opts metav1.ListOptions) (result *v1alpha1.CertManagerList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -75,7 +75,7 @@ func (c *certManagers) List(ctx context.Context, opts v1.ListOptions) (result *v
 }
 
 // Watch returns a watch.Interface that watches the requested certManagers.
-func (c *certManagers) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
+func (c *certManagers) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -89,7 +89,7 @@ func (c *certManagers) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 }
 
 // Create takes the representation of a certManager and creates it.  Returns the server's representation of the certManager, and an error, if there is any.
-func (c *certManagers) Create(ctx context.Context, certManager *v1alpha1.CertManager, opts v1.CreateOptions) (result *v1alpha1.CertManager, err error) {
+func (c *certManagers) Create(ctx context.Context, certManager *v1alpha1.CertManager, opts metav1.CreateOptions) (result *v1alpha1.CertManager, err error) {
 	result = &v1alpha1.CertManager{}
 	err = c.client.Post().
 		Resource("certmanagers").
@@ -101,7 +101,7 @@ func (c *certManagers) Create(ctx context.Context, certManager *v1alpha1.CertMan
 }
 
 // Update takes the representation of a certManager and updates it. Returns the server's representation of the certManager, and an error, if there is any.
-func (c *certManagers) Update(ctx context.Context, certManager *v1alpha1.CertManager, opts v1.UpdateOptions) (result *v1alpha1.CertManager, err error) {
+func (c *certManagers) Update(ctx context.Context, certManager *v1alpha1.CertManager, opts metav1.UpdateOptions) (result *v1alpha1.CertManager, err error) {
 	result = &v1alpha1.CertManager{}
 	err = c.client.Put().
 		Resource("certmanagers").
@@ -115,7 +115,7 @@ func (c *certManagers) Update(ctx context.Context, certManager *v1alpha1.CertMan
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *certManagers) UpdateStatus(ctx context.Context, certManager *v1alpha1.CertManager, opts v1.UpdateOptions) (result *v1alpha1.CertManager, err error) {
+func (c *certManagers) UpdateStatus(ctx context.Context, certManager *v1alpha1.CertManager, opts metav1.UpdateOptions) (result *v1alpha1.CertManager, err error) {
 	result = &v1alpha1.CertManager{}
 	err = c.client.Put().
 		Resource("certmanagers").
@@ -129,7 +129,7 @@ func (c *certManagers) UpdateStatus(ctx context.Context, certManager *v1alpha1.C
 }
 
 // Delete takes name of the certManager and deletes it. Returns an error if one occurs.
-func (c *certManagers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
+func (c *certManagers) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Resource("certmanagers").
 		Name(name).
@@ -139,7 +139,7 @@ func (c *certManagers) Delete(ctx context.Context, name string, opts v1.DeleteOp
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *certManagers) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
+func (c *certManagers) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	var timeout time.Duration
 	if listOpts.TimeoutSeconds != nil {
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
@@ -154,7 +154,7 @@ func (c *certManagers) DeleteCollection(ctx context.Context, opts v1.DeleteOptio
 }
 
 // Patch applies the patch and returns the patched certManager.
-func (c *certManagers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.CertManager, err error) {
+func (c *certManagers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1alpha1.CertManager, err error) {
 	result = &v1alpha1.CertManager{}
 	err = c.client.Patch(pt).
 		Resource("certmanagers").

--- a/pkg/operator/clientset/versioned/typed/operator/v1alpha1/fake/fake_certmanager.go
+++ b/pkg/operator/clientset/versioned/typed/operator/v1alpha1/fake/fake_certmanager.go
@@ -6,7 +6,7 @@ import (
 	"context"
 
 	v1alpha1 "github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -23,7 +23,7 @@ var certmanagersResource = v1alpha1.SchemeGroupVersion.WithResource("certmanager
 var certmanagersKind = v1alpha1.SchemeGroupVersion.WithKind("CertManager")
 
 // Get takes name of the certManager, and returns the corresponding certManager object, and an error if there is any.
-func (c *FakeCertManagers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.CertManager, err error) {
+func (c *FakeCertManagers) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1alpha1.CertManager, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(certmanagersResource, name), &v1alpha1.CertManager{})
 	if obj == nil {
@@ -33,7 +33,7 @@ func (c *FakeCertManagers) Get(ctx context.Context, name string, options v1.GetO
 }
 
 // List takes label and field selectors, and returns the list of CertManagers that match those selectors.
-func (c *FakeCertManagers) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.CertManagerList, err error) {
+func (c *FakeCertManagers) List(ctx context.Context, opts metav1.ListOptions) (result *v1alpha1.CertManagerList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(certmanagersResource, certmanagersKind, opts), &v1alpha1.CertManagerList{})
 	if obj == nil {
@@ -54,13 +54,13 @@ func (c *FakeCertManagers) List(ctx context.Context, opts v1.ListOptions) (resul
 }
 
 // Watch returns a watch.Interface that watches the requested certManagers.
-func (c *FakeCertManagers) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
+func (c *FakeCertManagers) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(certmanagersResource, opts))
 }
 
 // Create takes the representation of a certManager and creates it.  Returns the server's representation of the certManager, and an error, if there is any.
-func (c *FakeCertManagers) Create(ctx context.Context, certManager *v1alpha1.CertManager, opts v1.CreateOptions) (result *v1alpha1.CertManager, err error) {
+func (c *FakeCertManagers) Create(ctx context.Context, certManager *v1alpha1.CertManager, opts metav1.CreateOptions) (result *v1alpha1.CertManager, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(certmanagersResource, certManager), &v1alpha1.CertManager{})
 	if obj == nil {
@@ -70,7 +70,7 @@ func (c *FakeCertManagers) Create(ctx context.Context, certManager *v1alpha1.Cer
 }
 
 // Update takes the representation of a certManager and updates it. Returns the server's representation of the certManager, and an error, if there is any.
-func (c *FakeCertManagers) Update(ctx context.Context, certManager *v1alpha1.CertManager, opts v1.UpdateOptions) (result *v1alpha1.CertManager, err error) {
+func (c *FakeCertManagers) Update(ctx context.Context, certManager *v1alpha1.CertManager, opts metav1.UpdateOptions) (result *v1alpha1.CertManager, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(certmanagersResource, certManager), &v1alpha1.CertManager{})
 	if obj == nil {
@@ -81,7 +81,7 @@ func (c *FakeCertManagers) Update(ctx context.Context, certManager *v1alpha1.Cer
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeCertManagers) UpdateStatus(ctx context.Context, certManager *v1alpha1.CertManager, opts v1.UpdateOptions) (*v1alpha1.CertManager, error) {
+func (c *FakeCertManagers) UpdateStatus(ctx context.Context, certManager *v1alpha1.CertManager, opts metav1.UpdateOptions) (*v1alpha1.CertManager, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateSubresourceAction(certmanagersResource, "status", certManager), &v1alpha1.CertManager{})
 	if obj == nil {
@@ -91,14 +91,14 @@ func (c *FakeCertManagers) UpdateStatus(ctx context.Context, certManager *v1alph
 }
 
 // Delete takes name of the certManager and deletes it. Returns an error if one occurs.
-func (c *FakeCertManagers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
+func (c *FakeCertManagers) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteActionWithOptions(certmanagersResource, name, opts), &v1alpha1.CertManager{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeCertManagers) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
+func (c *FakeCertManagers) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(certmanagersResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.CertManagerList{})
@@ -106,7 +106,7 @@ func (c *FakeCertManagers) DeleteCollection(ctx context.Context, opts v1.DeleteO
 }
 
 // Patch applies the patch and returns the patched certManager.
-func (c *FakeCertManagers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.CertManager, err error) {
+func (c *FakeCertManagers) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1alpha1.CertManager, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootPatchSubresourceAction(certmanagersResource, name, pt, data, subresources...), &v1alpha1.CertManager{})
 	if obj == nil {

--- a/pkg/operator/informers/externalversions/factory.go
+++ b/pkg/operator/informers/externalversions/factory.go
@@ -10,7 +10,7 @@ import (
 	versioned "github.com/openshift/cert-manager-operator/pkg/operator/clientset/versioned"
 	internalinterfaces "github.com/openshift/cert-manager-operator/pkg/operator/informers/externalversions/internalinterfaces"
 	operator "github.com/openshift/cert-manager-operator/pkg/operator/informers/externalversions/operator"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
@@ -39,7 +39,7 @@ type sharedInformerFactory struct {
 }
 
 // WithCustomResyncConfig sets a custom resync period for the specified informer types.
-func WithCustomResyncConfig(resyncConfig map[v1.Object]time.Duration) SharedInformerOption {
+func WithCustomResyncConfig(resyncConfig map[metav1.Object]time.Duration) SharedInformerOption {
 	return func(factory *sharedInformerFactory) *sharedInformerFactory {
 		for k, v := range resyncConfig {
 			factory.customResync[reflect.TypeOf(k)] = v
@@ -81,7 +81,7 @@ func NewFilteredSharedInformerFactory(client versioned.Interface, defaultResync 
 func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
 	factory := &sharedInformerFactory{
 		client:           client,
-		namespace:        v1.NamespaceAll,
+		namespace:        metav1.NamespaceAll,
 		defaultResync:    defaultResync,
 		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),

--- a/pkg/operator/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/operator/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -6,7 +6,7 @@ import (
 	time "time"
 
 	versioned "github.com/openshift/cert-manager-operator/pkg/operator/clientset/versioned"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
 )
@@ -20,5 +20,5 @@ type SharedInformerFactory interface {
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 
-// TweakListOptionsFunc is a function that transforms a v1.ListOptions.
-type TweakListOptionsFunc func(*v1.ListOptions)
+// TweakListOptionsFunc is a function that transforms a metav1.ListOptions.
+type TweakListOptionsFunc func(*metav1.ListOptions)

--- a/pkg/operator/informers/externalversions/operator/v1alpha1/certmanager.go
+++ b/pkg/operator/informers/externalversions/operator/v1alpha1/certmanager.go
@@ -10,7 +10,7 @@ import (
 	versioned "github.com/openshift/cert-manager-operator/pkg/operator/clientset/versioned"
 	internalinterfaces "github.com/openshift/cert-manager-operator/pkg/operator/informers/externalversions/internalinterfaces"
 	v1alpha1 "github.com/openshift/cert-manager-operator/pkg/operator/listers/operator/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
@@ -41,13 +41,13 @@ func NewCertManagerInformer(client versioned.Interface, resyncPeriod time.Durati
 func NewFilteredCertManagerInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
-			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
 				return client.OperatorV1alpha1().CertManagers().List(context.TODO(), options)
 			},
-			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}

--- a/test/e2e/certificates_test.go
+++ b/test/e2e/certificates_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/openshift/cert-manager-operator/test/library"
 
-	v1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	acmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 
@@ -124,17 +124,17 @@ var _ = Describe("ACME Certificate", Ordered, func() {
 				},
 				Spec: certmanagerv1.IssuerSpec{
 					IssuerConfig: certmanagerv1.IssuerConfig{
-						ACME: &v1.ACMEIssuer{
+						ACME: &acmev1.ACMEIssuer{
 							Server: "https://acme-staging-v02.api.letsencrypt.org/directory",
 							PrivateKey: certmanagermetav1.SecretKeySelector{
 								LocalObjectReference: certmanagermetav1.LocalObjectReference{
 									Name: "letsencrypt-dns01-issuer",
 								},
 							},
-							Solvers: []v1.ACMEChallengeSolver{
+							Solvers: []acmev1.ACMEChallengeSolver{
 								{
-									DNS01: &v1.ACMEChallengeSolverDNS01{
-										Route53: &v1.ACMEIssuerDNS01ProviderRoute53{
+									DNS01: &acmev1.ACMEChallengeSolverDNS01{
+										Route53: &acmev1.ACMEIssuerDNS01ProviderRoute53{
 											AccessKeyID: string(awsAccessKeyID),
 											SecretAccessKey: certmanagermetav1.SecretKeySelector{
 												LocalObjectReference: certmanagermetav1.LocalObjectReference{
@@ -223,17 +223,17 @@ var _ = Describe("ACME Certificate", Ordered, func() {
 				},
 				Spec: certmanagerv1.IssuerSpec{
 					IssuerConfig: certmanagerv1.IssuerConfig{
-						ACME: &v1.ACMEIssuer{
+						ACME: &acmev1.ACMEIssuer{
 							Server: "https://acme-staging-v02.api.letsencrypt.org/directory",
 							PrivateKey: certmanagermetav1.SecretKeySelector{
 								LocalObjectReference: certmanagermetav1.LocalObjectReference{
 									Name: "letsencrypt-dns01-issuer",
 								},
 							},
-							Solvers: []v1.ACMEChallengeSolver{
+							Solvers: []acmev1.ACMEChallengeSolver{
 								{
-									DNS01: &v1.ACMEChallengeSolverDNS01{
-										Route53: &v1.ACMEIssuerDNS01ProviderRoute53{
+									DNS01: &acmev1.ACMEChallengeSolverDNS01{
+										Route53: &acmev1.ACMEIssuerDNS01ProviderRoute53{
 											Region: awsRegion,
 										},
 									},
@@ -316,17 +316,17 @@ var _ = Describe("ACME Certificate", Ordered, func() {
 				},
 				Spec: certmanagerv1.IssuerSpec{
 					IssuerConfig: certmanagerv1.IssuerConfig{
-						ACME: &v1.ACMEIssuer{
+						ACME: &acmev1.ACMEIssuer{
 							Server: "https://acme-staging-v02.api.letsencrypt.org/directory",
 							PrivateKey: certmanagermetav1.SecretKeySelector{
 								LocalObjectReference: certmanagermetav1.LocalObjectReference{
 									Name: "letsencrypt-dns01-issuer",
 								},
 							},
-							Solvers: []v1.ACMEChallengeSolver{
+							Solvers: []acmev1.ACMEChallengeSolver{
 								{
-									DNS01: &v1.ACMEChallengeSolverDNS01{
-										Route53: &v1.ACMEIssuerDNS01ProviderRoute53{
+									DNS01: &acmev1.ACMEChallengeSolverDNS01{
+										Route53: &acmev1.ACMEIssuerDNS01ProviderRoute53{
 											Region: awsRegion,
 										},
 									},
@@ -414,17 +414,17 @@ var _ = Describe("ACME Certificate", Ordered, func() {
 				},
 				Spec: certmanagerv1.IssuerSpec{
 					IssuerConfig: certmanagerv1.IssuerConfig{
-						ACME: &v1.ACMEIssuer{
+						ACME: &acmev1.ACMEIssuer{
 							Server: "https://acme-staging-v02.api.letsencrypt.org/directory",
 							PrivateKey: certmanagermetav1.SecretKeySelector{
 								LocalObjectReference: certmanagermetav1.LocalObjectReference{
 									Name: "letsencrypt-dns01-issuer",
 								},
 							},
-							Solvers: []v1.ACMEChallengeSolver{
+							Solvers: []acmev1.ACMEChallengeSolver{
 								{
-									DNS01: &v1.ACMEChallengeSolverDNS01{
-										CloudDNS: &v1.ACMEIssuerDNS01ProviderCloudDNS{
+									DNS01: &acmev1.ACMEChallengeSolverDNS01{
+										CloudDNS: &acmev1.ACMEIssuerDNS01ProviderCloudDNS{
 											Project: string(gcpProjectID),
 											ServiceAccount: &certmanagermetav1.SecretKeySelector{
 												LocalObjectReference: certmanagermetav1.LocalObjectReference{

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/errors"
@@ -58,7 +57,7 @@ func verifyOperatorStatusCondition(client *certmanoperatorclient.Clientset, cont
 		go func(index int) {
 			defer wg.Done()
 			err := wait.PollImmediate(time.Second*1, time.Minute*5, func() (done bool, err error) {
-				operator, err := client.OperatorV1alpha1().CertManagers().Get(context.TODO(), "cluster", v1.GetOptions{})
+				operator, err := client.OperatorV1alpha1().CertManagers().Get(context.TODO(), "cluster", metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
 						return false, nil
@@ -94,7 +93,7 @@ func resetCertManagerState(ctx context.Context, client *certmanoperatorclient.Cl
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var operatorState *v1alpha1.CertManager
 		err := wait.PollImmediate(PollInterval, TestTimeout, func() (bool, error) {
-			operator, err := client.OperatorV1alpha1().CertManagers().Get(ctx, "cluster", v1.GetOptions{})
+			operator, err := client.OperatorV1alpha1().CertManagers().Get(ctx, "cluster", metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					return false, nil
@@ -118,7 +117,7 @@ func resetCertManagerState(ctx context.Context, client *certmanoperatorclient.Cl
 			ManagementState: opv1.Managed,
 		}
 
-		_, err = client.OperatorV1alpha1().CertManagers().Update(context.TODO(), updatedOperator, v1.UpdateOptions{})
+		_, err = client.OperatorV1alpha1().CertManagers().Update(context.TODO(), updatedOperator, metav1.UpdateOptions{})
 		return err
 	})
 
@@ -142,7 +141,7 @@ func resetCertManagerState(ctx context.Context, client *certmanoperatorclient.Cl
 	}
 
 	subscriptionClient := loader.DynamicClient.Resource(subscriptionSchema).Namespace("cert-manager-operator")
-	_, err = subscriptionClient.Patch(ctx, subName, types.MergePatchType, payload, v1.PatchOptions{})
+	_, err = subscriptionClient.Patch(ctx, subName, types.MergePatchType, payload, metav1.PatchOptions{})
 	return err
 }
 
@@ -150,7 +149,7 @@ func resetCertManagerState(ctx context.Context, client *certmanoperatorclient.Cl
 // a conflict error is encountered.
 func addOverrideArgs(client *certmanoperatorclient.Clientset, deploymentName string, args []string) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		operator, err := client.OperatorV1alpha1().CertManagers().Get(context.TODO(), "cluster", v1.GetOptions{})
+		operator, err := client.OperatorV1alpha1().CertManagers().Get(context.TODO(), "cluster", metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -174,7 +173,7 @@ func addOverrideArgs(client *certmanoperatorclient.Clientset, deploymentName str
 			return fmt.Errorf("unsupported deployment name: %s", deploymentName)
 		}
 
-		_, err = client.OperatorV1alpha1().CertManagers().Update(context.TODO(), updatedOperator, v1.UpdateOptions{})
+		_, err = client.OperatorV1alpha1().CertManagers().Update(context.TODO(), updatedOperator, metav1.UpdateOptions{})
 		return err
 	})
 }
@@ -185,7 +184,7 @@ func addOverrideArgs(client *certmanoperatorclient.Clientset, deploymentName str
 func verifyDeploymentArgs(k8sclient *kubernetes.Clientset, deploymentName string, args []string, added bool) error {
 
 	return wait.PollImmediate(time.Second*1, time.Minute*5, func() (done bool, err error) {
-		controllerDeployment, err := k8sclient.AppsV1().Deployments(operandNamespace).Get(context.TODO(), deploymentName, v1.GetOptions{})
+		controllerDeployment, err := k8sclient.AppsV1().Deployments(operandNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil
@@ -217,7 +216,7 @@ func verifyDeploymentArgs(k8sclient *kubernetes.Clientset, deploymentName string
 // is retried if a conflict error is encountered.
 func addOverrideResources(client *certmanoperatorclient.Clientset, deploymentName string, res v1alpha1.CertManagerResourceRequirements) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		operator, err := client.OperatorV1alpha1().CertManagers().Get(context.TODO(), "cluster", v1.GetOptions{})
+		operator, err := client.OperatorV1alpha1().CertManagers().Get(context.TODO(), "cluster", metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -241,7 +240,7 @@ func addOverrideResources(client *certmanoperatorclient.Clientset, deploymentNam
 			return fmt.Errorf("unsupported deployment name: %s", deploymentName)
 		}
 
-		_, err = client.OperatorV1alpha1().CertManagers().Update(context.TODO(), updatedOperator, v1.UpdateOptions{})
+		_, err = client.OperatorV1alpha1().CertManagers().Update(context.TODO(), updatedOperator, metav1.UpdateOptions{})
 		return err
 	})
 }
@@ -252,7 +251,7 @@ func addOverrideResources(client *certmanoperatorclient.Clientset, deploymentNam
 func verifyDeploymentResources(k8sclient *kubernetes.Clientset, deploymentName string, res v1alpha1.CertManagerResourceRequirements, added bool) error {
 
 	return wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
-		controllerDeployment, err := k8sclient.AppsV1().Deployments(operandNamespace).Get(context.TODO(), deploymentName, v1.GetOptions{})
+		controllerDeployment, err := k8sclient.AppsV1().Deployments(operandNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil
@@ -288,7 +287,7 @@ func verifyDeploymentResources(k8sclient *kubernetes.Clientset, deploymentName s
 // is retried if a conflict error is encountered.
 func addOverrideScheduling(client *certmanoperatorclient.Clientset, deploymentName string, res v1alpha1.CertManagerScheduling) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		operator, err := client.OperatorV1alpha1().CertManagers().Get(context.TODO(), "cluster", v1.GetOptions{})
+		operator, err := client.OperatorV1alpha1().CertManagers().Get(context.TODO(), "cluster", metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -312,7 +311,7 @@ func addOverrideScheduling(client *certmanoperatorclient.Clientset, deploymentNa
 			return fmt.Errorf("unsupported deployment name: %s", deploymentName)
 		}
 
-		_, err = client.OperatorV1alpha1().CertManagers().Update(context.TODO(), updatedOperator, v1.UpdateOptions{})
+		_, err = client.OperatorV1alpha1().CertManagers().Update(context.TODO(), updatedOperator, metav1.UpdateOptions{})
 		return err
 	})
 }
@@ -323,7 +322,7 @@ func addOverrideScheduling(client *certmanoperatorclient.Clientset, deploymentNa
 func verifyDeploymentScheduling(k8sclient *kubernetes.Clientset, deploymentName string, res v1alpha1.CertManagerScheduling, added bool) error {
 
 	return wait.PollUntilContextTimeout(context.Background(), time.Second*10, time.Minute*5, true, func(context.Context) (done bool, err error) {
-		controllerDeployment, err := k8sclient.AppsV1().Deployments(operandNamespace).Get(context.TODO(), deploymentName, v1.GetOptions{})
+		controllerDeployment, err := k8sclient.AppsV1().Deployments(operandNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil
@@ -380,7 +379,7 @@ func verifyDeploymentScheduling(k8sclient *kubernetes.Clientset, deploymentName 
 func getCertManagerOperatorSubscription(ctx context.Context, loader library.DynamicResourceLoader) (string, error) {
 	subscriptionClient := loader.DynamicClient.Resource(subscriptionSchema).Namespace("cert-manager-operator")
 
-	subs, err := subscriptionClient.List(ctx, v1.ListOptions{})
+	subs, err := subscriptionClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -422,7 +421,7 @@ func patchSubscriptionWithCloudCredential(ctx context.Context, loader library.Dy
 	}
 
 	subscriptionClient := loader.DynamicClient.Resource(subscriptionSchema).Namespace("cert-manager-operator")
-	_, err = subscriptionClient.Patch(ctx, subName, types.MergePatchType, payload, v1.PatchOptions{})
+	_, err = subscriptionClient.Patch(ctx, subName, types.MergePatchType, payload, metav1.PatchOptions{})
 	return err
 }
 

--- a/test/library/cert_utils.go
+++ b/test/library/cert_utils.go
@@ -11,10 +11,10 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
-func GetX509Certificate(secret *v1.Secret) (*x509.Certificate, error) {
+func GetX509Certificate(secret *corev1.Secret) (*x509.Certificate, error) {
 	tlsCrtBytes, ok := secret.Data["tls.crt"]
 	if !ok {
 		return nil, fmt.Errorf("tls.crt key not found in provided secret %v in %v namespace", secret.Name, secret.Namespace)
@@ -24,7 +24,7 @@ func GetX509Certificate(secret *v1.Secret) (*x509.Certificate, error) {
 	return x509.ParseCertificate(block.Bytes)
 }
 
-func GetTLSConfig(secret *v1.Secret) (tls.Config, bool) {
+func GetTLSConfig(secret *corev1.Secret) (tls.Config, bool) {
 	roots := x509.NewCertPool()
 	ok := roots.AppendCertsFromPEM([]byte(secret.Data["tls.crt"]))
 	if !ok {
@@ -80,11 +80,11 @@ func GetCertIssuer(hostname string) (pkix.Name, error) {
 	return conn.ConnectionState().PeerCertificates[0].Issuer, err
 }
 
-func VerifySecretNotNull(secret *v1.Secret) (bool, error) {
+func VerifySecretNotNull(secret *corev1.Secret) (bool, error) {
 	return len(secret.Data["tls.crt"]) != 0 && len(secret.Data["tls.key"]) != 0, nil
 }
 
-func VerifyHostx509Cert(secret *v1.Secret, hostname string) (bool, error) {
+func VerifyHostx509Cert(secret *corev1.Secret, hostname string) (bool, error) {
 	// TODO: verify cert using the x509 package WIP
 	cert, err := x509.ParseCertificates((secret.Data["tls.crt"]))
 	if err != nil {
@@ -98,7 +98,7 @@ func VerifyHostx509Cert(secret *v1.Secret, hostname string) (bool, error) {
 	return true, err
 }
 
-func VerifyCertificate(secret *v1.Secret, commonName string) (bool, error) {
+func VerifyCertificate(secret *corev1.Secret, commonName string) (bool, error) {
 	// check certificate is not null
 	isNotNull, err := VerifySecretNotNull(secret)
 	if !isNotNull {

--- a/test/library/utils.go
+++ b/test/library/utils.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -17,8 +17,8 @@ import (
 	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 )
 
-func (d DynamicResourceLoader) CreateTestingNS(namespacePrefix string) (*v1.Namespace, error) {
-	namespace := &v1.Namespace{
+func (d DynamicResourceLoader) CreateTestingNS(namespacePrefix string) (*corev1.Namespace, error) {
+	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%v-", namespacePrefix),
 			Labels: map[string]string{
@@ -28,7 +28,7 @@ func (d DynamicResourceLoader) CreateTestingNS(namespacePrefix string) (*v1.Name
 		},
 	}
 
-	var got *v1.Namespace
+	var got *corev1.Namespace
 	if err := wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
 		var err error
 		got, err = d.KubeClient.CoreV1().Namespaces().Create(context.Background(), namespace, metav1.CreateOptions{})


### PR DESCRIPTION
Address import consistency so the imports are more descriptive than `v1`.

Similar to:
- https://github.com/openshift-kni/eco-goinfra/pull/921
- https://github.com/openshift-kni/eco-goinfra/pull/711
- https://github.com/openshift-kni/eco-goinfra/pull/694
- https://github.com/openshift-kni/eco-goinfra/pull/387
- https://github.com/openshift-kni/eco-goinfra/pull/239