### PR TITLE
CM-590: deliberately fail the e2e on encountering an unexpected Degraded condition

### DIFF
--- a/test/e2e/condition_matcher_test.go
+++ b/test/e2e/condition_matcher_test.go
@@ -1,0 +1,148 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"regexp"
+
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	opv1 "github.com/openshift/api/operator/v1"
+	v1alpha1client "github.com/openshift/cert-manager-operator/pkg/operator/clientset/versioned/typed/operator/v1alpha1"
+)
+
+// ConditionMatcher tracks a regex pattern cond.Type with an expected cond.Status
+type ConditionMatcher struct {
+	TypePattern    *regexp.Regexp       `json:"condition.Type"`
+	ExpectedStatus opv1.ConditionStatus `json:"condition.Status"`
+
+	// Any when true will expect matcher to succeed
+	// when atleast one conditions match, default is false when
+	// matcher will succeed only on matching all pattern conditions.
+	Any bool `json:"matcher.shouldMatchAny"`
+}
+
+// MatchesType returns true if the provided Condition.Type satisfies regex pattern
+func (m *ConditionMatcher) MatchesType(cond *opv1.OperatorCondition) bool {
+	return m.TypePattern.MatchString(cond.Type)
+}
+
+// MatchesStatus returns true if the provided Condition.Status is same as ExpectedStatus
+func (m *ConditionMatcher) MatchesStatus(cond *opv1.OperatorCondition) bool {
+	return cond.Status == m.ExpectedStatus
+}
+
+func (m *ConditionMatcher) Matches(conditions []opv1.OperatorCondition) bool {
+	matchCount := 0
+	for _, cond := range conditions {
+		if m.MatchesType(&cond) && m.MatchesStatus(&cond) {
+
+			if m.Any {
+				return true
+			}
+
+			matchCount += 1
+		}
+
+		if m.MatchesType(&cond) && !m.MatchesStatus(&cond) {
+			return false
+		}
+	}
+
+	return matchCount > 0
+}
+
+const (
+	MatchAnyCondition  bool = true
+	MatchAllConditions bool = false
+)
+
+// PrefixAndMatchTypeTuple is a tuple containing
+// controller name (i.e. the condition prefix)
+// and the condition matcher type be ANY or ALL.
+type PrefixAndMatchTypeTuple struct {
+	Prefix         string
+	ShouldMatchAny bool
+}
+
+func GenerateConditionMatchers(tuples []PrefixAndMatchTypeTuple, expectedConditions map[string]opv1.ConditionStatus) []ConditionMatcher {
+	matchers := make([]ConditionMatcher, len(tuples)*len(expectedConditions))
+
+	idx := 0
+	for _, t := range tuples {
+		for suffix, state := range expectedConditions {
+			matchers[idx] = ConditionMatcher{
+				TypePattern:    regexp.MustCompile("^" + t.Prefix + ".*" + suffix + "$"),
+				ExpectedStatus: state,
+				Any:            t.ShouldMatchAny,
+			}
+			idx += 1
+		}
+	}
+	return matchers
+}
+
+// verifyOperatorStatusCondition polls every few second to check if the status of each of the controllers
+// match with the expected conditions. It returns an error if a timeout (few mins) occurs or an error was
+// encountered which polls the status.
+func verifyOperatorStatusCondition(client v1alpha1client.OperatorV1alpha1Interface, conditionMatchers []ConditionMatcher) error {
+	var lastFetchedConditions []opv1.OperatorCondition
+
+	err := wait.PollUntilContextTimeout(context.TODO(), fastPollInterval, lowTimeout, true, func(context.Context) (bool, error) {
+		operator, err := client.CertManagers().Get(context.TODO(), "cluster", metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		if operator.DeletionTimestamp != nil {
+			return false, nil
+		}
+
+		lastFetchedConditions = operator.Status.DeepCopy().Conditions
+		for _, matcher := range conditionMatchers {
+			if !matcher.Matches(lastFetchedConditions) {
+
+				// [retry] false:   NOT match as desired
+				return false, nil
+			}
+		}
+
+		// [no-retry] true: when ALL match as desired
+		return true, nil
+	})
+
+	if err != nil {
+		prettyConds, _ := json.Marshal(lastFetchedConditions)
+		log.Printf("found status.conditions: %s", prettyConds)
+		prettyMatchers, _ := json.Marshal(conditionMatchers)
+		log.Printf("expected status.conditions to adhere with %s", prettyMatchers)
+
+		return fmt.Errorf("could not verify all status conditions as expected : %v", err)
+	}
+
+	return nil
+}
+
+func VerifyHealthyOperatorConditions(client v1alpha1client.OperatorV1alpha1Interface) error {
+	return verifyOperatorStatusCondition(client,
+		GenerateConditionMatchers(
+			[]PrefixAndMatchTypeTuple{
+				{certManagerController, MatchAllConditions},
+				{certManagerWebhook, MatchAllConditions},
+				{certManagerCAInjector, MatchAllConditions},
+			},
+			validOperatorStatusConditions,
+		),
+	)
+}

--- a/test/e2e/condition_matcher_unit_test.go
+++ b/test/e2e/condition_matcher_unit_test.go
@@ -1,0 +1,151 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	opv1 "github.com/openshift/api/operator/v1"
+	operatorv1alpha1 "github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
+	fakecertmanclient "github.com/openshift/cert-manager-operator/pkg/operator/clientset/versioned/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// TestVerifyOperatorStatusCondition unit test for verifyOperatorStatusCondition func
+func TestVerifyOperatorStatusCondition(t *testing.T) {
+	controllerPrefix := "foo-controller"
+
+	newCertManagerObjectWithConditions := func(conditions ...opv1.OperatorCondition) *operatorv1alpha1.CertManager {
+		return &operatorv1alpha1.CertManager{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster",
+			},
+			Status: operatorv1alpha1.CertManagerStatus{
+				OperatorStatus: opv1.OperatorStatus{
+					Conditions: conditions,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name               string
+		initialObjects     []runtime.Object
+		expectedConditions map[string]opv1.ConditionStatus
+		matchAny           bool
+		expectError        bool
+		errorContains      string
+	}{
+		{
+			name: "One degraded is true but another is false using Any",
+			expectedConditions: map[string]opv1.ConditionStatus{
+				"Available":   opv1.ConditionTrue,
+				"Degraded":    opv1.ConditionFalse,
+				"Progressing": opv1.ConditionFalse,
+			},
+			initialObjects: []runtime.Object{
+				newCertManagerObjectWithConditions(
+					opv1.OperatorCondition{Type: controllerPrefix + "Available", Status: opv1.ConditionTrue},
+
+					opv1.OperatorCondition{Type: controllerPrefix + "Degraded", Status: opv1.ConditionFalse},
+					opv1.OperatorCondition{Type: controllerPrefix + "-rand-Degraded", Status: opv1.ConditionTrue},
+
+					opv1.OperatorCondition{Type: controllerPrefix + "Progressing", Status: opv1.ConditionFalse},
+				),
+			},
+			matchAny:      true,
+			expectError:   false,
+			errorContains: "context deadline exceeded",
+		},
+		{
+			name: "Both degraded is false",
+			expectedConditions: map[string]opv1.ConditionStatus{
+				"Available":   opv1.ConditionTrue,
+				"Degraded":    opv1.ConditionFalse,
+				"Progressing": opv1.ConditionFalse,
+			},
+			initialObjects: []runtime.Object{
+				newCertManagerObjectWithConditions(
+					opv1.OperatorCondition{Type: controllerPrefix + "Available", Status: opv1.ConditionTrue},
+
+					opv1.OperatorCondition{Type: controllerPrefix + "Degraded", Status: opv1.ConditionFalse},
+					opv1.OperatorCondition{Type: controllerPrefix + "-bar-Degraded", Status: opv1.ConditionFalse},
+
+					opv1.OperatorCondition{Type: controllerPrefix + "Progressing", Status: opv1.ConditionFalse},
+				),
+			},
+			expectError: false,
+		},
+		{
+			name: "One available is true but another is false using All",
+			expectedConditions: map[string]opv1.ConditionStatus{
+				"Available":   opv1.ConditionTrue,
+				"Degraded":    opv1.ConditionFalse,
+				"Progressing": opv1.ConditionFalse,
+			},
+			initialObjects: []runtime.Object{
+				newCertManagerObjectWithConditions(
+					opv1.OperatorCondition{Type: controllerPrefix + "Available", Status: opv1.ConditionTrue},
+					opv1.OperatorCondition{Type: controllerPrefix + "-bar-Available", Status: opv1.ConditionFalse},
+
+					opv1.OperatorCondition{Type: controllerPrefix + "Degraded", Status: opv1.ConditionFalse},
+					opv1.OperatorCondition{Type: controllerPrefix + "-bar-Degraded", Status: opv1.ConditionFalse},
+
+					opv1.OperatorCondition{Type: controllerPrefix + "Progressing", Status: opv1.ConditionFalse},
+				),
+			},
+			expectError:   true,
+			errorContains: "context deadline exceeded",
+		},
+		{
+			name: "A missing condition for Progressing",
+			expectedConditions: map[string]opv1.ConditionStatus{
+				"Available":   opv1.ConditionTrue,
+				"Degraded":    opv1.ConditionFalse,
+				"Progressing": opv1.ConditionFalse,
+			},
+			initialObjects: []runtime.Object{
+				newCertManagerObjectWithConditions(
+					opv1.OperatorCondition{Type: controllerPrefix + "Available", Status: opv1.ConditionTrue},
+					opv1.OperatorCondition{Type: controllerPrefix + "-bar-Available", Status: opv1.ConditionFalse},
+
+					opv1.OperatorCondition{Type: controllerPrefix + "Degraded", Status: opv1.ConditionFalse},
+					opv1.OperatorCondition{Type: controllerPrefix + "-bar-Degraded", Status: opv1.ConditionFalse},
+				),
+			},
+			expectError:   true,
+			errorContains: "could not verify all status conditions as expected",
+		},
+	}
+
+	t.Parallel()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fakecertmanclient.NewSimpleClientset(tt.initialObjects...)
+
+			matchers := GenerateConditionMatchers([]PrefixAndMatchTypeTuple{
+				{controllerPrefix, tt.matchAny},
+			}, tt.expectedConditions)
+
+			err := verifyOperatorStatusCondition(fakeClient.OperatorV1alpha1(), matchers)
+
+			if tt.expectError && err == nil {
+				t.Errorf("Expected an error, but got nil")
+			}
+
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error, but got: %v", err)
+			}
+
+			if tt.expectError && err != nil {
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("Expected error to contain '%s', but got: %v", tt.errorContains, err)
+				}
+			}
+		})
+	}
+}

--- a/test/e2e/istio_csr_test.go
+++ b/test/e2e/istio_csr_test.go
@@ -58,11 +58,7 @@ var _ = Describe("Istio-CSR", Ordered, Label("TechPreview", "Feature:IstioCSR"),
 
 	BeforeEach(func() {
 		By("waiting for operator status to become available")
-		err := verifyOperatorStatusCondition(certmanageroperatorclient, []string{
-			certManagerControllerDeploymentControllerName,
-			certManagerWebhookDeploymentControllerName,
-			certManagerCAInjectorDeploymentControllerName,
-		}, validOperatorStatusConditions)
+		err := VerifyHealthyOperatorConditions(certmanageroperatorclient.OperatorV1alpha1())
 		Expect(err).NotTo(HaveOccurred(), "Operator is expected to be available")
 
 		By("creating a test namespace")

--- a/test/e2e/overrides_test.go
+++ b/test/e2e/overrides_test.go
@@ -24,12 +24,8 @@ var _ = Describe("Overrides test", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for operator status to become available")
-		err = verifyOperatorStatusCondition(certmanageroperatorclient,
-			[]string{certManagerControllerDeploymentControllerName,
-				certManagerWebhookDeploymentControllerName,
-				certManagerCAInjectorDeploymentControllerName},
-			validOperatorStatusConditions)
-		Expect(err).NotTo(HaveOccurred(), "Operator is expected to be available")
+		err = VerifyHealthyOperatorConditions(certmanageroperatorclient.OperatorV1alpha1())
+		Expect(err).NotTo(HaveOccurred(), "Operator is expected to be healthy and available")
 
 		By("Wait for non-empty generations status")
 		err = verifyDeploymentGenerationIsNotEmpty(certmanageroperatorclient, []metav1.ObjectMeta{
@@ -50,7 +46,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager controller status to become available")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerControllerDeploymentControllerName}, validOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerController, MatchAllConditions}}, validOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the args to be added to the cert-manager controller deployment")
@@ -69,7 +67,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager webhook controller status to become available")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerWebhookDeploymentControllerName}, validOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerWebhook, MatchAllConditions}}, validOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the args to be added to the cert-manager webhook deployment")
@@ -88,7 +88,10 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager cainjector controller status to become available")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerCAInjectorDeploymentControllerName}, validOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(),
+				GenerateConditionMatchers(
+					[]PrefixAndMatchTypeTuple{{certManagerCAInjector, MatchAllConditions}}, validOperatorStatusConditions,
+				))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the args to be added to the cert-manager cainjector deployment")
@@ -107,7 +110,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager controller status to become degraded")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerControllerDeploymentControllerName}, invalidOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerController, MatchAnyCondition}}, invalidOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if the args are not added to the cert-manager controller deployment")
@@ -126,7 +131,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager webhook controller status to become degraded")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerWebhookDeploymentControllerName}, invalidOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerWebhook, MatchAnyCondition}}, invalidOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if the args are not added to the cert-manager webhook deployment")
@@ -145,7 +152,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager cainjector controller status to become degraded")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerCAInjectorDeploymentControllerName}, invalidOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerCAInjector, MatchAnyCondition}}, invalidOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if the args are not added to the cert-manager cainjector deployment")
@@ -173,7 +182,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager controller status to become available")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerControllerDeploymentControllerName}, validOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerController, MatchAllConditions}}, validOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the resources to be added to the cert-manager controller deployment")
@@ -201,7 +212,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager webhook controller status to become available")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerWebhookDeploymentControllerName}, validOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerWebhook, MatchAllConditions}}, validOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the resources to be added to the cert-manager webhook deployment")
@@ -229,7 +242,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager cainjector controller status to become available")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerCAInjectorDeploymentControllerName}, validOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerCAInjector, MatchAllConditions}}, validOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the resources to be added to the cert-manager cainjector deployment")
@@ -255,7 +270,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager controller status to become degraded")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerControllerDeploymentControllerName}, invalidOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerController, MatchAnyCondition}}, invalidOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if the resources are not added to the cert-manager controller deployment")
@@ -281,7 +298,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager webhook controller status to become degraded")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerWebhookDeploymentControllerName}, invalidOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerWebhook, MatchAnyCondition}}, invalidOperatorStatusConditions),
+			)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if the resources are not added to the cert-manager webhook deployment")
@@ -307,7 +326,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager cainjector controller status to become degraded")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerCAInjectorDeploymentControllerName}, invalidOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerCAInjector, MatchAnyCondition}}, invalidOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if the resources are not added to the cert-manager cainjector deployment")
@@ -337,7 +358,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager controller status to become available")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerControllerDeploymentControllerName}, validOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerController, MatchAllConditions}}, validOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the scheduling to be added to the cert-manager controller deployment")
@@ -367,7 +390,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager webhook controller status to become available")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerWebhookDeploymentControllerName}, validOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerWebhook, MatchAllConditions}}, validOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the scheduling to be added to the cert-manager webhook deployment")
@@ -397,7 +422,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager cainjector controller status to become available")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerCAInjectorDeploymentControllerName}, validOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerCAInjector, MatchAllConditions}}, validOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the scheduling to be added to the cert-manager cainjector deployment")
@@ -428,7 +455,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager controller status to become degraded")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerControllerDeploymentControllerName}, invalidOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerController, MatchAnyCondition}}, invalidOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if the scheduling are not added to the cert-manager controller deployment")
@@ -459,7 +488,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager webhook controller status to become degraded")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerWebhookDeploymentControllerName}, invalidOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerWebhook, MatchAnyCondition}}, invalidOperatorStatusConditions),
+			)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if the scheduling are not added to the cert-manager webhook deployment")
@@ -490,7 +521,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager cainjector controller status to become degraded")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerCAInjectorDeploymentControllerName}, invalidOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerCAInjector, MatchAnyCondition}}, invalidOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if the scheduling are not added to the cert-manager cainjector deployment")
@@ -509,7 +542,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager controller status to become available")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerControllerDeploymentControllerName}, validOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerController, MatchAllConditions}}, validOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the env to be added to the cert-manager controller deployment")
@@ -528,7 +563,9 @@ var _ = Describe("Overrides test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for cert-manager controller status to become degraded")
-			err = verifyOperatorStatusCondition(certmanageroperatorclient, []string{certManagerControllerDeploymentControllerName}, invalidOperatorStatusConditions)
+			err = verifyOperatorStatusCondition(certmanageroperatorclient.OperatorV1alpha1(), GenerateConditionMatchers(
+				[]PrefixAndMatchTypeTuple{{certManagerController, MatchAnyCondition}}, invalidOperatorStatusConditions,
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if the env are not added to the cert-manager controller deployment")
@@ -543,11 +580,7 @@ var _ = Describe("Overrides test", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for operator status to become available")
-		err = verifyOperatorStatusCondition(certmanageroperatorclient,
-			[]string{certManagerControllerDeploymentControllerName,
-				certManagerWebhookDeploymentControllerName,
-				certManagerCAInjectorDeploymentControllerName},
-			validOperatorStatusConditions)
+		err = VerifyHealthyOperatorConditions(certmanageroperatorclient.OperatorV1alpha1())
 		Expect(err).NotTo(HaveOccurred(), "Operator is expected to be available")
 	})
 })

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -26,9 +26,9 @@ import (
 const (
 	operatorName = "cert-manager"
 
-	certManagerControllerDeploymentControllerName = operatorName + "-controller-deployment"
-	certManagerWebhookDeploymentControllerName    = operatorName + "-webhook-deployment"
-	certManagerCAInjectorDeploymentControllerName = operatorName + "-cainjector-deployment"
+	certManagerController = operatorName + "-controller"
+	certManagerWebhook    = operatorName + "-webhook"
+	certManagerCAInjector = operatorName + "-cainjector"
 
 	certmanagerControllerDeployment = "cert-manager"
 	certmanagerWebhookDeployment    = "cert-manager-webhook"
@@ -96,11 +96,7 @@ var _ = BeforeSuite(func() {
 	Expect(certmanageroperatorclient).NotTo(BeNil())
 
 	By("verifying operator and cert-manager deployments status is available")
-	err = verifyOperatorStatusCondition(certmanageroperatorclient,
-		[]string{certManagerControllerDeploymentControllerName,
-			certManagerWebhookDeploymentControllerName,
-			certManagerCAInjectorDeploymentControllerName},
-		validOperatorStatusConditions)
+	err = VerifyHealthyOperatorConditions(certmanageroperatorclient.OperatorV1alpha1())
 	Expect(err).NotTo(HaveOccurred(), "operator is expected to be available")
 
 	By("creating dynamic resources client")


### PR DESCRIPTION
Protect against arbitrary `*Degraded` conditions as true and deliberately fail the e2e if we encounter any unexpected Degraded in Status.Conditions.

Currently, if `cert-manager-*-deploymentDegraded` is True the e2e would fail but in the event of a Condition `{Type: "cert-manager-controller-static-resources-Degraded", status: "True"}` it does not error out which caused us to overlook such errors as observed in https://issues.redhat.com/browse/OCPBUGS-56758.

/cc @lunarwhite @siddhibhor-56 