### PR TITLE
CM-904: Fix clientgen scripts when .git points at a missing submodule gitdir

### DIFF
--- a/hack/update-clientgen.sh
+++ b/hack/update-clientgen.sh
@@ -8,7 +8,9 @@ set -o pipefail
 # so all Go commands it runs need module mode
 export GOFLAGS=""
 
-SCRIPT_ROOT=$(git rev-parse --show-toplevel)
+# Prefer git when the work tree is complete (e.g. Konflux copies submodule source without
+# the parent repo, so .git may reference a missing gitdir).
+SCRIPT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd))
 
 # code-generator shell scripts aren't vendored (go work vendor only copies .go files)
 # so we fetch the module path from the module cache

--- a/hack/verify-clientgen.sh
+++ b/hack/verify-clientgen.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(git rev-parse --show-toplevel)
+SCRIPT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd))
 
 "${SCRIPT_ROOT}/hack/update-clientgen.sh"
 


### PR DESCRIPTION
## Problem
`hack/update-clientgen.sh` used `git rev-parse --show-toplevel` to find the repo root. When this repository is used as a git submodule, `.git` is a file that references the parent repo’s `modules/...` path. Container builds (e.g. Konflux) often copy only the operator tree into the image, so that referenced path does not exist and `git rev-parse` fails with:

`fatal: not a git repository: .../.git/modules/cert-manager-operator`

That breaks make generate during `make build` in the Dockerfile.

## Solution
Resolve `SCRIPT_ROOT` the same way in spirit as the top of the `Makefile`: try `git rev-parse --show-toplevel`, and if that fails, use the directory containing hack/ derived from the script’s location (`BASH_SOURCE`). The fallback is wrapped in a subshell so `||` / `&&` precedence does not run `pwd` when `git` already succeeded.

Files
`hack/update-clientgen.sh` — primary fix for image/CI builds.
`hack/verify-clientgen.sh` — same `SCRIPT_ROOT` logic for consistency.
