### PR TITLE
CM-674: Enable ReadOnly Root Filesystem for operator controller

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -693,15 +693,22 @@ spec:
                     drop:
                     - ALL
                   privileged: false
+                  readOnlyRootFilesystem: true
                   runAsNonRoot: true
                   seccompProfile:
                     type: RuntimeDefault
+                volumeMounts:
+                - mountPath: /tmp
+                  name: tmp
               securityContext:
                 runAsNonRoot: true
                 seccompProfile:
                   type: RuntimeDefault
               serviceAccountName: cert-manager-operator-controller-manager
               terminationGracePeriodSeconds: 10
+              volumes:
+              - emptyDir: {}
+                name: tmp
       permissions:
       - rules:
         - apiGroups:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -105,6 +105,7 @@ spec:
                 - 'ALL'
             privileged: false
             runAsNonRoot: true
+            readOnlyRootFilesystem: true
             seccompProfile:
               type: 'RuntimeDefault'
           ports:
@@ -115,5 +116,11 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
Supersede https://github.com/openshift/cert-manager-operator/pull/294

### Motivation

All cert-manager operands containers are applied with "readOnlyRootFilesystem: true" in their securityContext (aligned with upstream natively):

- cert-manager-controller https://github.com/openshift/cert-manager-operator/blob/bb69f735ac8611d97b02d012d6f99f0184a567a4/bindata/cert-manager-deployment/controller/cert-manager-deployment.yaml#L71
- cainjector https://github.com/openshift/cert-manager-operator/blob/bb69f735ac8611d97b02d012d6f99f0184a567a4/bindata/cert-manager-deployment/cainjector/cert-manager-cainjector-deployment.yaml#L55
- webhook https://github.com/openshift/cert-manager-operator/blob/bb69f735ac8611d97b02d012d6f99f0184a567a4/bindata/cert-manager-deployment/webhook/cert-manager-webhook-deployment.yaml#L84
- istio-csr https://github.com/openshift/cert-manager-operator/blob/bb69f735ac8611d97b02d012d6f99f0184a567a4/bindata/istio-csr/cert-manager-istio-csr-deployment.yaml#L81

But the operator controller-manager is not:

- cert-manager-operator-controller-manager https://github.com/openshift/cert-manager-operator/blob/bb69f735ac8611d97b02d012d6f99f0184a567a4/config/manager/manager.yaml#L101-L109

As called out in https://issues.redhat.com/browse/OCPSTRAT-2045, it's a common hardening recommendation to set readOnlyRootFilesystem to true, which ensures that the container's root filesystem is mounted as read-only.

### Supplementary tests

- Verify `securityContext.readOnlyRootFilesystem` indeed takes affect
```
oc rsh -n cert-manager-operator deployment/cert-manager-operator-controller-manager
sh-5.1$ touch /usr/bin/foo    
touch: cannot touch '/usr/bin/foo': Read-only file system
sh-5.1$ touch /var/foo
touch: cannot touch '/var/foo': Read-only file system
sh-5.1$ touch /etc/foo
touch: cannot touch '/etc/foo': Read-only file system
```
- Trigger QE e2e test suite on `aos-4_20/ipi-on-gcp/versioned-installer`: https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/ocp-common/job/ginkgo-test/294150/console, passed
