### PR TITLE
CM-746: Rebase for operator v1.16.2 release with upstream cert-manager v1.16.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the BUNDLE_VERSION as arg of the bundle target (e.g make bundle BUNDLE_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export BUNDLE_VERSION=0.0.2)
-BUNDLE_VERSION ?= 1.16.1
+BUNDLE_VERSION ?= 1.16.2
 CERT_MANAGER_VERSION ?= "v1.16.5"
 ISTIO_CSR_VERSION ?= "v0.14.0"
 

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -250,7 +250,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/token-auth-gcp: "true"
-    olm.skipRange: '>=1.15.1 <1.16.1'
+    olm.skipRange: '>=1.16.1 <1.16.2'
     operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
       OpenShift will be removed from cert-manager-operator namespace. If your Operator
       configured any off-cluster resources, these will continue to run and require
@@ -271,7 +271,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: cert-manager-operator.v1.16.1
+  name: cert-manager-operator.v1.16.2
   namespace: cert-manager-operator
 spec:
   apiservicedefinitions: {}
@@ -670,7 +670,7 @@ spec:
                 - name: ISTIOCSR_OPERAND_IMAGE_VERSION
                   value: 0.14.0
                 - name: OPERATOR_IMAGE_VERSION
-                  value: 1.16.1
+                  value: 1.16.2
                 - name: OPERATOR_LOG_LEVEL
                   value: "2"
                 - name: TRUSTED_CA_CONFIGMAP_NAME
@@ -774,7 +774,5 @@ spec:
     name: cert-manager-acmesolver
   - image: quay.io/jetstack/cert-manager-istio-csr:v0.14.0
     name: cert-manager-istiocsr
-  replaces: cert-manager-operator.v1.16.0
-  skips:
-  - cert-manager-operator.v1.15.1
-  version: 1.16.1
+  replaces: cert-manager-operator.v1.16.1
+  version: 1.16.2

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -89,7 +89,7 @@ spec:
             - name: ISTIOCSR_OPERAND_IMAGE_VERSION
               value: 0.14.0
             - name: OPERATOR_IMAGE_VERSION
-              value: 1.16.1
+              value: 1.16.2
             - name: OPERATOR_LOG_LEVEL
               value: '2'
             - name: TRUSTED_CA_CONFIGMAP_NAME

--- a/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cert-manager-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
     features.operators.openshift.io/token-auth-gcp: "true"
-    olm.skipRange: '>=1.15.1 <1.16.1'
+    olm.skipRange: '>=1.16.1 <1.16.2'
     operator.openshift.io/uninstall-message: The cert-manager Operator for Red Hat
       OpenShift will be removed from cert-manager-operator namespace. If your Operator
       configured any off-cluster resources, these will continue to run and require
@@ -38,7 +38,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: cert-manager-operator.v1.16.1
+  name: cert-manager-operator.v1.16.2
   namespace: cert-manager-operator
 spec:
   apiservicedefinitions: {}
@@ -104,7 +104,5 @@ spec:
   minKubeVersion: 1.27.0
   provider:
     name: Red Hat
-  replaces: cert-manager-operator.v1.16.0
-  skips:
-  - cert-manager-operator.v1.15.1
-  version: 1.16.1
+  replaces: cert-manager-operator.v1.16.1
+  version: 1.16.2


### PR DESCRIPTION
Rebase downstream cert-manager-operator for v1.16.1 with upstream cert-manager [v1.16.5](https://github.com/openshift/jetstack-cert-manager/releases/tag/v1.16.5).

## Motivation
This rebase was triggered to fix CVEs on the RHEL base image. See details:  https://redhat-internal.slack.com/archives/C045YMPKR3M/p1759851363012459

## Steps

- [x] Update Makefile for next z-stream release

```
- replace `BUNDLE_VERSION` 1.16.0 => 1.16.1
* make bundle
* make update
* make update-bindata
```

- [x] Change OLM bundle skipRange and replaces

```
- name: cert-manager-operator.v1.16.2
  replaces: cert-manager-operator.v1.16.1
  skipRange: '>=1.16.1 <1.16.2'
```