### PR TITLE
CM-680: [istio-csr] Enable multi-cluster support with clusterID

### DIFF
--- a/api/operator/v1alpha1/istiocsr_types.go
+++ b/api/operator/v1alpha1/istiocsr_types.go
@@ -212,6 +212,12 @@ type IstiodTLSConfig struct {
 // ServerConfig is for configuring the server endpoint used by istio
 // for obtaining the certificates.
 type ServerConfig struct {
+	// clusterID is the istio cluster ID to verify incoming CSRs.
+	// +kubebuilder:default:="Kubernetes"
+	// +kubebuilder:validation:Optional
+	// +optional
+	ClusterID string `json:"clusterID,omitempty"`
+
 	// port to serve istio-csr gRPC service.
 	// +kubebuilder:default:=443
 	// +kubebuilder:validation:XValidation:rule="oldSelf == 0 || self == oldSelf",message="port is immutable once set"

--- a/bundle/manifests/operator.openshift.io_istiocsrs.yaml
+++ b/bundle/manifests/operator.openshift.io_istiocsrs.yaml
@@ -1221,6 +1221,11 @@ spec:
                       server is for configuring the server endpoint used by istio
                       for obtaining the certificates.
                     properties:
+                      clusterID:
+                        default: Kubernetes
+                        description: clusterID is the istio cluster ID to verify incoming
+                          CSRs.
+                        type: string
                       port:
                         default: 443
                         description: port to serve istio-csr gRPC service.

--- a/config/crd/bases/operator.openshift.io_istiocsrs.yaml
+++ b/config/crd/bases/operator.openshift.io_istiocsrs.yaml
@@ -1221,6 +1221,11 @@ spec:
                       server is for configuring the server endpoint used by istio
                       for obtaining the certificates.
                     properties:
+                      clusterID:
+                        default: Kubernetes
+                        description: clusterID is the istio cluster ID to verify incoming
+                          CSRs.
+                        type: string
                       port:
                         default: 443
                         description: port to serve istio-csr gRPC service.

--- a/pkg/controller/istiocsr/deployments.go
+++ b/pkg/controller/istiocsr/deployments.go
@@ -139,6 +139,11 @@ func updatePodTemplateLabels(deployment *appsv1.Deployment, resourceLabels map[s
 
 func updateArgList(deployment *appsv1.Deployment, istiocsr *v1alpha1.IstioCSR) {
 	istiocsrConfigs := istiocsr.Spec.IstioCSRConfig
+	// Default clusterID to "Kubernetes" if not provided.
+	clusterID := "Kubernetes"
+	if istiocsrConfigs.Server != nil && istiocsrConfigs.Server.ClusterID != "" {
+		clusterID = istiocsrConfigs.Server.ClusterID
+	}
 	args := []string{
 		fmt.Sprintf("--log-level=%d", istiocsrConfigs.LogLevel),
 		fmt.Sprintf("--log-format=%s", istiocsrConfigs.LogFormat),
@@ -152,7 +157,7 @@ func updateArgList(deployment *appsv1.Deployment, istiocsr *v1alpha1.IstioCSR) {
 		fmt.Sprintf("--serving-certificate-dns-names=cert-manager-istio-csr.%s.svc", istiocsr.GetNamespace()),
 		fmt.Sprintf("--serving-certificate-duration=%.0fm", istiocsrConfigs.IstiodTLSConfig.CertificateDuration.Minutes()),
 		fmt.Sprintf("--trust-domain=%s", istiocsrConfigs.IstiodTLSConfig.TrustDomain),
-		"--cluster-id=Kubernetes",
+		fmt.Sprintf("--cluster-id=%s", clusterID),
 		fmt.Sprintf("--max-client-certificate-duration=%.0fm", istiocsrConfigs.IstiodTLSConfig.MaxCertificateDuration.Minutes()),
 		"--serving-address=0.0.0.0:6443",
 		fmt.Sprintf("--serving-certificate-key-size=%d", istiocsrConfigs.IstiodTLSConfig.PrivateKeySize),

--- a/pkg/operator/applyconfigurations/operator/v1alpha1/serverconfig.go
+++ b/pkg/operator/applyconfigurations/operator/v1alpha1/serverconfig.go
@@ -5,13 +5,22 @@ package v1alpha1
 // ServerConfigApplyConfiguration represents a declarative configuration of the ServerConfig type for use
 // with apply.
 type ServerConfigApplyConfiguration struct {
-	Port *int32 `json:"port,omitempty"`
+	ClusterID *string `json:"clusterID,omitempty"`
+	Port      *int32  `json:"port,omitempty"`
 }
 
 // ServerConfigApplyConfiguration constructs a declarative configuration of the ServerConfig type for use with
 // apply.
 func ServerConfig() *ServerConfigApplyConfiguration {
 	return &ServerConfigApplyConfiguration{}
+}
+
+// WithClusterID sets the ClusterID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ClusterID field is set to the value of the last call.
+func (b *ServerConfigApplyConfiguration) WithClusterID(value string) *ServerConfigApplyConfiguration {
+	b.ClusterID = &value
+	return b
 }
 
 // WithPort sets the Port field in the declarative configuration to the given value

--- a/test/e2e/config_template.go
+++ b/test/e2e/config_template.go
@@ -25,6 +25,8 @@ type CertificateConfig struct {
 type IstioCSRGRPCurlJobConfig struct {
 	CertificateSigningRequest string
 	IstioCSRStatus            v1alpha1.IstioCSRStatus
+	ClusterID                 string
+	JobName                   string
 }
 
 // replaceWithTemplate puts field values from a template struct

--- a/test/e2e/istio_csr_test.go
+++ b/test/e2e/istio_csr_test.go
@@ -34,6 +34,10 @@ type LogEntry struct {
 	CertChain []string `json:"certChain"`
 }
 
+type IstioCSRConfig struct {
+	ClusterID string
+}
+
 var _ = Describe("Istio-CSR", Ordered, Label("TechPreview", "Feature:IstioCSR"), func() {
 	ctx := context.TODO()
 	var clientset *kubernetes.Clientset
@@ -224,8 +228,16 @@ var _ = Describe("Istio-CSR", Ordered, Label("TechPreview", "Feature:IstioCSR"),
 			grpcAppName := "grpcurl-istio-csr-cluster-id"
 
 			By("creating istiocsr.operator.openshift.io resource with custom clusterID")
-			loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "istio", "istio_csr_custom_cluster_id.yaml"), ns.Name)
-			defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "istio", "istio_csr_custom_cluster_id.yaml"), ns.Name)
+			loader.CreateFromFile(AssetFunc(testassets.ReadFile).WithTemplateValues(
+				IstioCSRConfig{
+					ClusterID: clusterName,
+				},
+			), filepath.Join("testdata", "istio", "istio_csr_custom_cluster_id.yaml"), ns.Name)
+			defer loader.DeleteFromFile(AssetFunc(testassets.ReadFile).WithTemplateValues(
+				IstioCSRConfig{
+					ClusterID: clusterName,
+				},
+			), filepath.Join("testdata", "istio", "istio_csr_custom_cluster_id.yaml"), ns.Name)
 
 			istioCSRStatus := waitForIstioCSRReady(ns)
 
@@ -241,7 +253,7 @@ var _ = Describe("Istio-CSR", Ordered, Label("TechPreview", "Feature:IstioCSR"),
 				IstioCSRGRPCurlJobConfig{
 					CertificateSigningRequest: csr,
 					IstioCSRStatus:            istioCSRStatus,
-					ClusterID:                 "test-cluster-id", // matches the IstioCSR resource
+					ClusterID:                 clusterName, // matches the IstioCSR resource
 					JobName:                   grpcAppName,
 				},
 			), filepath.Join("testdata", "istio", "grpcurl_job_with_cluster_id.yaml"), ns.Name)
@@ -284,8 +296,16 @@ var _ = Describe("Istio-CSR", Ordered, Label("TechPreview", "Feature:IstioCSR"),
 			grpcAppName := "grpcurl-istio-csr-wrong-cluster-id"
 
 			By("creating istiocsr.operator.openshift.io resource with custom clusterID")
-			loader.CreateFromFile(testassets.ReadFile, filepath.Join("testdata", "istio", "istio_csr_custom_cluster_id.yaml"), ns.Name)
-			defer loader.DeleteFromFile(testassets.ReadFile, filepath.Join("testdata", "istio", "istio_csr_custom_cluster_id.yaml"), ns.Name)
+			loader.CreateFromFile(AssetFunc(testassets.ReadFile).WithTemplateValues(
+				IstioCSRConfig{
+					ClusterID: clusterName,
+				},
+			), filepath.Join("testdata", "istio", "istio_csr_custom_cluster_id.yaml"), ns.Name)
+			defer loader.DeleteFromFile(AssetFunc(testassets.ReadFile).WithTemplateValues(
+				IstioCSRConfig{
+					ClusterID: clusterName,
+				},
+			), filepath.Join("testdata", "istio", "istio_csr_custom_cluster_id.yaml"), ns.Name)
 
 			istioCSRStatus := waitForIstioCSRReady(ns)
 

--- a/test/e2e/testdata/istio/grpcurl_job_with_cluster_id.yaml
+++ b/test/e2e/testdata/istio/grpcurl_job_with_cluster_id.yaml
@@ -1,0 +1,62 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.JobName}}
+spec:
+  backoffLimit: 10
+  completions: 1
+  template:
+    metadata:
+      labels:
+        app: {{.JobName}}
+      name: {{.JobName}}
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - args:
+            - |
+              go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.9.2 >/dev/null 2>&1 && \
+              TOKEN=$(cat /var/run/secrets/istio-ca/token) && \
+              /tmp/go/bin/grpcurl \
+                -import-path /proto \
+                -proto /proto/ca.proto \
+                -H "Authorization: Bearer $TOKEN" \
+                -d '{"csr": "{{.CertificateSigningRequest}}", "validity_duration": 3600, "metadata": {"clusterid": "{{.ClusterID}}"}}' \
+                -cacert /etc/root-secret/ca.crt \
+                -key /etc/root-secret/tls.key \
+                -cert /etc/root-secret/tls.crt \
+                {{.IstioCSRStatus.IstioCSRGRPCEndpoint}} istio.v1.auth.IstioCertificateService/CreateCertificate
+          command:
+            - /bin/sh
+            - -c
+          env:
+            - name: GOCACHE
+              value: /tmp/go-cache
+            - name: GOPATH
+              value: /tmp/go
+          image: registry.redhat.io/rhel9/go-toolset
+          name: grpcurl
+          volumeMounts:
+            - mountPath: /etc/root-secret
+              name: root-secret
+            - mountPath: /proto
+              name: proto
+            - mountPath: /var/run/secrets/istio-ca
+              name: sa-token
+      restartPolicy: OnFailure
+      serviceAccountName: "{{.IstioCSRStatus.ServiceAccount}}"
+      volumes:
+        - name: sa-token
+          projected:
+            defaultMode: 420
+            sources:
+              - serviceAccountToken:
+                  audience: istio-ca
+                  expirationSeconds: 3600
+                  path: token
+        - name: root-secret
+          secret:
+            secretName: istiod-tls
+        - configMap:
+            name: proto-cm
+          name: proto

--- a/test/e2e/testdata/istio/grpcurl_job_with_cluster_id.yaml
+++ b/test/e2e/testdata/istio/grpcurl_job_with_cluster_id.yaml
@@ -44,7 +44,7 @@ spec:
               name: proto
             - mountPath: /var/run/secrets/istio-ca
               name: sa-token
-      restartPolicy: OnFailure
+      restartPolicy: Never
       serviceAccountName: "{{.IstioCSRStatus.ServiceAccount}}"
       volumes:
         - name: sa-token

--- a/test/e2e/testdata/istio/grpcurl_job_with_cluster_id.yaml
+++ b/test/e2e/testdata/istio/grpcurl_job_with_cluster_id.yaml
@@ -21,7 +21,8 @@ spec:
                 -import-path /proto \
                 -proto /proto/ca.proto \
                 -H "Authorization: Bearer $TOKEN" \
-                -d '{"csr": "{{.CertificateSigningRequest}}", "validity_duration": 3600, "metadata": {"clusterid": "{{.ClusterID}}"}}' \
+                -H "ClusterID: {{.ClusterID}}" \
+                -d '{"csr": "{{.CertificateSigningRequest}}", "validity_duration": 3600}' \
                 -cacert /etc/root-secret/ca.crt \
                 -key /etc/root-secret/tls.key \
                 -cert /etc/root-secret/tls.crt \

--- a/test/e2e/testdata/istio/istio_csr_custom_cluster_id.yaml
+++ b/test/e2e/testdata/istio/istio_csr_custom_cluster_id.yaml
@@ -15,4 +15,4 @@ spec:
     istio:
       namespace: istio-system
     server:
-      clusterID: test-cluster-id
+      clusterID: {{.ClusterID}}

--- a/test/e2e/testdata/istio/istio_csr_custom_cluster_id.yaml
+++ b/test/e2e/testdata/istio/istio_csr_custom_cluster_id.yaml
@@ -1,0 +1,18 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: IstioCSR
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  istioCSRConfig:
+    certManager:
+      issuerRef:
+        name: istio-ca
+        kind: Issuer
+        group: cert-manager.io
+    istiodTLSConfig:
+      trustDomain: cluster.local
+    istio:
+      namespace: istio-system
+    server:
+      clusterID: test-cluster-id


### PR DESCRIPTION
## Description
This PR extends the `istiocsr.operator.openshift.io` API to allow configuration of the Istio Cluster ID.

The istio-csr component validates incoming `CreateCertificate` gRPC requests from Istio by checking the `clusterid` in the request metadata. This change introduces a `clusterID` field in the IstioCSR spec, allowing users to specify the expected clusterID.

If the `clusterID` is not specified, it defaults to `"Kubernetes"`. This value is then passed as the `--cluster-id` command-line argument to the istio-csr deployment.