### PR TITLE
CM-561: Turn o/api `configv1.Infrastructure` into an optional dependency

### DIFF
--- a/pkg/controller/deployment/cert_manager_cainjector_deployment.go
+++ b/pkg/controller/deployment/cert_manager_cainjector_deployment.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openshift/cert-manager-operator/pkg/operator/assets"
 	certmanoperatorinformers "github.com/openshift/cert-manager-operator/pkg/operator/informers/externalversions"
+	"github.com/openshift/cert-manager-operator/pkg/operator/optionalinformer"
 )
 
 const (
@@ -50,7 +51,7 @@ func NewCertManagerCAInjectorStaticResourcesController(operatorClient v1helpers.
 
 func NewCertManagerCAInjectorDeploymentController(operatorClient v1helpers.OperatorClientWithFinalizers,
 	certManagerOperatorInformers certmanoperatorinformers.SharedInformerFactory,
-	infraInformers configinformers.SharedInformerFactory,
+	infraInformers optionalinformer.OptionalInformer[configinformers.SharedInformerFactory],
 	kubeClient kubernetes.Interface,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
 	eventsRecorder events.Recorder, targetVersion string, versionRecorder status.VersionGetter,

--- a/pkg/controller/deployment/cert_manager_controller_deployment.go
+++ b/pkg/controller/deployment/cert_manager_controller_deployment.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openshift/cert-manager-operator/pkg/operator/assets"
 	certmanoperatorinformers "github.com/openshift/cert-manager-operator/pkg/operator/informers/externalversions"
+	"github.com/openshift/cert-manager-operator/pkg/operator/optionalinformer"
 )
 
 const (
@@ -69,7 +70,7 @@ func NewCertManagerControllerStaticResourcesController(operatorClient v1helpers.
 
 func NewCertManagerControllerDeploymentController(operatorClient v1helpers.OperatorClientWithFinalizers,
 	certManagerOperatorInformers certmanoperatorinformers.SharedInformerFactory,
-	infraInformers configinformers.SharedInformerFactory,
+	infraInformers optionalinformer.OptionalInformer[configinformers.SharedInformerFactory],
 	kubeClient kubernetes.Interface,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
 	eventsRecorder events.Recorder, targetVersion string, versionRecorder status.VersionGetter, trustedCAConfigmapName, cloudCredentialsSecretName string) factory.Controller {

--- a/pkg/controller/deployment/cert_manager_controller_set.go
+++ b/pkg/controller/deployment/cert_manager_controller_set.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	certmanoperatorinformers "github.com/openshift/cert-manager-operator/pkg/operator/informers/externalversions"
+	"github.com/openshift/cert-manager-operator/pkg/operator/optionalinformer"
 )
 
 type CertManagerControllerSet struct {
@@ -27,7 +28,7 @@ func NewCertManagerControllerSet(
 	kubeClient kubernetes.Interface,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
-	infraInformers configinformers.SharedInformerFactory,
+	infraInformers optionalinformer.OptionalInformer[configinformers.SharedInformerFactory],
 	operatorClient v1helpers.OperatorClientWithFinalizers,
 	certManagerOperatorInformers certmanoperatorinformers.SharedInformerFactory,
 	kubeClientContainer *resourceapply.ClientHolder,

--- a/pkg/controller/deployment/cert_manager_webhook_deployment.go
+++ b/pkg/controller/deployment/cert_manager_webhook_deployment.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openshift/cert-manager-operator/pkg/operator/assets"
 	certmanoperatorinformers "github.com/openshift/cert-manager-operator/pkg/operator/informers/externalversions"
+	"github.com/openshift/cert-manager-operator/pkg/operator/optionalinformer"
 )
 
 const (
@@ -51,7 +52,7 @@ func NewCertManagerWebhookStaticResourcesController(operatorClient v1helpers.Ope
 
 func NewCertManagerWebhookDeploymentController(operatorClient v1helpers.OperatorClientWithFinalizers,
 	certManagerOperatorInformers certmanoperatorinformers.SharedInformerFactory,
-	infraInformers configinformers.SharedInformerFactory,
+	infraInformers optionalinformer.OptionalInformer[configinformers.SharedInformerFactory],
 	kubeclient kubernetes.Interface,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
 	eventsRecorder events.Recorder, targetVersion string, versionRecorder status.VersionGetter, trustedCAConfigmapName, cloudCredentialsSecretName string) factory.Controller {

--- a/pkg/operator/optionalinformer/optional_informer.go
+++ b/pkg/operator/optionalinformer/optional_informer.go
@@ -1,0 +1,67 @@
+package optionalinformer
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+)
+
+type OptionalInformer[GroupInformer any] struct {
+	gvr             schema.GroupVersionResource
+	discoveryClient discovery.DiscoveryInterface
+
+	InformerFactory *GroupInformer
+}
+
+func NewOptionalInformer[groupInformer any](
+	ctx context.Context,
+	gvr schema.GroupVersionResource,
+	discoveryClient discovery.DiscoveryInterface,
+	informerInitFunc func() groupInformer,
+) (*OptionalInformer[groupInformer], error) {
+	o := &OptionalInformer[groupInformer]{
+		gvr:             gvr,
+		discoveryClient: discoveryClient,
+	}
+
+	discovered, err := o.Discover()
+	if err != nil {
+		return nil, err
+	}
+
+	if discovered {
+		informer := informerInitFunc()
+		o.InformerFactory = &informer
+	}
+
+	return o, nil
+}
+
+// Applicable determines if an active informer was successfully created
+func (o *OptionalInformer[GroupInformer]) Applicable() bool {
+	return o.InformerFactory != nil
+}
+
+// Discover returns if the required CRD is present on the cluster or not
+func (o *OptionalInformer[GroupInformer]) Discover() (bool, error) {
+	_ = o.gvr.GroupVersion().String()
+	resources, err := o.discoveryClient.ServerResourcesForGroupVersion(o.gvr.GroupVersion().String())
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	for _, res := range resources.APIResources {
+		if res.Name == o.gvr.Resource {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/operator/optionalinformer/optional_informer_test.go
+++ b/pkg/operator/optionalinformer/optional_informer_test.go
@@ -1,0 +1,108 @@
+package optionalinformer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+
+	operatorv1alpha1 "github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
+	"github.com/openshift/cert-manager-operator/pkg/operator/clientset/versioned/fake"
+)
+
+func createFakeClient(isResourcePresent bool) *fake.Clientset {
+	if !isResourcePresent {
+		return fake.NewClientset()
+	}
+
+	fakeClient := fake.NewClientset(&operatorv1alpha1.CertManager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Status: operatorv1alpha1.CertManagerStatus{},
+	})
+
+	// the fake client set does not populate API resource list by default
+	// which is required to make a fake discovery call
+	fakeClient.Fake.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: operatorv1alpha1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{
+					Name:         "certmanagers",
+					SingularName: "certmanager",
+					Namespaced:   false,
+					Group:        operatorv1alpha1.SchemeGroupVersion.Group,
+					Version:      operatorv1alpha1.SchemeGroupVersion.Version,
+					Kind:         "CertManager",
+					Verbs:        []string{"get", "list", "create", "update", "patch", "watch", "delete"},
+				},
+			},
+		},
+	}
+
+	return fakeClient
+}
+
+type alwaysErrorFakeDiscovery struct {
+	fakediscovery.FakeDiscovery
+}
+
+// ServerResourcesForGroupVersion is the only func that OptionalInformer's discovery client calls
+func (f *alwaysErrorFakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	return nil, fmt.Errorf("expected foo error")
+}
+
+func createErroneousFakeDiscoveryClient() discovery.DiscoveryInterface {
+	return &alwaysErrorFakeDiscovery{}
+}
+
+func TestOptionalInformer(t *testing.T) {
+	type fakeInformerFactoryStub struct{}
+	dummyInformerInit := func() fakeInformerFactoryStub {
+		return struct{}{}
+	}
+
+	fixedGVRForTest := operatorv1alpha1.SchemeGroupVersion.WithResource("certmanagers")
+
+	t.Run("positive cases with no expected errors", func(t *testing.T) {
+		tests := []struct {
+			isCRDPresent   bool
+			expectInformer bool
+		}{
+			// positive cases with no error
+			// false => false, true => true
+			{isCRDPresent: false, expectInformer: false},
+			{isCRDPresent: true, expectInformer: true},
+		}
+
+		for _, tt := range tests {
+			fakeClient := createFakeClient(tt.isCRDPresent)
+
+			optInformer, err := NewOptionalInformer(context.TODO(), fixedGVRForTest,
+				fakeClient.Discovery(), dummyInformerInit)
+			require.NoError(t, err)
+
+			discovered, err := optInformer.Discover()
+			require.NoError(t, err)
+			assert.Equal(t, tt.isCRDPresent, discovered, "discovery does not match CRD registration")
+
+			assert.Equal(t, tt.expectInformer, optInformer.Applicable(), "undesired optional informer applicable(ity)")
+			assert.Equal(t, tt.expectInformer, optInformer.InformerFactory != nil, "broken informer factory init func call")
+		}
+	})
+
+	t.Run("negative case with an expected error", func(t *testing.T) {
+		errorProneDiscoveryClient := createErroneousFakeDiscoveryClient()
+		_, err := NewOptionalInformer(context.TODO(), fixedGVRForTest,
+			errorProneDiscoveryClient, dummyInformerInit)
+
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
An optional informer that discovers a CRD before enacting,
applicable/useful for wrapping around configv1.Infrastructure which is not present when using a non-OpenShift cluster variant (eg. MicroShift).

Checklist:
- [x] Verify this works on a microshift
     -  [x] [Integration with Route(s) tested](https://github.com/openshift/cert-manager-operator/pull/278#issuecomment-2976727063)
- [x] Add unit test(s)