### PR TITLE
CM-735: Fix IstioCSR cache sync race condition by using unified manager cache

### DIFF
--- a/pkg/controller/istiocsr/client.go
+++ b/pkg/controller/istiocsr/client.go
@@ -31,12 +31,12 @@ type ctrlClient interface {
 }
 
 func NewClient(m manager.Manager) (ctrlClient, error) {
-	c, err := BuildCustomClient(m)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build custom client: %w", err)
-	}
+	// Use the manager's client directly instead of creating a custom client.
+	// The manager's client uses the manager's cache, which ensures the reconciler
+	// reads from the same cache that the controller's watches use, preventing
+	// cache mismatch issues.
 	return &ctrlClientImpl{
-		Client: c,
+		Client: m.GetClient(),
 	}, nil
 }
 

--- a/pkg/operator/setup_manager.go
+++ b/pkg/operator/setup_manager.go
@@ -10,11 +10,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -54,10 +52,9 @@ func NewControllerManager() (*Manager, error) {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
-		NewClient: func(config *rest.Config, options client.Options) (client.Client, error) {
-			return client.New(config, options)
-		},
-		Logger: ctrl.Log.WithName("operator-manager"),
+		// Use custom cache builder to configure label selectors for managed resources
+		NewCache: istiocsr.NewCacheBuilder,
+		Logger:   ctrl.Log.WithName("operator-manager"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create manager: %w", err)


### PR DESCRIPTION
### Background

Fixes: https://issues.redhat.com/browse/CM-735

The istio-csr controller exhibits an intermittent race condition where newly created IstioCSR custom resources are sometimes not reconciled, resulting in:
- Empty `.status` field in the IstioCSR object
- Missing `cert-manager-istio-csr` deployment
- "object not found" errors in operator logs despite the object existing
- Operator restart required to resolve

### Root Cause

The custom cache used by the istio-csr controller is not properly waited for synchronization before the controller starts processing reconcile requests.

- **Before**: Two separate caches → race condition
  - Manager's default cache (watches)
  - Custom cache (reads)

```
OLD (Race):
Manager cache syncs → triggers reconcile → reads from different custom cache → might not be synced
```

- **After**: Single unified cache → no race possible
  - Manager's cache configured with `NewCacheBuilder`
  - Both watches AND reads use same cache instance
  - Controller-runtime guarantees cache sync before reconciliation

```
NEW (No Race):
Manager cache syncs → triggers reconcile → reads from SAME manager cache → guaranteed synced
```

### Changes
- Removed `BuildCustomClient()` - No more separate custom cache
- Added `NewCacheBuilder()` - Configures manager's cache with label selectors
- Updated `NewClient()` - Now uses manager's `m.GetClient()` directly
- Updated setup_manager.go - Configure manager with custom cache builder

### Validation

IstioCSR e2e test suite passed repeatedly without suffering the described flakiness.

Proofs (exited after a 1h global timeout, till then all runs are passing):
- https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cert-manager-operator/324/pull-ci-openshift-cert-manager-operator-master-e2e-operator/1977574909999583232/artifacts/e2e-operator/test/build-log.txt
- https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cert-manager-operator/324/pull-ci-openshift-cert-manager-operator-master-e2e-operator-tech-preview/1977561174056636416/artifacts/e2e-operator-tech-preview/test/build-log.txt

_**[NB] Major dialogues with AI: https://gist.github.com/lunarwhite/8928d1dc8e35d0d23e6cc7a364985215**_