### PR TITLE
ci: migrate golangci to v2 schema and correct issues

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -1,0 +1,27 @@
+name: Test Incoming Changes
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    env:
+      SHELL: /bin/bash
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GolangCI-lint
+        uses: golangci/golangci-lint-action@v7

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,90 +1,51 @@
-# This file contains all available configuration options
-# with their default values.
-
-# options for analysis running
+version: "2"
 run:
-  # default concurrency is a available CPU number
   concurrency: 4
-
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
-
-  # exit code when at least one issue was found, default is 1
-  issues-exit-code: 1
-
-  # include test files or not, default is true
-  tests: true
-  # list of build tags, all linters use it. Default is empty list.
   build-tags:
     - e2e
-
-  # which dirs to skip: issues from them won't be reported;
-  # can use regexp here: generated.*, regexp is applied on full path;
-  # default value is empty list, but default dirs are skipped independently
-  # from this option's value (see skip-dirs-use-default).
-  # "/" will be replaced by current OS file path separator to properly work
-  # on Windows.
-  skip-dirs:
-    - vendor
-
-  # default is true. Enables skipping of directories:
-  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: true
-
-  # by default isn't set. If set we pass it to "go list -mod={option}". From "go help modules":
-  # If invoked with -mod=readonly, the go command is disallowed from the implicit
-  # automatic updating of go.mod described above. Instead, it fails when any changes
-  # to go.mod are needed. This setting is most useful to check that go.mod does
-  # not need updates, such as in a continuous integration and testing system.
-  # If invoked with -mod=vendor, the go command assumes that the vendor
-  # directory holds the correct copies of dependencies and ignores
-  # the dependency descriptions in go.mod.
   modules-download-mode: vendor
-
-  # Allow multiple parallel golangci-lint instances running.
-  # If false (default) - golangci-lint acquires file lock on start.
+  issues-exit-code: 1
+  tests: true
   allow-parallel-runners: false
-
-
-# output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
-  # default is "colored-line-number"
-  format: tab
-
-  # print lines of code with issue, default is true
-  print-issued-lines: true
-
-  # print linter name in the end of issue text, default is true
-  print-linter-name: true
-
-  # make issues output unique by line, default is true
-  uniq-by-line: true
-
-  # add a prefix to the output file references; default is no prefix
   path-prefix: ""
-
-  # sorts results by: filepath, line and column
-  sort-results: false
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
-    - gofmt
-    - goimports
-    - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - staticcheck
-    - typecheck
     - unused
-  fast: false
-
-linters-settings:
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/openshift/cert-manager-operator
+  disable:
+    - gosec
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+  settings:
+    errcheck:
+      exclude-functions:
+        - (k8s.io/client-go/tools/cache.SharedInformer).AddEventHandler
+        - (github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1.IssuerInterface).Delete
+        - (github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1.ClusterIssuerInterface).Delete
+        - (k8s.io/client-go/kubernetes/typed/networking/v1.IngressInterface).Delete
+        - (github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1.CertificateInterface).Delete
+        - (k8s.io/client-go/kubernetes/typed/core/v1.ConfigMapInterface).Delete
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func NewOperatorCommand() *cobra.Command {
 		Use:   "cert-manager-operator",
 		Short: "OpenShift cluster cert-manager operator",
 		Run: func(cmd *cobra.Command, args []string) {
+			//nolint: errcheck
 			cmd.Help()
 			os.Exit(1)
 		},

--- a/pkg/controller/deployment/deployment_overrides.go
+++ b/pkg/controller/deployment/deployment_overrides.go
@@ -92,7 +92,7 @@ func withContainerArgsOverrideHook(certmanagerinformer certmanagerinformer.CertM
 			return err
 		}
 
-		if overrideArgs != nil && len(overrideArgs) > 0 && len(deployment.Spec.Template.Spec.Containers) == 1 && deployment.Name == deploymentName {
+		if len(overrideArgs) > 0 && len(deployment.Spec.Template.Spec.Containers) == 1 && deployment.Name == deploymentName {
 			deployment.Spec.Template.Spec.Containers[0].Args = mergeContainerArgs(
 				deployment.Spec.Template.Spec.Containers[0].Args, overrideArgs)
 			sort.Strings(deployment.Spec.Template.Spec.Containers[0].Args)
@@ -110,7 +110,7 @@ func withContainerEnvOverrideHook(certmanagerinformer certmanagerinformer.CertMa
 			return err
 		}
 
-		if overrideEnv != nil && len(overrideEnv) > 0 && len(deployment.Spec.Template.Spec.Containers) == 1 && deployment.Name == deploymentName {
+		if len(overrideEnv) > 0 && len(deployment.Spec.Template.Spec.Containers) == 1 && deployment.Name == deploymentName {
 			deployment.Spec.Template.Spec.Containers[0].Env = mergeContainerEnvs(
 				deployment.Spec.Template.Spec.Containers[0].Env, overrideEnv)
 
@@ -212,7 +212,7 @@ func withPodLabelsOverrideHook(certmanagerinformer certmanagerinformer.CertManag
 			return err
 		}
 
-		if overrideLabels != nil && len(overrideLabels) > 0 && deployment.Name == deploymentName {
+		if len(overrideLabels) > 0 && deployment.Name == deploymentName {
 			mergedLabels := labels.Merge(deployment.Spec.Template.GetLabels(), overrideLabels)
 			deployment.Spec.Template.SetLabels(mergedLabels)
 		}

--- a/pkg/controller/deployment/deployment_overrides_test.go
+++ b/pkg/controller/deployment/deployment_overrides_test.go
@@ -112,7 +112,7 @@ func TestUnsupportedConfigOverrides(t *testing.T) {
 		},
 
 		// unsupported config overrides as a mechanism of appending new args
-		"Controller overrides should append newer overriden values": {
+		"Controller overrides should append newer overridden values": {
 			deploymentName: "cert-manager",
 			overrides: &v1alpha1.UnsupportedConfigOverrides{
 				Controller: v1alpha1.UnsupportedConfigOverridesForCertManagerController{
@@ -129,7 +129,7 @@ func TestUnsupportedConfigOverrides(t *testing.T) {
 				"--v=2",
 			},
 		},
-		"CAInjector overrides should append newer overriden values": {
+		"CAInjector overrides should append newer overridden values": {
 			deploymentName: "cert-manager-cainjector",
 			overrides: &v1alpha1.UnsupportedConfigOverrides{
 				CAInjector: v1alpha1.UnsupportedConfigOverridesForCertManagerCAInjector{
@@ -143,7 +143,7 @@ func TestUnsupportedConfigOverrides(t *testing.T) {
 				"--v=2",
 			},
 		},
-		"Webhook overrides should append newer overriden values": {
+		"Webhook overrides should append newer overridden values": {
 			deploymentName: "cert-manager-webhook",
 			overrides: &v1alpha1.UnsupportedConfigOverrides{
 				Webhook: v1alpha1.UnsupportedConfigOverridesForCertManagerWebhook{

--- a/pkg/controller/deployment/deployment_unsupported_overrides.go
+++ b/pkg/controller/deployment/deployment_unsupported_overrides.go
@@ -44,6 +44,7 @@ func withUnsupportedArgsOverrideHook(operatorSpec *operatorv1.OperatorSpec, depl
 			return err
 		}
 	}
+	//nolint:staticcheck,ineffassign
 	deployment = unsupportedConfigOverrides(deployment, cfg)
 	return nil
 }

--- a/pkg/controller/istiocsr/certificates_test.go
+++ b/pkg/controller/istiocsr/certificates_test.go
@@ -34,7 +34,7 @@ func TestCreateOrApplyCertificates(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *certmanagerv1.Certificate:
-						return false, testError
+						return false, errorForTest
 					}
 					return true, nil
 				})
@@ -64,7 +64,7 @@ func TestCreateOrApplyCertificates(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *certmanagerv1.Certificate:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -113,7 +113,7 @@ func TestCreateOrApplyCertificates(t *testing.T) {
 				m.CreateCalls(func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 					switch obj.(type) {
 					case *certmanagerv1.Certificate:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})

--- a/pkg/controller/istiocsr/controller_test.go
+++ b/pkg/controller/istiocsr/controller_test.go
@@ -128,7 +128,7 @@ func TestReconcile(t *testing.T) {
 					case *v1alpha1.IstioCSR:
 						// fail the operation where controller is trying to add processed annotation.
 						if _, exist := o.GetAnnotations()[controllerProcessedAnnotation]; exist {
-							return testError
+							return errorForTest
 						}
 					}
 					return nil
@@ -349,7 +349,7 @@ func TestReconcile(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *v1alpha1.IstioCSR:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -371,7 +371,7 @@ func TestReconcile(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *v1alpha1.IstioCSR:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -555,7 +555,7 @@ func TestProcessReconcileRequest(t *testing.T) {
 				m.ListCalls(func(ctx context.Context, list client.ObjectList, option ...client.ListOption) error {
 					switch list.(type) {
 					case *v1alpha1.IstioCSRList:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -632,7 +632,7 @@ func TestProcessReconcileRequest(t *testing.T) {
 					m.StatusUpdateCalls(func(ctx context.Context, obj client.Object, option ...client.SubResourceUpdateOption) error {
 						switch obj.(type) {
 						case *v1alpha1.IstioCSR:
-							return testError
+							return errorForTest
 						}
 						return nil
 					})
@@ -681,7 +681,7 @@ func TestProcessReconcileRequest(t *testing.T) {
 					m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, option ...client.UpdateOption) error {
 						switch obj.(type) {
 						case *v1alpha1.IstioCSR:
-							return testError
+							return errorForTest
 						}
 						return nil
 					})

--- a/pkg/controller/istiocsr/deployments.go
+++ b/pkg/controller/istiocsr/deployments.go
@@ -28,7 +28,7 @@ const (
 	caVolumeMountPath = "/var/run/configmaps/istio-csr"
 )
 
-var invalidIssuerRefConfigError = fmt.Errorf("invalid issuerRef config")
+var errorInvalidRefConfig = fmt.Errorf("invalid issuerRef config")
 
 func (r *Reconciler) createOrApplyDeployments(istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
 	desired, err := r.getDeploymentObject(istiocsr, resourceLabels)
@@ -229,12 +229,12 @@ func updateNodeSelector(deployment *appsv1.Deployment, istiocsr *v1alpha1.IstioC
 func (r *Reconciler) assertIssuerRefExists(istiocsr *v1alpha1.IstioCSR) error {
 	issuerRefKind := strings.ToLower(istiocsr.Spec.IstioCSRConfig.CertManager.IssuerRef.Kind)
 	if issuerRefKind != clusterIssuerKind && issuerRefKind != issuerKind {
-		return NewIrrecoverableError(invalidIssuerRefConfigError, "spec.istioCSRConfig.certManager.issuerRef.kind can be anyof `%s` or `%s`, configured: %s", clusterIssuerKind, issuerKind, issuerKind)
+		return NewIrrecoverableError(errorInvalidRefConfig, "spec.istioCSRConfig.certManager.issuerRef.kind can be anyof `%s` or `%s`, configured: %s", clusterIssuerKind, issuerKind, issuerKind)
 	}
 
 	issuerRefGroup := strings.ToLower(istiocsr.Spec.IstioCSRConfig.CertManager.IssuerRef.Group)
 	if issuerRefGroup != issuerGroup {
-		return NewIrrecoverableError(invalidIssuerRefConfigError, "spec.istioCSRConfig.certManager.issuerRef.group can be only `%s`, configured: %s", issuerGroup, issuerRefGroup)
+		return NewIrrecoverableError(errorInvalidRefConfig, "spec.istioCSRConfig.certManager.issuerRef.group can be only `%s`, configured: %s", issuerGroup, issuerRefGroup)
 	}
 
 	obj, err := r.getIssuer(istiocsr)
@@ -250,7 +250,7 @@ func (r *Reconciler) assertIssuerRefExists(istiocsr *v1alpha1.IstioCSR) error {
 		issuerConfig = obj.(*certmanagerv1.Issuer).Spec.IssuerConfig
 	}
 	if issuerConfig.ACME != nil {
-		return NewIrrecoverableError(invalidIssuerRefConfigError, "spec.istioCSRConfig.certManager.issuerRef uses unsupported ACME issuer")
+		return NewIrrecoverableError(errorInvalidRefConfig, "spec.istioCSRConfig.certManager.issuerRef uses unsupported ACME issuer")
 	}
 
 	return nil

--- a/pkg/controller/istiocsr/deployments_test.go
+++ b/pkg/controller/istiocsr/deployments_test.go
@@ -98,7 +98,7 @@ func TestCreateOrApplyDeployments(t *testing.T) {
 				m.CreateCalls(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) error {
 					switch obj.(type) {
 					case *corev1.ConfigMap:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -135,7 +135,7 @@ func TestCreateOrApplyDeployments(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *appsv1.Deployment:
-						return false, testError
+						return false, errorForTest
 					}
 					return true, nil
 				})
@@ -160,7 +160,7 @@ func TestCreateOrApplyDeployments(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, _ ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *appsv1.Deployment:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -289,7 +289,7 @@ func TestCreateOrApplyDeployments(t *testing.T) {
 				m.StatusUpdateCalls(func(ctx context.Context, obj client.Object, _ ...client.SubResourceUpdateOption) error {
 					switch obj.(type) {
 					case *v1alpha1.IstioCSR:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -456,7 +456,7 @@ func TestCreateOrApplyDeployments(t *testing.T) {
 						deployment := testDeployment()
 						deployment.DeepCopyInto(o)
 					case *corev1.ConfigMap:
-						return false, testError
+						return false, errorForTest
 					}
 					return true, nil
 				})
@@ -489,7 +489,7 @@ func TestCreateOrApplyDeployments(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, _ ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *corev1.ConfigMap:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})

--- a/pkg/controller/istiocsr/install_instiocsr_test.go
+++ b/pkg/controller/istiocsr/install_instiocsr_test.go
@@ -65,7 +65,7 @@ func TestReconcileIstioCSRDeployment(t *testing.T) {
 				m.CreateCalls(func(ctx context.Context, obj client.Object, option ...client.CreateOption) error {
 					switch obj.(type) {
 					case *corev1.ServiceAccount:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -78,7 +78,7 @@ func TestReconcileIstioCSRDeployment(t *testing.T) {
 				m.CreateCalls(func(ctx context.Context, obj client.Object, option ...client.CreateOption) error {
 					switch o := obj.(type) {
 					case *rbacv1.Role:
-						return testError
+						return errorForTest
 					case *rbacv1.ClusterRoleBinding:
 						roleBinding := testClusterRoleBinding()
 						roleBinding.DeepCopyInto(o)
@@ -94,7 +94,7 @@ func TestReconcileIstioCSRDeployment(t *testing.T) {
 				m.CreateCalls(func(ctx context.Context, obj client.Object, option ...client.CreateOption) error {
 					switch o := obj.(type) {
 					case *certmanagerv1.Certificate:
-						return testError
+						return errorForTest
 					case *rbacv1.ClusterRoleBinding:
 						roleBinding := testClusterRoleBinding()
 						roleBinding.DeepCopyInto(o)

--- a/pkg/controller/istiocsr/install_istiocsr.go
+++ b/pkg/controller/istiocsr/install_istiocsr.go
@@ -2,6 +2,7 @@ package istiocsr
 
 import (
 	"fmt"
+
 	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
 )
 

--- a/pkg/controller/istiocsr/rbacs_test.go
+++ b/pkg/controller/istiocsr/rbacs_test.go
@@ -28,7 +28,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *rbacv1.ClusterRole:
-						return false, testError
+						return false, errorForTest
 					}
 					return true, nil
 				})
@@ -44,7 +44,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *rbacv1.ClusterRoleBinding:
-						return false, testError
+						return false, errorForTest
 					}
 					return true, nil
 				})
@@ -60,7 +60,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *rbacv1.Role:
-						return false, testError
+						return false, errorForTest
 					}
 					return true, nil
 				})
@@ -73,7 +73,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *rbacv1.RoleBinding:
-						return false, testError
+						return false, errorForTest
 					}
 					return true, nil
 				})
@@ -87,7 +87,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 					switch obj.(type) {
 					case *rbacv1.Role:
 						if strings.HasSuffix(ns.Name, "-leases") {
-							return false, testError
+							return false, errorForTest
 						}
 					}
 					return true, nil
@@ -102,7 +102,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 					switch obj.(type) {
 					case *rbacv1.RoleBinding:
 						if strings.HasSuffix(ns.Name, "-leases") {
-							return false, testError
+							return false, errorForTest
 						}
 					}
 					return true, nil
@@ -116,7 +116,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.ListCalls(func(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
 					switch obj.(type) {
 					case *rbacv1.ClusterRoleBindingList:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -173,7 +173,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *rbacv1.ClusterRoleBinding:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -214,7 +214,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.CreateCalls(func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 					switch obj.(type) {
 					case *rbacv1.ClusterRoleBinding:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -247,7 +247,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.StatusUpdateCalls(func(ctx context.Context, obj client.Object, option ...client.SubResourceUpdateOption) error {
 					switch obj.(type) {
 					case *v1alpha1.IstioCSR:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -284,7 +284,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 					switch o := obj.(type) {
 					case *v1alpha1.IstioCSR:
 						if o.Status.ClusterRoleBinding != "" {
-							return testError
+							return errorForTest
 						}
 					}
 					return nil
@@ -310,7 +310,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *rbacv1.ClusterRole:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -333,7 +333,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.CreateCalls(func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 					switch obj.(type) {
 					case *rbacv1.ClusterRole:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -355,7 +355,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *rbacv1.Role:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -375,7 +375,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.CreateCalls(func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 					switch obj.(type) {
 					case *rbacv1.Role:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -400,7 +400,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 					switch obj.(type) {
 					case *rbacv1.Role:
 						if strings.HasSuffix(obj.GetName(), "-leases") {
-							return testError
+							return errorForTest
 						}
 					}
 					return nil
@@ -424,7 +424,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 					switch obj.(type) {
 					case *rbacv1.Role:
 						if strings.HasSuffix(obj.GetName(), "-leases") {
-							return testError
+							return errorForTest
 						}
 					}
 					return nil
@@ -447,7 +447,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *rbacv1.RoleBinding:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -467,7 +467,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 				m.CreateCalls(func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 					switch obj.(type) {
 					case *rbacv1.RoleBinding:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -492,7 +492,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 					switch obj.(type) {
 					case *rbacv1.RoleBinding:
 						if strings.HasSuffix(obj.GetName(), "-leases") {
-							return testError
+							return errorForTest
 						}
 					}
 					return nil
@@ -516,7 +516,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 					switch obj.(type) {
 					case *rbacv1.RoleBinding:
 						if strings.HasSuffix(obj.GetName(), "-leases") {
-							return testError
+							return errorForTest
 						}
 					}
 					return nil

--- a/pkg/controller/istiocsr/serviceaccounts_test.go
+++ b/pkg/controller/istiocsr/serviceaccounts_test.go
@@ -42,7 +42,7 @@ func TestCreateOrApplyServiceAccounts(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *corev1.ServiceAccount:
-						return false, testError
+						return false, errorForTest
 					}
 					return false, nil
 				})
@@ -55,7 +55,7 @@ func TestCreateOrApplyServiceAccounts(t *testing.T) {
 				m.StatusUpdateCalls(func(ctx context.Context, obj client.Object, option ...client.SubResourceUpdateOption) error {
 					switch obj.(type) {
 					case *v1alpha1.IstioCSR:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})

--- a/pkg/controller/istiocsr/services_test.go
+++ b/pkg/controller/istiocsr/services_test.go
@@ -45,7 +45,7 @@ func TestCreateOrApplyServices(t *testing.T) {
 				m.ExistsCalls(func(ctx context.Context, ns types.NamespacedName, obj client.Object) (bool, error) {
 					switch obj.(type) {
 					case *corev1.Service:
-						return false, testError
+						return false, errorForTest
 					}
 					return false, nil
 				})
@@ -58,7 +58,7 @@ func TestCreateOrApplyServices(t *testing.T) {
 				m.UpdateWithRetryCalls(func(ctx context.Context, obj client.Object, option ...client.UpdateOption) error {
 					switch obj.(type) {
 					case *corev1.Service:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})
@@ -81,7 +81,7 @@ func TestCreateOrApplyServices(t *testing.T) {
 				m.CreateCalls(func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 					switch obj.(type) {
 					case *corev1.Service:
-						return testError
+						return errorForTest
 					}
 					return nil
 				})

--- a/pkg/controller/istiocsr/test_utils.go
+++ b/pkg/controller/istiocsr/test_utils.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	testError = fmt.Errorf("test client error")
+	errorForTest = fmt.Errorf("test client error")
 )
 
 func testReconciler(t *testing.T) *Reconciler {

--- a/pkg/controller/istiocsr/utils.go
+++ b/pkg/controller/istiocsr/utils.go
@@ -401,7 +401,7 @@ func (r *Reconciler) disallowMultipleIstioCSRInstances(istiocsr *v1alpha1.IstioC
 		r.log.V(4).Info("%s/%s istiocsr resource contains processing rejected annotation", istiocsr.Namespace, istiocsr.Name)
 		// ensure status is updated.
 		var updateErr error
-		if istiocsr.Status.ConditionalStatus.SetCondition(v1alpha1.Ready, metav1.ConditionFalse, v1alpha1.ReasonFailed, statusMessage) {
+		if istiocsr.Status.SetCondition(v1alpha1.Ready, metav1.ConditionFalse, v1alpha1.ReasonFailed, statusMessage) {
 			updateErr = r.updateCondition(istiocsr, nil)
 		}
 		return NewMultipleInstanceError(utilerrors.NewAggregate([]error{fmt.Errorf("%s", statusMessage), updateErr}))
@@ -433,7 +433,7 @@ func (r *Reconciler) disallowMultipleIstioCSRInstances(istiocsr *v1alpha1.IstioC
 
 	if ignoreProcessing {
 		var condUpdateErr, annUpdateErr error
-		if istiocsr.Status.ConditionalStatus.SetCondition(v1alpha1.Ready, metav1.ConditionFalse, v1alpha1.ReasonFailed, statusMessage) {
+		if istiocsr.Status.SetCondition(v1alpha1.Ready, metav1.ConditionFalse, v1alpha1.ReasonFailed, statusMessage) {
 			condUpdateErr = r.updateCondition(istiocsr, nil)
 		}
 		if addProcessingRejectedAnnotation(istiocsr) {

--- a/test/e2e/cert_manager_deployment_test.go
+++ b/test/e2e/cert_manager_deployment_test.go
@@ -1,0 +1,467 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"embed"
+	"path/filepath"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	opv1 "github.com/openshift/api/operator/v1"
+	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+
+	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
+	certmanoperatorclient "github.com/openshift/cert-manager-operator/pkg/operator/clientset/versioned"
+	"github.com/openshift/cert-manager-operator/test/library"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	certmanagerclientset "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	PollInterval = 5 * time.Second
+	TestTimeout  = 10 * time.Minute
+)
+
+//go:embed testdata/*
+var testassets embed.FS
+
+func TestSelfSignedCerts(t *testing.T) {
+	ctx := context.Background()
+	loader := library.NewDynamicResourceLoader(ctx, t)
+
+	ns, err := loader.CreateTestingNS("e2e-self-signed-cert", false)
+	require.NoError(t, err)
+	//nolint:errcheck
+	defer loader.DeleteTestingNS(ns.Name, t.Failed)
+	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "cluster_issuer.yaml"), ns.Name)
+	//nolint:errcheck
+	defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "cluster_issuer.yaml"), ns.Name)
+	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "issuer.yaml"), ns.Name)
+	//nolint:errcheck
+	defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "issuer.yaml"), ns.Name)
+	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "certificate.yaml"), ns.Name)
+	//nolint:errcheck
+	defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "certificate.yaml"), ns.Name)
+
+	err = wait.PollUntilContextTimeout(ctx, PollInterval, TestTimeout, true, func(ctx context.Context) (bool, error) {
+		// TODO: The loader.KubeClient might be worth splitting out. Let's see once we have more tests.
+		secret, err := loader.KubeClient.CoreV1().Secrets(ns.Name).Get(ctx, "root-secret", metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			t.Logf("Unable to retrieve the root secret: %v", err)
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return library.VerifySecretNotNull(secret)
+	})
+	require.NoError(t, err)
+}
+
+func TestACMECertsIngress(t *testing.T) {
+	ctx := context.Background()
+	loader := library.NewDynamicResourceLoader(ctx, t)
+	config, err := library.GetConfigForTest(t)
+	require.NoError(t, err)
+
+	ns, err := loader.CreateTestingNS("e2e-acme-ingress-cert", false)
+	require.NoError(t, err)
+	//nolint:errcheck
+	defer loader.DeleteTestingNS(ns.Name, t.Failed)
+	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "acme", "clusterissuer.yaml"), ns.Name)
+	//nolint:errcheck
+	defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "acme", "clusterissuer.yaml"), ns.Name)
+	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "acme", "deployment.yaml"), ns.Name)
+	//nolint:errcheck
+	defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "acme", "deployment.yaml"), ns.Name)
+	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "acme", "service.yaml"), ns.Name)
+	//nolint:errcheck
+	defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "acme", "service.yaml"), ns.Name)
+
+	configClient, err := configv1.NewForConfig(config)
+	require.NoError(t, err)
+	baseDomain, err := library.GetClusterBaseDomain(ctx, configClient)
+	require.NoError(t, err)
+	appsDomain := "apps." + baseDomain
+
+	ingress_host := "eaic." + appsDomain
+	path_type := networkingv1.PathTypePrefix
+	ingress := &networkingv1.Ingress{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "networking.k8s.io/v1",
+			Kind:       "Ingress",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress-le-prod",
+			Namespace: ns.Name,
+			Annotations: map[string]string{
+				"cert-manager.io/cluster-issuer":            "letsencrypt-prod",
+				"acme.cert-manager.io/http01-ingress-class": "openshift-default",
+			},
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: ingress_host,
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: &path_type,
+									Backend:  networkingv1.IngressBackend{Service: &networkingv1.IngressServiceBackend{Name: "hello-openshift", Port: networkingv1.ServiceBackendPort{Number: 8080}}},
+								},
+							},
+						},
+					},
+				},
+			},
+			TLS: []networkingv1.IngressTLS{{
+				Hosts:      []string{ingress_host},
+				SecretName: "ingress-prod-secret",
+			}},
+		},
+	}
+	ingress, err = loader.KubeClient.NetworkingV1().Ingresses(ingress.Namespace).Create(ctx, ingress, metav1.CreateOptions{})
+	require.NoError(t, err)
+	defer loader.KubeClient.NetworkingV1().Ingresses(ingress.Namespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{})
+
+	err = wait.PollUntilContextTimeout(ctx, PollInterval, TestTimeout, true, func(ctx context.Context) (bool, error) {
+		secret, err := loader.KubeClient.CoreV1().Secrets(ingress.Namespace).Get(ctx, "ingress-prod-secret", metav1.GetOptions{})
+		tlsConfig, isvalid := library.GetTLSConfig(secret)
+		if !isvalid {
+			t.Logf("Unable to retrieve the TLS config: %v", err)
+			return false, nil
+		}
+		is_host_correct, err := library.VerifyHostname(ingress_host, tlsConfig.Clone())
+		if err != nil {
+			t.Logf("Host: %v", err)
+			return false, nil
+		}
+		is_not_expired, err := library.VerifyExpiry(ingress_host+":443", tlsConfig.Clone())
+		if err != nil {
+			t.Logf("Expired: %v", err)
+			return false, nil
+		}
+		return is_host_correct && is_not_expired, nil
+	})
+	require.NoError(t, err)
+}
+
+func TestCertRenew(t *testing.T) {
+	ctx := context.Background()
+	loader := library.NewDynamicResourceLoader(ctx, t)
+	config, err := library.GetConfigForTest(t)
+	require.NoErrorf(t, err, "failed to fetch host configuration: %v", err)
+
+	ns, err := loader.CreateTestingNS("e2e-cert-renew", false)
+	require.NoErrorf(t, err, "failed to create namespace: %v", err)
+	//nolint:errcheck
+	defer loader.DeleteTestingNS(ns.Name, t.Failed)
+	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "cluster_issuer.yaml"), ns.Name)
+	//nolint:errcheck
+	defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "cluster_issuer.yaml"), ns.Name)
+	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "issuer.yaml"), ns.Name)
+	//nolint:errcheck
+	defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "issuer.yaml"), ns.Name)
+	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "certificate.yaml"), ns.Name)
+	//nolint:errcheck
+	defer loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "self_signed", "certificate.yaml"), ns.Name)
+	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "acme", "deployment.yaml"), ns.Name)
+	//nolint:errcheck
+	defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "acme", "deployment.yaml"), ns.Name)
+	loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "acme", "service.yaml"), ns.Name)
+	//nolint:errcheck
+	defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "acme", "service.yaml"), ns.Name)
+
+	configClient, err := configv1.NewForConfig(config)
+	require.NoErrorf(t, err, "failed to create config client: %v", err)
+	baseDomain, err := library.GetClusterBaseDomain(ctx, configClient)
+	require.NoErrorf(t, err, "failed to fetch cluster base domain: %v", err)
+	appsDomain := "apps." + baseDomain
+
+	ingressHost := "ecr." + appsDomain
+	pathType := networkingv1.PathTypePrefix
+	ingress := &networkingv1.Ingress{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "networking.k8s.io/v1",
+			Kind:       "Ingress",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "frontend",
+			Namespace: ns.Name,
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: ingressHost,
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: &pathType,
+									Backend:  networkingv1.IngressBackend{Service: &networkingv1.IngressServiceBackend{Name: "hello-openshift", Port: networkingv1.ServiceBackendPort{Number: 8080}}},
+								},
+							},
+						},
+					},
+				},
+			},
+			TLS: []networkingv1.IngressTLS{{
+				Hosts:      []string{ingressHost},
+				SecretName: "selfsigned-server-cert-tls",
+			}},
+		},
+	}
+	ingress, err = loader.KubeClient.NetworkingV1().Ingresses(ingress.Namespace).Create(ctx, ingress, metav1.CreateOptions{})
+	require.NoErrorf(t, err, "failed to create Ingress: %v", err)
+	defer loader.KubeClient.NetworkingV1().Ingresses(ingress.Namespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{})
+
+	var (
+		certDuration        = time.Hour
+		renewBeforeDuration = time.Minute * 59
+	)
+	crt := &certmanagerv1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "selfsigned-server-cert",
+			Namespace: ns.Name,
+		},
+		Spec: certmanagerv1.CertificateSpec{
+			DNSNames:    []string{ingressHost, "server"},
+			SecretName:  "selfsigned-server-cert-tls",
+			IsCA:        false,
+			Duration:    &metav1.Duration{Duration: certDuration},
+			RenewBefore: &metav1.Duration{Duration: renewBeforeDuration},
+			Usages:      []certmanagerv1.KeyUsage{certmanagerv1.UsageServerAuth},
+			IssuerRef: certmanagermetav1.ObjectReference{
+				Name:  "my-ca-issuer",
+				Kind:  "Issuer",
+				Group: "cert-manager.io",
+			},
+		},
+	}
+
+	certmanagerv1Client, err := certmanagerclientset.NewForConfig(config)
+	require.NoErrorf(t, err, "failed to create cert manager client: %v", err)
+	_, err = certmanagerv1Client.CertmanagerV1().Certificates(crt.Namespace).Create(ctx, crt, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create certificate: %v", err)
+	defer certmanagerv1Client.CertmanagerV1().Certificates(crt.Namespace).Delete(ctx, crt.Name, metav1.DeleteOptions{})
+
+	err = waitForCertificateReadinessWithClient(ctx, certmanagerv1Client, crt.Name, crt.Namespace)
+	require.NoError(t, err, "failed while waiting for certificate to be ready: %v", err)
+	err = waitForIngressReadiness(ctx, loader.KubeClient, *ingress, appsDomain)
+	require.NoErrorf(t, err, "failed while waiting for ingress to be ready: %v", err)
+
+	secret, err := loader.KubeClient.CoreV1().Secrets(ns.Name).Get(ctx, crt.Spec.SecretName, metav1.GetOptions{})
+	require.NoError(t, err, "failed to fetch secret containing the certificate: %v", err)
+	tlsConfig, isValid := library.GetTLSConfig(secret)
+	require.Truef(t, isValid, "failed to validate certificate stored in the secret")
+
+	expiryTime, err := library.GetCertExpiry(ingressHost+":443", tlsConfig.Clone())
+	require.NoError(t, err, "failed to establish a test connection: %v", err)
+	t.Logf("newly created Certificate's NotAfter: %v", expiryTime)
+
+	err = wait.PollUntilContextTimeout(ctx, PollInterval, TestTimeout, true, func(ctx context.Context) (bool, error) {
+		secret, _ = loader.KubeClient.CoreV1().Secrets(ns.Name).Get(ctx, crt.Spec.SecretName, metav1.GetOptions{})
+		tlsConfig, isValid = library.GetTLSConfig(secret)
+		if !isValid {
+			return false, nil
+		}
+
+		isHostCorrect, err := library.VerifyHostname(ingressHost, tlsConfig.Clone())
+		if err != nil {
+			t.Errorf("Host %v", err)
+			return false, nil
+		}
+
+		isNotExpired, err := library.VerifyExpiry(ingressHost+":443", tlsConfig.Clone())
+		if err != nil {
+			t.Errorf("Expiry %v", err)
+			return false, nil
+		}
+
+		// include grace time for certificate rotation and for secret change propagation to
+		// the pod, to the sleep time.
+		timeUntil := (time.Until(expiryTime) - renewBeforeDuration) + time.Second*30
+		time.Sleep(timeUntil)
+
+		secret, _ = loader.KubeClient.CoreV1().Secrets(ns.Name).Get(ctx, crt.Spec.SecretName, metav1.GetOptions{})
+		tlsConfig, isValid = library.GetTLSConfig(secret)
+		if !isValid {
+			return false, nil
+		}
+
+		expiryTimeNew, err := library.GetCertExpiry(ingressHost+":443", tlsConfig.Clone())
+		t.Logf("expected to be renewed Certificate's NotAfter: %v", expiryTimeNew)
+		if err != nil {
+			return false, nil
+		}
+
+		isCertRenewed := expiryTimeNew.After(expiryTime)
+		if !isCertRenewed {
+			t.Logf("certificate's NotAfter unchanged, old: %v, new: %v", expiryTime, expiryTimeNew)
+		}
+		return isHostCorrect && isNotExpired && isCertRenewed, nil
+	})
+	require.NoErrorf(t, err, "TestCertRenew failed with err: %v", err)
+}
+
+func TestContainerOverrides(t *testing.T) {
+	ctx := context.Background()
+	config, err := library.GetConfigForTest(t)
+	require.NoError(t, err)
+
+	certmanageroperatorclient, err := certmanoperatorclient.NewForConfig(config)
+	require.NoError(t, err)
+
+	operator, err := certmanageroperatorclient.OperatorV1alpha1().CertManagers().Get(ctx, "cluster", metav1.GetOptions{})
+	require.NoError(t, err)
+	defer func() {
+		err := resetCertManagerState(ctx, certmanageroperatorclient, library.NewDynamicResourceLoader(ctx, t))
+		require.NoError(t, err)
+	}()
+
+	verifyValidControllerOperatorStatus(t, certmanageroperatorclient)
+	updatedOperator := operator.DeepCopy()
+
+	addValidControlleDeploymentConfig(updatedOperator)
+	_, err = certmanageroperatorclient.OperatorV1alpha1().CertManagers().Update(ctx, updatedOperator, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	verifyValidControllerOperatorStatus(t, certmanageroperatorclient)
+
+	err = certmanageroperatorclient.OperatorV1alpha1().CertManagers().Delete(ctx, "cluster", metav1.DeleteOptions{})
+	require.NoError(t, err)
+
+	verifyValidControllerOperatorStatus(t, certmanageroperatorclient)
+
+	operator, err = certmanageroperatorclient.OperatorV1alpha1().CertManagers().Get(ctx, "cluster", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	updatedOperator = operator.DeepCopy()
+	addInvalidControlleOverrideEnv(updatedOperator)
+	_, err = certmanageroperatorclient.OperatorV1alpha1().CertManagers().Update(ctx, updatedOperator, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	verifyInvalidControllerOperatorStatus(t, certmanageroperatorclient)
+
+	// reset operator spec
+	operator, err = certmanageroperatorclient.OperatorV1alpha1().CertManagers().Get(ctx, "cluster", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	updatedOperator = operator.DeepCopy()
+	updatedOperator.Spec = v1alpha1.CertManagerSpec{
+		OperatorSpec: opv1.OperatorSpec{
+			ManagementState: opv1.Managed,
+		},
+	}
+	_, err = certmanageroperatorclient.OperatorV1alpha1().CertManagers().Update(ctx, updatedOperator, metav1.UpdateOptions{})
+	require.NoError(t, err)
+}
+
+func verifyValidControllerOperatorStatus(t *testing.T, client *certmanoperatorclient.Clientset) {
+
+	t.Log("verifying valid controller operator status")
+	err := wait.PollUntilContextTimeout(context.TODO(), time.Second*5, time.Minute*5, true, func(ctx context.Context) (done bool, err error) {
+		operator, err := client.OperatorV1alpha1().CertManagers().Get(ctx, "cluster", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if operator.DeletionTimestamp != nil {
+			return false, nil
+		}
+
+		flag := false
+		for _, cond := range operator.Status.Conditions {
+			if cond.Type == "cert-manager-controller-deploymentAvailable" {
+				flag = cond.Status == opv1.ConditionTrue
+			}
+
+			if cond.Type == "cert-manager-controller-deploymentDegraded" {
+				flag = cond.Status == opv1.ConditionFalse
+			}
+
+			if cond.Type == "cert-manager-controller-deploymentProgressing" {
+				flag = cond.Status == opv1.ConditionFalse
+			}
+		}
+
+		t.Logf("Current poll status: %v", flag)
+		return flag, nil
+	})
+	require.NoError(t, err)
+}
+
+func addValidControlleDeploymentConfig(operator *v1alpha1.CertManager) {
+	operator.Spec.ControllerConfig = &v1alpha1.DeploymentConfig{
+		OverrideEnv: []corev1.EnvVar{
+			{
+				Name:  "HTTP_PROXY",
+				Value: "172.0.0.10:8080",
+			},
+		},
+		OverrideResources: v1alpha1.CertManagerResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    k8sresource.MustParse("500m"),
+				corev1.ResourceMemory: k8sresource.MustParse("128Mi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    k8sresource.MustParse("10m"),
+				corev1.ResourceMemory: k8sresource.MustParse("32Mi"),
+			},
+		},
+	}
+}
+
+func addInvalidControlleOverrideEnv(operator *v1alpha1.CertManager) {
+	operator.Spec.ControllerConfig = &v1alpha1.DeploymentConfig{
+		OverrideEnv: []corev1.EnvVar{
+			{
+				Name:  "FOO",
+				Value: "BAR",
+			},
+		},
+	}
+}
+
+func verifyInvalidControllerOperatorStatus(t *testing.T, client *certmanoperatorclient.Clientset) {
+	t.Log("verifying invalid controller operator status")
+	err := wait.PollUntilContextTimeout(context.TODO(), time.Second*5, time.Minute*5, true, func(ctx context.Context) (done bool, err error) {
+
+		operator, err := client.OperatorV1alpha1().CertManagers().Get(ctx, "cluster", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if operator.DeletionTimestamp != nil {
+			return false, nil
+		}
+
+		flag := false
+		for _, cond := range operator.Status.Conditions {
+			if cond.Type == "cert-manager-controller-deploymentDegraded" {
+				flag = cond.Status == opv1.ConditionTrue
+			}
+		}
+
+		t.Logf("Current poll status: %v", flag)
+		return flag, nil
+	})
+	require.NoError(t, err)
+
+}

--- a/test/e2e/certificates_test.go
+++ b/test/e2e/certificates_test.go
@@ -80,7 +80,8 @@ var _ = Describe("ACME Certificate", Ordered, func() {
 		ns = namespace
 
 		DeferCleanup(func() {
-			loader.DeleteTestingNS(ns.Name, func() bool { return CurrentSpecReport().Failed() })
+			_, err := loader.DeleteTestingNS(ns.Name, func() bool { return CurrentSpecReport().Failed() })
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
@@ -680,7 +681,8 @@ var _ = Describe("Self-signed Certificate", Ordered, func() {
 		ns = namespace
 
 		DeferCleanup(func() {
-			loader.DeleteTestingNS(ns.Name, func() bool { return CurrentSpecReport().Failed() })
+			_, err := loader.DeleteTestingNS(ns.Name, func() bool { return CurrentSpecReport().Failed() })
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 

--- a/test/e2e/istio_csr_test.go
+++ b/test/e2e/istio_csr_test.go
@@ -24,9 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// backOffLimit is the max retries for the Job
-const backOffLimit int32 = 10
-
 // istioCSRProtoURL links to proto for istio-csr API spec
 const istioCSRProtoURL = "https://raw.githubusercontent.com/istio/api/v1.24.1/security/v1alpha1/ca.proto"
 
@@ -71,7 +68,8 @@ var _ = Describe("Istio-CSR", Ordered, Label("TechPreview", "Feature:IstioCSR"),
 		ns = namespace
 
 		DeferCleanup(func() {
-			loader.DeleteTestingNS(ns.Name, func() bool { return CurrentSpecReport().Failed() })
+			_, err := loader.DeleteTestingNS(ns.Name, func() bool { return CurrentSpecReport().Failed() })
+			Expect(err).NotTo(HaveOccurred(), "Failed to delete namespace %s", ns.Name)
 		})
 	})
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -185,6 +185,10 @@ func resetCertManagerState(ctx context.Context, client *certmanoperatorclient.Cl
 		return err
 	})
 
+	if err != nil {
+		return err
+	}
+
 	// remove any entries present in Subscription spec.config for
 	// user provided injected env vars, etc.
 	// it should put operator back to default deployment
@@ -618,7 +622,7 @@ func verifyCertificateRenewed(ctx context.Context, secretName, namespace string,
 		}
 
 		// checks if expiry time was updated
-		if *initExpiryTime == cert.NotAfter {
+		if time.Time.Equal(*initExpiryTime, cert.NotAfter) {
 			return false, nil
 		}
 

--- a/test/library/cert_utils.go
+++ b/test/library/cert_utils.go
@@ -27,11 +27,14 @@ func GetTLSConfig(secret *corev1.Secret) (tls.Config, bool) {
 	roots := x509.NewCertPool()
 	ok := roots.AppendCertsFromPEM([]byte(secret.Data["tls.crt"]))
 	if !ok {
-		return tls.Config{}, ok
+		return tls.Config{
+			MinVersion: tls.VersionTLS13,
+		}, ok
 	}
 	return tls.Config{
 		RootCAs:    roots,
 		ClientCAs:  roots,
+		MinVersion: tls.VersionTLS13,
 		ClientAuth: tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{
 			{

--- a/test/library/utils.go
+++ b/test/library/utils.go
@@ -24,6 +24,11 @@ import (
 	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 )
 
+const (
+	PollInterval = 5 * time.Second
+	TestTimeout  = 10 * time.Minute
+)
+
 func (d DynamicResourceLoader) CreateTestingNS(namespacePrefix string, noSuffix bool) (*corev1.Namespace, error) {
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Similar to other `v2` migrations:
- https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2875

There were a number of things that the latest version of golangci-lint flagged for fixing.

Also, I added a `.github/workflows/pre-main.yaml` that contains a job to run the linter prior to merging PRs.