### PR TITLE
CM-499: Enable disconnected support via annotation in operator CSV

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -243,7 +243,7 @@ metadata:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
-    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "false"

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -259,7 +259,6 @@ metadata:
       for additional steps.
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: cert-manager-operator
-    operators.openshift.io/infrastructure-features: '["proxy-aware"]'
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
       Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.25.1

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -27,7 +27,6 @@ metadata:
       for additional steps.
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: cert-manager-operator
-    operators.openshift.io/infrastructure-features: '["proxy-aware"]'
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
       Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/project_layout: unknown

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
-    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "false"


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/CM-429

Some CI results can be referenced: https://github.com/openshift/release/pull/63331#issuecomment-2834027775

--

Other change:

Remove v4.14+ deprecated `operators.openshift.io/infrastructure-features` to avoid confusion and inconsistency. Ref: https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/operators/developing-operators#osdk-csv-manual-annotations-deprecated_osdk-generating-csvs