### PR TITLE
CM-639: Adds metrics service creation for istio-csr

### DIFF
--- a/bindata/istio-csr/cert-manager-istio-csr-metrics-service.yaml
+++ b/bindata/istio-csr/cert-manager-istio-csr-metrics-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cert-manager-istio-csr-metrics
+  namespace: cert-manager
+  labels:
+    app: cert-manager-istio-csr-metrics
+    app.kubernetes.io/name: cert-manager-istio-csr
+    app.kubernetes.io/instance: cert-manager-istio-csr
+    app.kubernetes.io/version: v0.14.2
+    app.kubernetes.io/managed-by: cert-manager-operator
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9402
+      targetPort: 9402
+      protocol: TCP
+      name: metrics
+  selector:
+    app: cert-manager-istio-csr

--- a/hack/update-istio-csr-manifests.sh
+++ b/hack/update-istio-csr-manifests.sh
@@ -40,10 +40,7 @@ mkdir -p bindata/istio-csr
   kind=$(echo "$item" | ./bin/yq eval '.kind' - | tr '[:upper:]' '[:lower:]')
 
   # skip unused manifests
-  if [[ "${name}-${kind}" == "cert-manager-istio-csr-metrics-service" || \
-        "${name}-${kind}" == "cert-manager-istio-csr-dynamic-istiod-rolebinding" \
-  ]]; then
-    
+  if [[ "${name}-${kind}" == "cert-manager-istio-csr-dynamic-istiod-rolebinding" ]]; then
     continue
   fi
   

--- a/pkg/controller/istiocsr/certificates.go
+++ b/pkg/controller/istiocsr/certificates.go
@@ -5,7 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -23,11 +23,7 @@ func (r *Reconciler) createOrApplyCertificates(istiocsr *v1alpha1.IstioCSR, reso
 	certificateName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling certificate resource", "name", certificateName)
 	fetched := &certmanagerv1.Certificate{}
-	key := types.NamespacedName{
-		Name:      desired.GetName(),
-		Namespace: desired.GetNamespace(),
-	}
-	exist, err := r.Exists(r.ctx, key, fetched)
+	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), fetched)
 	if err != nil {
 		return FromClientError(err, "failed to check %s certificate resource already exists", certificateName)
 	}

--- a/pkg/controller/istiocsr/client.go
+++ b/pkg/controller/istiocsr/client.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,7 +73,7 @@ func (c *ctrlClientImpl) Update(
 func (c *ctrlClientImpl) UpdateWithRetry(
 	ctx context.Context, obj client.Object, opts ...client.UpdateOption,
 ) error {
-	key := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+	key := client.ObjectKeyFromObject(obj)
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		current := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(client.Object)
 		if err := c.Client.Get(ctx, key, current); err != nil {

--- a/pkg/controller/istiocsr/constants.go
+++ b/pkg/controller/istiocsr/constants.go
@@ -111,6 +111,7 @@ const (
 	roleBindingAssetName        = "istio-csr/cert-manager-istio-csr-rolebinding.yaml"
 	roleBindingLeasesAssetName  = "istio-csr/cert-manager-istio-csr-leases-rolebinding.yaml"
 	serviceAssetName            = "istio-csr/cert-manager-istio-csr-service.yaml"
+	metricsServiceAssetName     = "istio-csr/cert-manager-istio-csr-metrics-service.yaml"
 	serviceAccountAssetName     = "istio-csr/cert-manager-istio-csr-serviceaccount.yaml"
 )
 

--- a/pkg/controller/istiocsr/deployments.go
+++ b/pkg/controller/istiocsr/deployments.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/core"
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -39,11 +38,7 @@ func (r *Reconciler) createOrApplyDeployments(istiocsr *v1alpha1.IstioCSR, resou
 	deploymentName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling deployment resource", "name", deploymentName)
 	fetched := &appsv1.Deployment{}
-	key := types.NamespacedName{
-		Name:      desired.GetName(),
-		Namespace: desired.GetNamespace(),
-	}
-	exist, err := r.Exists(r.ctx, key, fetched)
+	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), fetched)
 	if err != nil {
 		return FromClientError(err, "failed to check %s deployment resource already exists", deploymentName)
 	}

--- a/pkg/controller/istiocsr/deployments.go
+++ b/pkg/controller/istiocsr/deployments.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/core"
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
@@ -331,7 +330,7 @@ func updateVolumeWithIssuerCA(deployment *appsv1.Deployment) {
 
 func (r *Reconciler) getIssuer(istiocsr *v1alpha1.IstioCSR) (client.Object, error) {
 	issuerRefKind := strings.ToLower(istiocsr.Spec.IstioCSRConfig.CertManager.IssuerRef.Kind)
-	namespacedName := types.NamespacedName{
+	key := client.ObjectKey{
 		Name:      istiocsr.Spec.IstioCSRConfig.CertManager.IssuerRef.Name,
 		Namespace: istiocsr.Spec.IstioCSRConfig.Istio.Namespace,
 	}
@@ -344,8 +343,8 @@ func (r *Reconciler) getIssuer(istiocsr *v1alpha1.IstioCSR) (client.Object, erro
 		object = &certmanagerv1.Issuer{}
 	}
 
-	if err := r.Get(r.ctx, namespacedName, object); err != nil {
-		return nil, fmt.Errorf("failed to fetch %q issuer: %w", namespacedName, err)
+	if err := r.Get(r.ctx, key, object); err != nil {
+		return nil, fmt.Errorf("failed to fetch %q issuer: %w", key, err)
 	}
 	return object, nil
 }
@@ -355,7 +354,7 @@ func (r *Reconciler) createCAConfigMap(istiocsr *v1alpha1.IstioCSR, issuerConfig
 		return nil
 	}
 
-	secretKey := types.NamespacedName{
+	secretKey := client.ObjectKey{
 		Name:      issuerConfig.CA.SecretName,
 		Namespace: istiocsr.Spec.IstioCSRConfig.Istio.Namespace,
 	}
@@ -367,7 +366,7 @@ func (r *Reconciler) createCAConfigMap(istiocsr *v1alpha1.IstioCSR, issuerConfig
 		return err
 	}
 
-	configmapKey := types.NamespacedName{
+	configmapKey := client.ObjectKey{
 		Name:      istiocsrCAConfigMapName,
 		Namespace: istiocsr.GetNamespace(),
 	}

--- a/pkg/controller/istiocsr/rbacs.go
+++ b/pkg/controller/istiocsr/rbacs.go
@@ -5,7 +5,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
@@ -60,14 +59,14 @@ func (r *Reconciler) createOrApplyClusterRoles(istiocsr *v1alpha1.IstioCSR, reso
 		exist    bool
 		err      error
 		roleName string
-		key      types.NamespacedName
+		key      client.ObjectKey
 		fetched  = &rbacv1.ClusterRole{}
 	)
 	r.log.V(4).Info("reconciling clusterrole resource created for istiocsr", "namespace", istiocsr.GetNamespace(), "name", istiocsr.GetName())
 	if istiocsr.Status.ClusterRole != "" {
 		roleName = fmt.Sprintf("%s/%s", desired.GetNamespace(), istiocsr.Status.ClusterRole)
 		fetched = &rbacv1.ClusterRole{}
-		key = types.NamespacedName{
+		key = client.ObjectKey{
 			Name:      istiocsr.Status.ClusterRole,
 			Namespace: desired.GetNamespace(),
 		}
@@ -153,14 +152,14 @@ func (r *Reconciler) createOrApplyClusterRoleBindings(istiocsr *v1alpha1.IstioCS
 		exist           bool
 		err             error
 		roleBindingName string
-		key             types.NamespacedName
+		key             client.ObjectKey
 		fetched         = &rbacv1.ClusterRoleBinding{}
 	)
 	r.log.V(4).Info("reconciling clusterrolebinding resource created for istiocsr", "namespace", istiocsr.GetNamespace(), "name", istiocsr.GetName())
 	if istiocsr.Status.ClusterRoleBinding != "" {
 		roleBindingName = fmt.Sprintf("%s/%s", desired.GetNamespace(), istiocsr.Status.ClusterRoleBinding)
 		fetched = &rbacv1.ClusterRoleBinding{}
-		key = types.NamespacedName{
+		key = client.ObjectKey{
 			Name:      istiocsr.Status.ClusterRoleBinding,
 			Namespace: desired.GetNamespace(),
 		}

--- a/pkg/controller/istiocsr/rbacs.go
+++ b/pkg/controller/istiocsr/rbacs.go
@@ -6,7 +6,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
@@ -243,11 +242,7 @@ func (r *Reconciler) createOrApplyRoles(istiocsr *v1alpha1.IstioCSR, resourceLab
 	roleName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling role resource", "name", roleName)
 	fetched := &rbacv1.Role{}
-	key := types.NamespacedName{
-		Name:      desired.GetName(),
-		Namespace: desired.GetNamespace(),
-	}
-	exist, err := r.Exists(r.ctx, key, fetched)
+	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), fetched)
 	if err != nil {
 		return FromClientError(err, "failed to check %s role resource already exists", roleName)
 	}
@@ -287,11 +282,7 @@ func (r *Reconciler) createOrApplyRoleBindings(istiocsr *v1alpha1.IstioCSR, serv
 	roleBindingName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling rolebinding resource", "name", roleBindingName)
 	fetched := &rbacv1.RoleBinding{}
-	key := types.NamespacedName{
-		Name:      desired.GetName(),
-		Namespace: desired.GetNamespace(),
-	}
-	exist, err := r.Exists(r.ctx, key, fetched)
+	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), fetched)
 	if err != nil {
 		return FromClientError(err, "failed to check %s rolebinding resource already exists", roleBindingName)
 	}
@@ -333,11 +324,7 @@ func (r *Reconciler) createOrApplyRoleForLeases(istiocsr *v1alpha1.IstioCSR, res
 	roleName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling role for lease resource", "name", roleName)
 	fetched := &rbacv1.Role{}
-	key := types.NamespacedName{
-		Name:      desired.GetName(),
-		Namespace: desired.GetNamespace(),
-	}
-	exist, err := r.Exists(r.ctx, key, fetched)
+	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), fetched)
 	if err != nil {
 		return FromClientError(err, "failed to check %s role resource already exists", roleName)
 	}
@@ -377,11 +364,7 @@ func (r *Reconciler) createOrApplyRoleBindingForLeases(istiocsr *v1alpha1.IstioC
 	roleBindingName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling rolebinding for lease resource", "name", roleBindingName)
 	fetched := &rbacv1.RoleBinding{}
-	key := types.NamespacedName{
-		Name:      desired.GetName(),
-		Namespace: desired.GetNamespace(),
-	}
-	exist, err := r.Exists(r.ctx, key, fetched)
+	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), fetched)
 	if err != nil {
 		return FromClientError(err, "failed to check %s rolebinding resource already exists", roleBindingName)
 	}

--- a/pkg/controller/istiocsr/serviceaccounts.go
+++ b/pkg/controller/istiocsr/serviceaccounts.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
 	"github.com/openshift/cert-manager-operator/pkg/operator/assets"
@@ -16,11 +16,7 @@ func (r *Reconciler) createOrApplyServiceAccounts(istiocsr *v1alpha1.IstioCSR, r
 	serviceAccountName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling serviceaccount resource", "name", serviceAccountName)
 	fetched := &corev1.ServiceAccount{}
-	key := types.NamespacedName{
-		Name:      desired.GetName(),
-		Namespace: desired.GetNamespace(),
-	}
-	exist, err := r.Exists(r.ctx, key, fetched)
+	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), fetched)
 	if err != nil {
 		return FromClientError(err, "failed to check %s serviceaccount resource already exists", serviceAccountName)
 	}

--- a/pkg/controller/istiocsr/utils.go
+++ b/pkg/controller/istiocsr/utils.go
@@ -11,10 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/retry"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -45,7 +43,7 @@ func init() {
 
 // updateStatus is for updating the status subresource of istiocsr.openshift.operator.io.
 func (r *Reconciler) updateStatus(ctx context.Context, changed *v1alpha1.IstioCSR) error {
-	namespacedName := types.NamespacedName{Name: changed.Name, Namespace: changed.Namespace}
+	namespacedName := client.ObjectKeyFromObject(changed)
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		r.log.V(4).Info("updating istiocsr.openshift.operator.io status", "request", namespacedName)
 		current := &v1alpha1.IstioCSR{}
@@ -68,7 +66,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, changed *v1alpha1.IstioCS
 
 // addFinalizer adds finalizer to istiocsr.openshift.operator.io resource.
 func (r *Reconciler) addFinalizer(ctx context.Context, istiocsr *v1alpha1.IstioCSR) error {
-	namespacedName := types.NamespacedName{Name: istiocsr.Name, Namespace: istiocsr.Namespace}
+	namespacedName := client.ObjectKeyFromObject(istiocsr)
 	if !controllerutil.ContainsFinalizer(istiocsr, finalizer) {
 		if !controllerutil.AddFinalizer(istiocsr, finalizer) {
 			return fmt.Errorf("failed to create %q istiocsr.openshift.operator.io object with finalizers added", namespacedName)
@@ -91,7 +89,7 @@ func (r *Reconciler) addFinalizer(ctx context.Context, istiocsr *v1alpha1.IstioC
 
 // removeFinalizer removes finalizers added to istiocsr.openshift.operator.io resource.
 func (r *Reconciler) removeFinalizer(ctx context.Context, istiocsr *v1alpha1.IstioCSR, finalizer string) error {
-	namespacedName := types.NamespacedName{Name: istiocsr.Name, Namespace: istiocsr.Namespace}
+	namespacedName := client.ObjectKeyFromObject(istiocsr)
 	if controllerutil.ContainsFinalizer(istiocsr, finalizer) {
 		if !controllerutil.RemoveFinalizer(istiocsr, finalizer) {
 			return fmt.Errorf("failed to create %q istiocsr.openshift.operator.io object with finalizers removed", namespacedName)

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -48,6 +48,7 @@
 // bindata/istio-csr/cert-manager-istio-csr-deployment.yaml
 // bindata/istio-csr/cert-manager-istio-csr-leases-role.yaml
 // bindata/istio-csr/cert-manager-istio-csr-leases-rolebinding.yaml
+// bindata/istio-csr/cert-manager-istio-csr-metrics-service.yaml
 // bindata/istio-csr/cert-manager-istio-csr-role.yaml
 // bindata/istio-csr/cert-manager-istio-csr-rolebinding.yaml
 // bindata/istio-csr/cert-manager-istio-csr-service.yaml
@@ -2523,6 +2524,43 @@ func istioCsrCertManagerIstioCsrLeasesRolebindingYaml() (*asset, error) {
 	return a, nil
 }
 
+var _istioCsrCertManagerIstioCsrMetricsServiceYaml = []byte(`apiVersion: v1
+kind: Service
+metadata:
+  name: cert-manager-istio-csr-metrics
+  namespace: cert-manager
+  labels:
+    app: cert-manager-istio-csr-metrics
+    app.kubernetes.io/name: cert-manager-istio-csr
+    app.kubernetes.io/instance: cert-manager-istio-csr
+    app.kubernetes.io/version: v0.14.2
+    app.kubernetes.io/managed-by: cert-manager-operator
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9402
+      targetPort: 9402
+      protocol: TCP
+      name: metrics
+  selector:
+    app: cert-manager-istio-csr
+`)
+
+func istioCsrCertManagerIstioCsrMetricsServiceYamlBytes() ([]byte, error) {
+	return _istioCsrCertManagerIstioCsrMetricsServiceYaml, nil
+}
+
+func istioCsrCertManagerIstioCsrMetricsServiceYaml() (*asset, error) {
+	bytes, err := istioCsrCertManagerIstioCsrMetricsServiceYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "istio-csr/cert-manager-istio-csr-metrics-service.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _istioCsrCertManagerIstioCsrRoleYaml = []byte(`kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -2812,6 +2850,7 @@ var _bindata = map[string]func() (*asset, error){
 	"istio-csr/cert-manager-istio-csr-deployment.yaml":                                                 istioCsrCertManagerIstioCsrDeploymentYaml,
 	"istio-csr/cert-manager-istio-csr-leases-role.yaml":                                                istioCsrCertManagerIstioCsrLeasesRoleYaml,
 	"istio-csr/cert-manager-istio-csr-leases-rolebinding.yaml":                                         istioCsrCertManagerIstioCsrLeasesRolebindingYaml,
+	"istio-csr/cert-manager-istio-csr-metrics-service.yaml":                                            istioCsrCertManagerIstioCsrMetricsServiceYaml,
 	"istio-csr/cert-manager-istio-csr-role.yaml":                                                       istioCsrCertManagerIstioCsrRoleYaml,
 	"istio-csr/cert-manager-istio-csr-rolebinding.yaml":                                                istioCsrCertManagerIstioCsrRolebindingYaml,
 	"istio-csr/cert-manager-istio-csr-service.yaml":                                                    istioCsrCertManagerIstioCsrServiceYaml,
@@ -2921,6 +2960,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"cert-manager-istio-csr-deployment.yaml":         {istioCsrCertManagerIstioCsrDeploymentYaml, map[string]*bintree{}},
 		"cert-manager-istio-csr-leases-role.yaml":        {istioCsrCertManagerIstioCsrLeasesRoleYaml, map[string]*bintree{}},
 		"cert-manager-istio-csr-leases-rolebinding.yaml": {istioCsrCertManagerIstioCsrLeasesRolebindingYaml, map[string]*bintree{}},
+		"cert-manager-istio-csr-metrics-service.yaml":    {istioCsrCertManagerIstioCsrMetricsServiceYaml, map[string]*bintree{}},
 		"cert-manager-istio-csr-role.yaml":               {istioCsrCertManagerIstioCsrRoleYaml, map[string]*bintree{}},
 		"cert-manager-istio-csr-rolebinding.yaml":        {istioCsrCertManagerIstioCsrRolebindingYaml, map[string]*bintree{}},
 		"cert-manager-istio-csr-service.yaml":            {istioCsrCertManagerIstioCsrServiceYaml, map[string]*bintree{}},


### PR DESCRIPTION
The PR has the following changes
- Adds metrics service static manifest.
- Creates the metrics service along with the core service.
- Updates the manifest fetch script to retain the metrics service manifest.
- Replaces `types.NamespacedName` with `client.ObjectKeyFromObject`