### PR TITLE
Avoid e2e to pass with faulty status

### DIFF
--- a/test/e2e/overrides_test.go
+++ b/test/e2e/overrides_test.go
@@ -13,6 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Overrides test", Ordered, func() {
@@ -29,6 +30,14 @@ var _ = Describe("Overrides test", Ordered, func() {
 				certManagerCAInjectorDeploymentControllerName},
 			validOperatorStatusConditions)
 		Expect(err).NotTo(HaveOccurred(), "Operator is expected to be available")
+
+		By("Wait for non-empty generations status")
+		err = verifyDeploymentGenerationIsNotEmpty(certmanageroperatorclient, []metav1.ObjectMeta{
+			{Name: certmanagerControllerDeployment, Namespace: operandNamespace},
+			{Name: certmanagerWebhookDeployment, Namespace: operandNamespace},
+			{Name: certmanagerCAinjectorDeployment, Namespace: operandNamespace},
+		})
+		Expect(err).NotTo(HaveOccurred(), "Operator status Generations should contain deployment last generation")
 	})
 
 	Context("When adding valid cert-manager controller override args", func() {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -81,15 +81,20 @@ func verifyOperatorStatusCondition(client *certmanoperatorclient.Clientset, cont
 					return false, nil
 				}
 
+				var condMatchCount int
 				for _, cond := range operator.Status.Conditions {
 					if status, exists := expectedConditionMap[strings.TrimPrefix(cond.Type, controllerNames[index])]; exists {
+						condMatchCount += 1
+
 						if cond.Status != status {
 							return false, nil
 						}
 					}
 				}
 
-				return true, nil
+				// [retry]    false:  when NOT all expected conditions were found
+				// [no-retry] true:   when all expected conditions were found
+				return condMatchCount == len(expectedConditionMap), nil
 			})
 			errs[index] = err
 		}(index)


### PR DESCRIPTION
Improves the `verifyOperatorStatusCondition` function to not allow bypassing `status.Conditions` when empty or has the required condition type(s) missing.

In #263, we managed to get the e2e pass with a faulty status update client that always kept the conditions array empty in the certmanager.operator/cluster resource.
- eg. [job that Succeeded](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cert-manager-operator/263/pull-ci-openshift-cert-manager-operator-master-e2e-operator/1912101154230112256) and it's corresponding [operator log with panics](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cert-manager-operator/263/pull-ci-openshift-cert-manager-operator-master-e2e-operator/1912101154230112256/artifacts/e2e-operator/gather-extra/artifacts/pods/cert-manager-operator_cert-manager-operator-controller-manager-79d97b766d-nrnxf_cert-manager-operator.log)