### PR TITLE
CM-675: Rebase istio-csr with upstream v0.14.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # - use environment variables to overwrite this value (e.g export BUNDLE_VERSION=0.0.2)
 BUNDLE_VERSION ?= 1.17.0
 CERT_MANAGER_VERSION ?= "v1.17.4"
-ISTIO_CSR_VERSION ?= "v0.14.0"
+ISTIO_CSR_VERSION ?= "v0.14.2"
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bindata/istio-csr/cert-manager-istio-csr-clusterrole.yaml
+++ b/bindata/istio-csr/cert-manager-istio-csr-clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
   name: cert-manager-istio-csr
 rules:

--- a/bindata/istio-csr/cert-manager-istio-csr-clusterrolebinding.yaml
+++ b/bindata/istio-csr/cert-manager-istio-csr-clusterrolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
   name: cert-manager-istio-csr
 roleRef:

--- a/bindata/istio-csr/cert-manager-istio-csr-deployment.yaml
+++ b/bindata/istio-csr/cert-manager-istio-csr-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
 spec:
   replicas: 1
@@ -19,14 +19,14 @@ spec:
         app: cert-manager-istio-csr
         app.kubernetes.io/name: cert-manager-istio-csr
         app.kubernetes.io/instance: cert-manager-istio-csr
-        app.kubernetes.io/version: v0.14.0
+        app.kubernetes.io/version: v0.14.2
     spec:
       serviceAccountName: cert-manager-istio-csr
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: cert-manager-istio-csr
-          image: quay.io/jetstack/cert-manager-istio-csr:v0.14.0
+          image: quay.io/jetstack/cert-manager-istio-csr:v0.14.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 6443
@@ -80,3 +80,5 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault

--- a/bindata/istio-csr/cert-manager-istio-csr-leases-role.yaml
+++ b/bindata/istio-csr/cert-manager-istio-csr-leases-role.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
   name: cert-manager-istio-csr-leases
   namespace: istio-system

--- a/bindata/istio-csr/cert-manager-istio-csr-leases-rolebinding.yaml
+++ b/bindata/istio-csr/cert-manager-istio-csr-leases-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/istio-csr/cert-manager-istio-csr-role.yaml
+++ b/bindata/istio-csr/cert-manager-istio-csr-role.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
   name: cert-manager-istio-csr
   namespace: istio-system

--- a/bindata/istio-csr/cert-manager-istio-csr-rolebinding.yaml
+++ b/bindata/istio-csr/cert-manager-istio-csr-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/istio-csr/cert-manager-istio-csr-service.yaml
+++ b/bindata/istio-csr/cert-manager-istio-csr-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: cert-manager-istio-csr
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
 spec:
   type: ClusterIP

--- a/bindata/istio-csr/cert-manager-istio-csr-serviceaccount.yaml
+++ b/bindata/istio-csr/cert-manager-istio-csr-serviceaccount.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
   name: cert-manager-istio-csr
   namespace: cert-manager

--- a/bindata/istio-csr/istiod-certificate.yaml
+++ b/bindata/istio-csr/istiod-certificate.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
 spec:
   commonName: istiod.istio-system.svc

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -664,11 +664,11 @@ spec:
                 - name: RELATED_IMAGE_CERT_MANAGER_ACMESOLVER
                   value: quay.io/jetstack/cert-manager-acmesolver:v1.17.4
                 - name: RELATED_IMAGE_CERT_MANAGER_ISTIOCSR
-                  value: quay.io/jetstack/cert-manager-istio-csr:v0.14.0
+                  value: quay.io/jetstack/cert-manager-istio-csr:v0.14.2
                 - name: OPERAND_IMAGE_VERSION
                   value: 1.17.4
                 - name: ISTIOCSR_OPERAND_IMAGE_VERSION
-                  value: 0.14.0
+                  value: 0.14.2
                 - name: OPERATOR_IMAGE_VERSION
                   value: 1.17.0
                 - name: OPERATOR_LOG_LEVEL
@@ -772,7 +772,7 @@ spec:
     name: cert-manager-controller
   - image: quay.io/jetstack/cert-manager-acmesolver:v1.17.4
     name: cert-manager-acmesolver
-  - image: quay.io/jetstack/cert-manager-istio-csr:v0.14.0
+  - image: quay.io/jetstack/cert-manager-istio-csr:v0.14.2
     name: cert-manager-istiocsr
   replaces: cert-manager-operator.v1.16.1
   version: 1.17.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -83,11 +83,11 @@ spec:
             - name: RELATED_IMAGE_CERT_MANAGER_ACMESOLVER
               value: quay.io/jetstack/cert-manager-acmesolver:v1.17.4
             - name: RELATED_IMAGE_CERT_MANAGER_ISTIOCSR
-              value: quay.io/jetstack/cert-manager-istio-csr:v0.14.0
+              value: quay.io/jetstack/cert-manager-istio-csr:v0.14.2
             - name: OPERAND_IMAGE_VERSION
               value: 1.17.4
             - name: ISTIOCSR_OPERAND_IMAGE_VERSION
-              value: 0.14.0
+              value: 0.14.2
             - name: OPERATOR_IMAGE_VERSION
               value: 1.17.0
             - name: OPERATOR_LOG_LEVEL

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -2263,7 +2263,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
   name: cert-manager-istio-csr
 rules:
@@ -2314,7 +2314,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
   name: cert-manager-istio-csr
 roleRef:
@@ -2350,7 +2350,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
 spec:
   replicas: 1
@@ -2363,14 +2363,14 @@ spec:
         app: cert-manager-istio-csr
         app.kubernetes.io/name: cert-manager-istio-csr
         app.kubernetes.io/instance: cert-manager-istio-csr
-        app.kubernetes.io/version: v0.14.0
+        app.kubernetes.io/version: v0.14.2
     spec:
       serviceAccountName: cert-manager-istio-csr
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: cert-manager-istio-csr
-          image: quay.io/jetstack/cert-manager-istio-csr:v0.14.0
+          image: quay.io/jetstack/cert-manager-istio-csr:v0.14.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 6443
@@ -2424,6 +2424,8 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
 `)
 
 func istioCsrCertManagerIstioCsrDeploymentYamlBytes() ([]byte, error) {
@@ -2447,7 +2449,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
   name: cert-manager-istio-csr-leases
   namespace: istio-system
@@ -2493,7 +2495,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2526,7 +2528,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
   name: cert-manager-istio-csr
   namespace: istio-system
@@ -2573,7 +2575,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2609,7 +2611,7 @@ metadata:
     app: cert-manager-istio-csr
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
 spec:
   type: ClusterIP
@@ -2643,7 +2645,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
   name: cert-manager-istio-csr
   namespace: cert-manager
@@ -2672,7 +2674,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cert-manager-istio-csr
     app.kubernetes.io/instance: cert-manager-istio-csr
-    app.kubernetes.io/version: v0.14.0
+    app.kubernetes.io/version: v0.14.2
     app.kubernetes.io/managed-by: cert-manager-operator
 spec:
   commonName: istiod.istio-system.svc


### PR DESCRIPTION
Rebase istio-csr with upstream v0.14.2

## Steps followed

- Update bindata manifests with istio-csr 0.14.2 

    - update Makefile `ISTIO_CSR_VERSION`=v0.14.2
    - make update
    - make update-manifests update-bindata
- Manual replacement in `config/manager/manager.yaml`

