### PR TITLE
Refactor `test/e2e/testdata` to use go template based replacements

### DIFF
--- a/test/e2e/config_template.go
+++ b/test/e2e/config_template.go
@@ -1,0 +1,55 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"text/template"
+)
+
+// IssuerConfig customizes fields in the issuer spec
+type IssuerConfig struct {
+	GCPProjectID   string
+	IBMCloudCISCRN string
+}
+
+// Certificate customize fields in the cert spec
+type CertificateConfig struct {
+	DNSName string
+}
+
+// replaceWithTemplate puts field values from a template struct
+func replaceWithTemplate(sourceFileContents string, templatedValues any) ([]byte, error) {
+	tmpl, err := template.New("template").Parse(sourceFileContents)
+	if err != nil {
+		return nil, err
+	}
+
+	var doc bytes.Buffer
+	err = tmpl.Execute(&doc, templatedValues)
+	if err != nil {
+		return nil, err
+	}
+
+	return doc.Bytes(), nil
+}
+
+// AssetFunc wraps the asset load function (used in dynamic resource loader),
+// and extends it with a hook to allow template value replacement.
+type AssetFunc func(name string) ([]byte, error)
+
+// WithTemplateValues is a wrapper for using `replaceWithTemplate` with an `AssetFunc`,
+// i.e. chains the loading -> modification.
+func (sourceFn AssetFunc) WithTemplateValues(templatedValues any) AssetFunc {
+	x := func(name string) ([]byte, error) {
+		bytes, err := sourceFn(name)
+		if err != nil {
+			return nil, err
+		}
+
+		fileContentsStr := string(bytes)
+		return replaceWithTemplate(fileContentsStr, templatedValues)
+	}
+	return x
+}

--- a/test/e2e/testdata/acme/certificate_gcp.yaml
+++ b/test/e2e/testdata/acme/certificate_gcp.yaml
@@ -9,5 +9,5 @@ spec:
     kind: ClusterIssuer
     name: acme-dns01-clouddns-ambient
   dnsNames:
-    - RANDOM_STR.DNS_NAME
-    - '*.RANDOM_STR.DNS_NAME'
+    - {{.DNSName}}
+    - '*.{{.DNSName}}'

--- a/test/e2e/testdata/acme/certificate_ibmcis.yaml
+++ b/test/e2e/testdata/acme/certificate_ibmcis.yaml
@@ -4,8 +4,8 @@ metadata:
   name: letsencrypt-cert-ic
 spec:
   dnsNames:
-    - RANDOM_STR.DNS_NAME
-    - '*.RANDOM_STR.DNS_NAME'
+    - {{.DNSName}}
+    - '*.{{.DNSName}}'
   issuerRef:
     name: letsencrypt-dns01-explicit-ic
     kind: ClusterIssuer

--- a/test/e2e/testdata/acme/clusterissuer_gcp.yaml
+++ b/test/e2e/testdata/acme/clusterissuer_gcp.yaml
@@ -12,4 +12,4 @@ spec:
     - dns01:
         cloudDNS:
           # The ID of the GCP project
-          project: PROJECT_ID
+          project: {{.GCPProjectId}}

--- a/test/e2e/testdata/acme/clusterissuer_ibmcis.yaml
+++ b/test/e2e/testdata/acme/clusterissuer_ibmcis.yaml
@@ -17,5 +17,4 @@ spec:
               name: ibmcis-credentials
               key: api-token
             cisCRN: 
-              - "CIS_CRN"
-              
+              - "{{.IBMCloudCISCRN}}"


### PR DESCRIPTION
For extensible replacement of field values in the yaml(s) used within e2e `testdata/` through config structs, 
the go `text/template` allows for better replacement support; aids readability as well.
