### PR TITLE
[DNM] : Verify OLMv1 based installation and testing

### DIFF
--- a/olmv1.yaml
+++ b/olmv1.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift-cert-manager-operator-installer
+  namespace: cert-manager-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-cert-manager-operator-installer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: openshift-cert-manager-operator-installer
+    namespace: cert-manager-operator
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: openshift-cert-manager-operator
+spec:
+  namespace: cert-manager-operator
+  serviceAccount:
+    name: openshift-cert-manager-operator-installer
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: openshift-cert-manager-operator

--- a/test/e2e/certificates_test.go
+++ b/test/e2e/certificates_test.go
@@ -220,8 +220,8 @@ var _ = Describe("ACME Certificate", Ordered, func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("setting cloud credential secret name in subscription object")
-			err = patchSubscriptionWithEnvVars(ctx, loader, map[string]string{
+			By("setting cloud credential secret name in operator deployment")
+			err = patchOperatorDeploymentWithEnvVars(ctx, loader.KubeClient, map[string]string{
 				"CLOUD_CREDENTIALS_SECRET_NAME": "aws-creds",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -317,8 +317,8 @@ var _ = Describe("ACME Certificate", Ordered, func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("setting cloud credential secret name in subscription object")
-			err = patchSubscriptionWithEnvVars(ctx, loader, map[string]string{
+			By("setting cloud credential secret name in operator deployment")
+			err = patchOperatorDeploymentWithEnvVars(ctx, loader.KubeClient, map[string]string{
 				"CLOUD_CREDENTIALS_SECRET_NAME": "aws-creds",
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -523,8 +523,8 @@ var _ = Describe("ACME Certificate", Ordered, func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Configure cert-manager to use credential, setting this credential secret name in subscription object")
-			err = patchSubscriptionWithEnvVars(ctx, loader, map[string]string{
+			By("Configure cert-manager to use credential, setting this credential secret name in operator deployment")
+			err = patchOperatorDeploymentWithEnvVars(ctx, loader.KubeClient, map[string]string{
 				"CLOUD_CREDENTIALS_SECRET_NAME": credentialSecret,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/istio_csr_test.go
+++ b/test/e2e/istio_csr_test.go
@@ -79,8 +79,8 @@ var _ = Describe("Istio-CSR", Ordered, Label("TechPreview", "Feature:IstioCSR"),
 		clientset, err = kubernetes.NewForConfig(cfg)
 		Expect(err).Should(BeNil())
 
-		By("enable IstioCSR addon feature by patching subscription object")
-		err = patchSubscriptionWithEnvVars(ctx, loader, map[string]string{
+		By("enable IstioCSR addon feature by patching operator deployment")
+		err = patchOperatorDeploymentWithEnvVars(ctx, loader.KubeClient, map[string]string{
 			"UNSUPPORTED_ADDON_FEATURES": "IstioCSR=true",
 			"OPERATOR_LOG_LEVEL":         "6",
 		})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -132,4 +132,8 @@ var _ = BeforeSuite(func() {
 	By("creating cert-manager client")
 	certmanagerClient, err = certmanagerclientset.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())
+
+	By("storing initial operator deployment environment variables")
+	err = storeInitialOperatorEnvVars(context.Background(), k8sClientSet)
+	Expect(err).NotTo(HaveOccurred())
 })


### PR DESCRIPTION
_**Do not review or merge this PR.**_ 

Currently, operator relies on `subscription.operators.coreos.com` of OLMv0 for its functionality.

- Work is in-progress to extend `clusterextension.olm.operatorframework.io` of OLMv1 with provision to set environment variables.
    - Ref: https://redhat-internal.slack.com/archives/C097W1N3UQ6/p1756742784139879
    - Tracker: https://issues.redhat.com/browse/OCPSTRAT-2305

This PR is just a workaround to modify the e2e to remove the dependency on `Subscription` to inject env vars, and instead update the operator deployment directly. 


/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a manifest to install the OpenShift cert-manager operator via OLM, creating the operator namespace, installer service account, cluster role binding, and a cluster extension that references the operator package.

- Tests
  - E2E tests now patch the operator Deployment environment directly (instead of the subscription).
  - Tests capture initial operator env vars at setup and restore them after runs for more reliable, deterministic tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->