### PR TITLE
CM-718: Enhance tests for overriding replicas of HA deployment

### DIFF
--- a/api/operator/v1alpha1/certmanager_types.go
+++ b/api/operator/v1alpha1/certmanager_types.go
@@ -82,7 +82,8 @@ type DeploymentConfig struct {
 	// +optional
 	OverrideResources CertManagerResourceRequirements `json:"overrideResources,omitempty"`
 
-	// OverrideReplicas defines the number of replicas to run for an operand
+	// OverrideReplicas defines the number of replicas for the operand deployment.
+	// If not specified, the default replicas from the deployment manifest will be used.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=1
 	// +optional

--- a/bundle/manifests/operator.openshift.io_certmanagers.yaml
+++ b/bundle/manifests/operator.openshift.io_certmanagers.yaml
@@ -178,8 +178,9 @@ spec:
                       type: string
                     type: object
                   overrideReplicas:
-                    description: OverrideReplicas defines the number of replicas to
-                      run for an operand
+                    description: |-
+                      OverrideReplicas defines the number of replicas for the operand deployment.
+                      If not specified, the default replicas from the deployment manifest will be used.
                     format: int32
                     minimum: 1
                     type: integer
@@ -420,8 +421,9 @@ spec:
                       type: string
                     type: object
                   overrideReplicas:
-                    description: OverrideReplicas defines the number of replicas to
-                      run for an operand
+                    description: |-
+                      OverrideReplicas defines the number of replicas for the operand deployment.
+                      If not specified, the default replicas from the deployment manifest will be used.
                     format: int32
                     minimum: 1
                     type: integer
@@ -707,8 +709,9 @@ spec:
                       type: string
                     type: object
                   overrideReplicas:
-                    description: OverrideReplicas defines the number of replicas to
-                      run for an operand
+                    description: |-
+                      OverrideReplicas defines the number of replicas for the operand deployment.
+                      If not specified, the default replicas from the deployment manifest will be used.
                     format: int32
                     minimum: 1
                     type: integer

--- a/config/crd/bases/operator.openshift.io_certmanagers.yaml
+++ b/config/crd/bases/operator.openshift.io_certmanagers.yaml
@@ -178,8 +178,9 @@ spec:
                       type: string
                     type: object
                   overrideReplicas:
-                    description: OverrideReplicas defines the number of replicas to
-                      run for an operand
+                    description: |-
+                      OverrideReplicas defines the number of replicas for the operand deployment.
+                      If not specified, the default replicas from the deployment manifest will be used.
                     format: int32
                     minimum: 1
                     type: integer
@@ -420,8 +421,9 @@ spec:
                       type: string
                     type: object
                   overrideReplicas:
-                    description: OverrideReplicas defines the number of replicas to
-                      run for an operand
+                    description: |-
+                      OverrideReplicas defines the number of replicas for the operand deployment.
+                      If not specified, the default replicas from the deployment manifest will be used.
                     format: int32
                     minimum: 1
                     type: integer
@@ -707,8 +709,9 @@ spec:
                       type: string
                     type: object
                   overrideReplicas:
-                    description: OverrideReplicas defines the number of replicas to
-                      run for an operand
+                    description: |-
+                      OverrideReplicas defines the number of replicas for the operand deployment.
+                      If not specified, the default replicas from the deployment manifest will be used.
                     format: int32
                     minimum: 1
                     type: integer

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -225,8 +225,8 @@ func addOverrideArgs(client *certmanoperatorclient.Clientset, deploymentName str
 	})
 }
 
-// verifyDeploymentArgs polls every 1 second to check if the deployment args list is updated to contain the
-// passed args. It returns an error if a timeout (5 mins) occurs or an error was encountered while polling
+// verifyDeploymentArgs polls every $fastPollInterval to check if the deployment args list is updated to contain the
+// passed args. It returns an error if a timeout ($lowTimeout) occurs or an error was encountered while polling
 // the deployment args list.
 func verifyDeploymentArgs(k8sclient *kubernetes.Clientset, deploymentName string, args []string, added bool) error {
 
@@ -292,8 +292,8 @@ func addOverrideEnv(client *certmanoperatorclient.Clientset, deploymentName stri
 	})
 }
 
-// verifyDeploymentEnv polls every 1 second to check if the deployment env list is updated to contain the
-// passed env. It returns an error if a timeout (5 mins) occurs or an error was encountered while polling
+// verifyDeploymentEnv polls every $fastPollInterval to check if the deployment env list is updated to contain the
+// passed env. It returns an error if a timeout ($lowTimeout) occurs or an error was encountered while polling
 // the deployment env list.
 func verifyDeploymentEnv(k8sclient *kubernetes.Clientset, deploymentName string, env []corev1.EnvVar, added bool) error {
 
@@ -359,8 +359,8 @@ func addOverrideResources(client *certmanoperatorclient.Clientset, deploymentNam
 	})
 }
 
-// verifyDeploymentResources polls every 10 seconds to check if the deployment resources is updated to contain
-// the passed resources. It returns an error if a timeout (5 mins) occurs or an error was encountered while
+// verifyDeploymentResources polls every $slowPollInterval to check if the deployment resources is updated to contain
+// the passed resources. It returns an error if a timeout ($highTimeout) occurs or an error was encountered while
 // polling the deployment resources.
 func verifyDeploymentResources(k8sclient *kubernetes.Clientset, deploymentName string, res v1alpha1.CertManagerResourceRequirements, added bool) error {
 
@@ -430,8 +430,8 @@ func addOverrideScheduling(client *certmanoperatorclient.Clientset, deploymentNa
 	})
 }
 
-// verifyDeploymentScheduling polls every 10 seconds to check if the deployment scheduling is updated to contain
-// the passed scheduling. It returns an error if a timeout (5 mins) occurs or an error was encountered while
+// verifyDeploymentScheduling polls every $slowPollInterval to check if the deployment scheduling is updated to contain
+// the passed scheduling. It returns an error if a timeout ($highTimeout) occurs or an error was encountered while
 // polling the deployment scheduling.
 func verifyDeploymentScheduling(k8sclient *kubernetes.Clientset, deploymentName string, res v1alpha1.CertManagerScheduling, added bool) error {
 
@@ -485,6 +485,75 @@ func verifyDeploymentScheduling(k8sclient *kubernetes.Clientset, deploymentName 
 		}
 
 		return true, nil
+	})
+}
+
+// addOverrideReplicas adds the override replicas to the specific cert-manager operand. The update process
+// is retried if a conflict error is encountered.
+func addOverrideReplicas(client *certmanoperatorclient.Clientset, deploymentName string, replicas *int32) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		operator, err := client.OperatorV1alpha1().CertManagers().Get(context.TODO(), "cluster", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		updatedOperator := operator.DeepCopy()
+
+		switch deploymentName {
+		case certmanagerControllerDeployment:
+			updatedOperator.Spec.ControllerConfig = &v1alpha1.DeploymentConfig{
+				OverrideReplicas: replicas,
+			}
+		case certmanagerWebhookDeployment:
+			updatedOperator.Spec.WebhookConfig = &v1alpha1.DeploymentConfig{
+				OverrideReplicas: replicas,
+			}
+		case certmanagerCAinjectorDeployment:
+			updatedOperator.Spec.CAInjectorConfig = &v1alpha1.DeploymentConfig{
+				OverrideReplicas: replicas,
+			}
+		default:
+			return fmt.Errorf("unsupported deployment name: %s", deploymentName)
+		}
+
+		_, err = client.OperatorV1alpha1().CertManagers().Update(context.TODO(), updatedOperator, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+// verifyDeploymentReplicas polls every $fastPollInterval to check if the deployment replicas is updated to contain
+// the passed replica count. It returns an error if a timeout ($lowTimeout) occurs or an error was encountered while
+// polling the deployment replicas.
+func verifyDeploymentReplicas(k8sclient *kubernetes.Clientset, deploymentName string, expectedReplicas *int32, shouldMatch bool) error {
+
+	return wait.PollUntilContextTimeout(context.TODO(), fastPollInterval, lowTimeout, true, func(context.Context) (bool, error) {
+		deployment, err := k8sclient.AppsV1().Deployments(operandNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		// Get expected replica count - defaults to 1 when nil
+		expectedReplicaCount := int32(1)
+		if expectedReplicas != nil {
+			expectedReplicaCount = *expectedReplicas
+		}
+
+		// Get actual replica count from deployment spec - defaults to 1 when nil
+		actualReplicaCount := int32(1)
+		if deployment.Spec.Replicas != nil {
+			actualReplicaCount = *deployment.Spec.Replicas
+		}
+
+		// Check if spec replica count matches expected
+		replicasMatch := actualReplicaCount == expectedReplicaCount
+
+		if shouldMatch {
+			return replicasMatch, nil
+		}
+		return !replicasMatch, nil
 	})
 }
 
@@ -777,10 +846,14 @@ func pollTillDeploymentAvailable(ctx context.Context, clientSet *kubernetes.Clie
 		}
 
 		// Deployment exists but not ready
+		desired := int32(1)
+		if deployment.Spec.Replicas != nil {
+			desired = *deployment.Spec.Replicas
+		}
 		return fmt.Errorf("timeout waiting for deployment %s/%s: ready %d/%d, updated %d/%d",
 			namespace, deploymentName,
-			deployment.Status.ReadyReplicas, *deployment.Spec.Replicas,
-			deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas)
+			deployment.Status.ReadyReplicas, desired,
+			deployment.Status.UpdatedReplicas, desired)
 	}
 
 	return err

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -205,17 +205,26 @@ func addOverrideArgs(client *certmanoperatorclient.Clientset, deploymentName str
 
 		switch deploymentName {
 		case certmanagerControllerDeployment:
-			updatedOperator.Spec.ControllerConfig = &v1alpha1.DeploymentConfig{
-				OverrideArgs: args,
+			cfg := updatedOperator.Spec.ControllerConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideArgs = args
+			updatedOperator.Spec.ControllerConfig = cfg
 		case certmanagerWebhookDeployment:
-			updatedOperator.Spec.WebhookConfig = &v1alpha1.DeploymentConfig{
-				OverrideArgs: args,
+			cfg := updatedOperator.Spec.WebhookConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideArgs = args
+			updatedOperator.Spec.WebhookConfig = cfg
 		case certmanagerCAinjectorDeployment:
-			updatedOperator.Spec.CAInjectorConfig = &v1alpha1.DeploymentConfig{
-				OverrideArgs: args,
+			cfg := updatedOperator.Spec.CAInjectorConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideArgs = args
+			updatedOperator.Spec.CAInjectorConfig = cfg
 		default:
 			return fmt.Errorf("unsupported deployment name: %s", deploymentName)
 		}
@@ -272,17 +281,26 @@ func addOverrideEnv(client *certmanoperatorclient.Clientset, deploymentName stri
 
 		switch deploymentName {
 		case certmanagerControllerDeployment:
-			updatedOperator.Spec.ControllerConfig = &v1alpha1.DeploymentConfig{
-				OverrideEnv: env,
+			cfg := updatedOperator.Spec.ControllerConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideEnv = env
+			updatedOperator.Spec.ControllerConfig = cfg
 		case certmanagerWebhookDeployment:
-			updatedOperator.Spec.WebhookConfig = &v1alpha1.DeploymentConfig{
-				OverrideEnv: env,
+			cfg := updatedOperator.Spec.WebhookConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideEnv = env
+			updatedOperator.Spec.WebhookConfig = cfg
 		case certmanagerCAinjectorDeployment:
-			updatedOperator.Spec.CAInjectorConfig = &v1alpha1.DeploymentConfig{
-				OverrideEnv: env,
+			cfg := updatedOperator.Spec.CAInjectorConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideEnv = env
+			updatedOperator.Spec.CAInjectorConfig = cfg
 		default:
 			return fmt.Errorf("unsupported deployment name: %s", deploymentName)
 		}
@@ -339,17 +357,26 @@ func addOverrideResources(client *certmanoperatorclient.Clientset, deploymentNam
 
 		switch deploymentName {
 		case certmanagerControllerDeployment:
-			updatedOperator.Spec.ControllerConfig = &v1alpha1.DeploymentConfig{
-				OverrideResources: res,
+			cfg := updatedOperator.Spec.ControllerConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideResources = res
+			updatedOperator.Spec.ControllerConfig = cfg
 		case certmanagerWebhookDeployment:
-			updatedOperator.Spec.WebhookConfig = &v1alpha1.DeploymentConfig{
-				OverrideResources: res,
+			cfg := updatedOperator.Spec.WebhookConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideResources = res
+			updatedOperator.Spec.WebhookConfig = cfg
 		case certmanagerCAinjectorDeployment:
-			updatedOperator.Spec.CAInjectorConfig = &v1alpha1.DeploymentConfig{
-				OverrideResources: res,
+			cfg := updatedOperator.Spec.CAInjectorConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideResources = res
+			updatedOperator.Spec.CAInjectorConfig = cfg
 		default:
 			return fmt.Errorf("unsupported deployment name: %s", deploymentName)
 		}
@@ -410,17 +437,26 @@ func addOverrideScheduling(client *certmanoperatorclient.Clientset, deploymentNa
 
 		switch deploymentName {
 		case certmanagerControllerDeployment:
-			updatedOperator.Spec.ControllerConfig = &v1alpha1.DeploymentConfig{
-				OverrideScheduling: res,
+			cfg := updatedOperator.Spec.ControllerConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideScheduling = res
+			updatedOperator.Spec.ControllerConfig = cfg
 		case certmanagerWebhookDeployment:
-			updatedOperator.Spec.WebhookConfig = &v1alpha1.DeploymentConfig{
-				OverrideScheduling: res,
+			cfg := updatedOperator.Spec.WebhookConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideScheduling = res
+			updatedOperator.Spec.WebhookConfig = cfg
 		case certmanagerCAinjectorDeployment:
-			updatedOperator.Spec.CAInjectorConfig = &v1alpha1.DeploymentConfig{
-				OverrideScheduling: res,
+			cfg := updatedOperator.Spec.CAInjectorConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideScheduling = res
+			updatedOperator.Spec.CAInjectorConfig = cfg
 		default:
 			return fmt.Errorf("unsupported deployment name: %s", deploymentName)
 		}
@@ -501,17 +537,26 @@ func addOverrideReplicas(client *certmanoperatorclient.Clientset, deploymentName
 
 		switch deploymentName {
 		case certmanagerControllerDeployment:
-			updatedOperator.Spec.ControllerConfig = &v1alpha1.DeploymentConfig{
-				OverrideReplicas: replicas,
+			cfg := updatedOperator.Spec.ControllerConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideReplicas = replicas
+			updatedOperator.Spec.ControllerConfig = cfg
 		case certmanagerWebhookDeployment:
-			updatedOperator.Spec.WebhookConfig = &v1alpha1.DeploymentConfig{
-				OverrideReplicas: replicas,
+			cfg := updatedOperator.Spec.WebhookConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideReplicas = replicas
+			updatedOperator.Spec.WebhookConfig = cfg
 		case certmanagerCAinjectorDeployment:
-			updatedOperator.Spec.CAInjectorConfig = &v1alpha1.DeploymentConfig{
-				OverrideReplicas: replicas,
+			cfg := updatedOperator.Spec.CAInjectorConfig
+			if cfg == nil {
+				cfg = &v1alpha1.DeploymentConfig{}
 			}
+			cfg.OverrideReplicas = replicas
+			updatedOperator.Spec.CAInjectorConfig = cfg
 		default:
 			return fmt.Errorf("unsupported deployment name: %s", deploymentName)
 		}


### PR DESCRIPTION
### Background

In https://github.com/openshift/cert-manager-operator/pull/237 we add the option to override the number of replicas for each cert-manager operand (controller, webhook, and cainjector) independently. This enables users to configure high availability setups and scale operands based on their specific operational requirements. This is a followup PR to enhance the tests coverage.

### Verifications

- [x] set replica count to 1 which equals to the default value - no rollout being triggered
- [x] set replica count to zero or minus value - validation failed as expected
- [x] set replica count to 3 for all three operands at same time - rolling update succeeded
- [x] remove `OverrideReplicas` fields completely from `certmanager` CR - rolling update succeeded
- [x] upgrade from existing installation - existing instance without `OverrideReplicas` continue to use default values (1)

### Out of scope

To keep goal focused, this PR doesn't handle `PodDisruptionBudget` or `PriorityClassName` which are also relevant to HA deployment setup. It would require dedicated design review if there is an RFE in future.

**NB: The credit should go to @appiepollo14 for implementing the initial PR** https://github.com/openshift/cert-manager-operator/pull/237