### PR TITLE
OCPBUGS-56758: Add tokenrequest RBAC for operator controller manager

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -333,6 +333,12 @@ spec:
           - update
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts/token
+          verbs:
+          - create
+        - apiGroups:
           - acme.cert-manager.io
           resources:
           - challenges

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -23,6 +23,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
   - acme.cert-manager.io
   resources:
   - challenges

--- a/pkg/controller/deployment/certmanager_controller.go
+++ b/pkg/controller/deployment/certmanager_controller.go
@@ -43,6 +43,7 @@ type CertManagerReconciler struct {
 // TODO clusterpermissions carried over as is, need to be reduced
 //+kubebuilder:rbac:groups="",resources=pods;secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events;services;namespaces;serviceaccounts;configmaps,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=serviceaccounts/token,verbs=create
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
To mitigate the static-resource controller degrade issue caused by lack of permission: 
```
'RoleCreateFailed' Failed to create Role.rbac.authorization.k8s.io/cert-manager-tokenrequest -n cert-manager: roles.rbac.authorization.k8s.io "cert-manager-tokenrequest" is forbidden: user "system:serviceaccount:cert-manager-operator:cert-manager-operator-controller-manager" (groups=["system:serviceaccounts" "system:serviceaccounts:cert-manager-operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:[""], Resources:["serviceaccounts/token"], ResourceNames:["cert-manager"], Verbs:["create"]}
```

Adds the `serviceaccount/token` create permission to the RBAC annotations of [certmanager_controller.go](https://github.com/openshift/cert-manager-operator/blob/master/pkg/controller/deployment/certmanager_controller.go), then executes `make generate && make bundle`. This way, while installing the operator, it will have sufficient permissions to grant the `cert-manager` serviceaccount the ability to create `serviceaccounts/token` resource within `cert-manager` namespace. 