### PR TITLE
dependabot: add config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Help manage dependencies in the repo automatically on a `weekly` cadence.

All this does is open up PRs for review with their respective changes.

Similar to:
- https://github.com/openshift-kni/eco-goinfra/pull/240
- https://github.com/openshift-kni/eco-gotests/pull/432
- https://github.com/redhat-best-practices-for-k8s/certsuite/pull/954
- https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/144
- https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/793
- https://github.com/redhat-best-practices-for-k8s/oct/pull/4