### PR TITLE
Update min Kubernetes version in CSV

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -754,7 +754,7 @@ spec:
   - email: support@redhat.com
     name: Red Hat Support
   maturity: stable
-  minKubeVersion: 1.25.0
+  minKubeVersion: 1.27.0
   provider:
     name: Red Hat
   relatedImages:

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -101,7 +101,7 @@ spec:
   - email: support@redhat.com
     name: Red Hat Support
   maturity: stable
-  minKubeVersion: 1.25.0
+  minKubeVersion: 1.27.0
   provider:
     name: Red Hat
   replaces: cert-manager-operator.v1.15.1


### PR DESCRIPTION
Updates the ClusterServiceVersion to include maxOpenShiftVersion (as 4.19, which is the highest supported version target for operator 1.16.0)