### PR TITLE
Use `k8s.io/utils/ptr` instead of deprecated `k8s.io/utils/pointer`

### DIFF
--- a/pkg/controller/deployment/deployment_overrides.go
+++ b/pkg/controller/deployment/deployment_overrides.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	coreinformersv1 "k8s.io/client-go/informers/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/operator-framework/operator-lib/proxy"
@@ -225,11 +225,11 @@ func withSABoundToken(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.
 		Name: boundSATokenVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Projected: &corev1.ProjectedVolumeSource{
-				DefaultMode: pointer.Int32(420),
+				DefaultMode: ptr.To(int32(420)),
 				Sources: []corev1.VolumeProjection{{
 					ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
 						Audience:          boundSAAudience,
-						ExpirationSeconds: pointer.Int64(boundSAExpirySec),
+						ExpirationSeconds: ptr.To(int64(boundSAExpirySec)),
 						Path:              boundSAPath,
 					}},
 				},


### PR DESCRIPTION
Broken out from #259 into a smaller PR.

Similar to: https://github.com/openshift-kni/cnf-features-deploy/pull/2345