### PR TITLE
CM-575: Add missing assets for static resource controllers

### DIFF
--- a/pkg/controller/deployment/cert_manager_cainjector_deployment.go
+++ b/pkg/controller/deployment/cert_manager_cainjector_deployment.go
@@ -29,6 +29,7 @@ var (
 		"cert-manager-deployment/cainjector/cert-manager-cainjector-leaderelection-rb.yaml",
 		"cert-manager-deployment/cainjector/cert-manager-cainjector-leaderelection-role.yaml",
 		"cert-manager-deployment/cainjector/cert-manager-cainjector-sa.yaml",
+		"cert-manager-deployment/cainjector/cert-manager-cainjector-svc.yaml",
 	}
 )
 

--- a/pkg/controller/deployment/cert_manager_controller_deployment.go
+++ b/pkg/controller/deployment/cert_manager_controller_deployment.go
@@ -25,12 +25,9 @@ const (
 var (
 	certManagerControllerAssetFiles = []string{
 		"cert-manager-deployment/cert-manager-namespace.yaml",
-		"cert-manager-deployment/cert-manager/cert-manager-controller-approve-cert-manager-io-cr.yaml",
-		"cert-manager-deployment/cert-manager/cert-manager-controller-approve-cert-manager-io-crb.yaml",
+		"cert-manager-deployment/controller/cert-manager-cluster-view-cr.yaml",
 		"cert-manager-deployment/controller/cert-manager-controller-certificates-cr.yaml",
 		"cert-manager-deployment/controller/cert-manager-controller-certificates-crb.yaml",
-		"cert-manager-deployment/cert-manager/cert-manager-controller-certificatesigningrequests-cr.yaml",
-		"cert-manager-deployment/cert-manager/cert-manager-controller-certificatesigningrequests-crb.yaml",
 		"cert-manager-deployment/controller/cert-manager-controller-challenges-cr.yaml",
 		"cert-manager-deployment/controller/cert-manager-controller-challenges-crb.yaml",
 		"cert-manager-deployment/controller/cert-manager-controller-clusterissuers-cr.yaml",
@@ -46,6 +43,8 @@ var (
 		"cert-manager-deployment/controller/cert-manager-leaderelection-role.yaml",
 		"cert-manager-deployment/controller/cert-manager-sa.yaml",
 		"cert-manager-deployment/controller/cert-manager-svc.yaml",
+		"cert-manager-deployment/controller/cert-manager-cert-manager-tokenrequest-rb.yaml",
+		"cert-manager-deployment/controller/cert-manager-tokenrequest-role.yaml",
 		"cert-manager-deployment/controller/cert-manager-view-cr.yaml",
 		"cert-manager-deployment/cert-manager/cert-manager-controller-approve-cert-manager-io-cr.yaml",
 		"cert-manager-deployment/cert-manager/cert-manager-controller-approve-cert-manager-io-crb.yaml",


### PR DESCRIPTION
### Changes

Adds missing asset files when `NewStaticResourceController` for cainjector and controller operands. Also remove redundant assets of `certManagerControllerAssetFiles`.

### Motivation

This issue was detected when testing [CM-574](https://issues.redhat.com/browse/CM-574). It turns out that the [cert-manager-cainjector-svc.yaml](https://github.com/openshift/cert-manager-operator/blob/master/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-svc.yaml) resource wasn't created which caused there to be no service endpoint for Prometheus to scrape.

When bumping to a new version from upstream, there may be few added/deleted resource definitions. They can be reflect in YAML manifests creation/deletion under [bindata/cert-manager-deployment/](https://github.com/openshift/cert-manager-operator/tree/master/bindata/cert-manager-deployment) path (handled by `make update`). But it seems we neglected to incorporate these changes into the operator's `NewStaticResourceController`, causing these resources not to be applied when the operator starts.