### PR TITLE
Remove unnecessary .ObjectMeta

### DIFF
--- a/pkg/controller/istiocsr/deployments.go
+++ b/pkg/controller/istiocsr/deployments.go
@@ -134,7 +134,7 @@ func (r *Reconciler) updateImageInStatus(istiocsr *v1alpha1.IstioCSR, deployment
 }
 
 func updatePodTemplateLabels(deployment *appsv1.Deployment, resourceLabels map[string]string) {
-	deployment.Spec.Template.ObjectMeta.Labels = resourceLabels
+	deployment.Spec.Template.Labels = resourceLabels
 }
 
 func updateArgList(deployment *appsv1.Deployment, istiocsr *v1alpha1.IstioCSR) {

--- a/pkg/controller/istiocsr/test_utils.go
+++ b/pkg/controller/istiocsr/test_utils.go
@@ -174,7 +174,7 @@ func testDeployment() *appsv1.Deployment {
 	deployment := decodeDeploymentObjBytes(assets.MustAsset(deploymentAssetName))
 	deployment.SetNamespace(testIstioCSRNamespace)
 	deployment.SetLabels(controllerDefaultResourceLabels)
-	deployment.Spec.Template.ObjectMeta.Labels = controllerDefaultResourceLabels
+	deployment.Spec.Template.Labels = controllerDefaultResourceLabels
 	deployment.Spec.Template.Spec.Containers[0].Image = image
 	return deployment
 }

--- a/pkg/controller/istiocsr/utils.go
+++ b/pkg/controller/istiocsr/utils.go
@@ -270,7 +270,7 @@ func deploymentSpecModified(desired, fetched *appsv1.Deployment) bool {
 		return true
 	}
 
-	if !reflect.DeepEqual(desired.Spec.Template.ObjectMeta.Labels, fetched.Spec.Template.ObjectMeta.Labels) ||
+	if !reflect.DeepEqual(desired.Spec.Template.Labels, fetched.Spec.Template.Labels) ||
 		len(desired.Spec.Template.Spec.Containers) != len(fetched.Spec.Template.Spec.Containers) {
 		return true
 	}

--- a/test/e2e/certificates_test.go
+++ b/test/e2e/certificates_test.go
@@ -640,13 +640,13 @@ var _ = Describe("ACME Certificate", Ordered, func() {
 					}},
 				},
 			}
-			ingress, err := loader.KubeClient.NetworkingV1().Ingresses(ingress.ObjectMeta.Namespace).Create(ctx, ingress, metav1.CreateOptions{})
+			ingress, err := loader.KubeClient.NetworkingV1().Ingresses(ingress.Namespace).Create(ctx, ingress, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			defer loader.KubeClient.NetworkingV1().Ingresses(ingress.ObjectMeta.Namespace).Delete(ctx, ingress.ObjectMeta.Name, metav1.DeleteOptions{})
+			defer loader.KubeClient.NetworkingV1().Ingresses(ingress.Namespace).Delete(ctx, ingress.Name, metav1.DeleteOptions{})
 
 			By("checking TLS certificate contents")
 			err = wait.PollUntilContextTimeout(context.TODO(), PollInterval, TestTimeout, true, func(context.Context) (bool, error) {
-				secret, err := loader.KubeClient.CoreV1().Secrets(ingress.ObjectMeta.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+				secret, err := loader.KubeClient.CoreV1().Secrets(ingress.Namespace).Get(ctx, secretName, metav1.GetOptions{})
 				tlsConfig, isvalid := library.GetTLSConfig(secret)
 				if !isvalid {
 					return false, nil

--- a/test/library/utils.go
+++ b/test/library/utils.go
@@ -35,9 +35,9 @@ func (d DynamicResourceLoader) CreateTestingNS(namespacePrefix string, noSuffix 
 	}
 
 	if noSuffix {
-		namespace.ObjectMeta.Name = namespacePrefix
+		namespace.Name = namespacePrefix
 	} else {
-		namespace.ObjectMeta.GenerateName = fmt.Sprintf("%v-", namespacePrefix)
+		namespace.GenerateName = fmt.Sprintf("%v-", namespacePrefix)
 	}
 
 	var got *corev1.Namespace


### PR DESCRIPTION
No need to reference `.ObjectMeta` when trying to access certain variables.

Broken out from #259 for easier reviewing.