### PR TITLE
CNF-22870: Define constants for magic strings in istiocsr

### DIFF
--- a/pkg/controller/istiocsr/certificates.go
+++ b/pkg/controller/istiocsr/certificates.go
@@ -87,8 +87,8 @@ func updateCertificateParams(istiocsr *v1alpha1.IstioCSR, certificate *certmanag
 		if revision == "" {
 			continue
 		}
-		if revision == "default" {
-			name := fmt.Sprintf(istiodCertificateDefaultDNSName, istiocsr.Spec.IstioCSRConfig.Istio.Namespace)
+		if revision == defaultIstioRevision {
+			name := fmt.Sprintf(istiodCertificateCommonNameFmt, istiocsr.Spec.IstioCSRConfig.Istio.Namespace)
 			dnsNames = append(dnsNames, name)
 			continue
 		}

--- a/pkg/controller/istiocsr/constants.go
+++ b/pkg/controller/istiocsr/constants.go
@@ -45,14 +45,21 @@ const (
 	// containing the image version of the istiocsr as value.
 	istiocsrImageVersionEnvVarName = "ISTIOCSR_OPERAND_IMAGE_VERSION"
 
+	// defaultClusterID is the default Kubernetes cluster identifier used by istio-csr
+	// when no custom cluster ID is configured.
+	defaultClusterID = "Kubernetes"
+
+	// defaultIstioRevision is the Istio default revision name. When this revision is
+	// specified, the DNS SAN uses the base istiod service name rather than a
+	// revision-prefixed name.
+	defaultIstioRevision = "default"
+
 	// istiocsrGRPCEndpointFmt is the format string for the istiocsr GRPC service endpoint.
 	istiocsrGRPCEndpointFmt = "%s.%s.svc:%d"
 
-	// istiodCertificateCommonNameFmt is the format string for deriving the istiod certificate common name.
+	// istiodCertificateCommonNameFmt is the format string for deriving the istiod certificate common name
+	// and default DNS name.
 	istiodCertificateCommonNameFmt = "istiod.%s.svc"
-
-	// istiodCertificateDefaultDNSName is the format string for deriving the istiod certificate default DNS name.
-	istiodCertificateDefaultDNSName = "istiod.%s.svc"
 
 	// istiodCertificateRevisionBasedDNSName is the format string for deriving the istiod certificate DNS name
 	// for each defined revision.

--- a/pkg/controller/istiocsr/deployments.go
+++ b/pkg/controller/istiocsr/deployments.go
@@ -137,7 +137,7 @@ func updatePodTemplateLabels(deployment *appsv1.Deployment, resourceLabels map[s
 func updateArgList(deployment *appsv1.Deployment, istiocsr *v1alpha1.IstioCSR) {
 	istiocsrConfigs := istiocsr.Spec.IstioCSRConfig
 	// Default clusterID to "Kubernetes" if not provided.
-	clusterID := "Kubernetes"
+	clusterID := defaultClusterID
 	if istiocsrConfigs.Server != nil && istiocsrConfigs.Server.ClusterID != "" {
 		clusterID = istiocsrConfigs.Server.ClusterID
 	}

--- a/pkg/controller/istiocsr/deployments_test.go
+++ b/pkg/controller/istiocsr/deployments_test.go
@@ -1105,7 +1105,7 @@ func TestUpdateArgList(t *testing.T) {
 				// Server config is nil, so clusterID should default
 			},
 			expectedArgs: map[string]string{
-				"cluster-id": "Kubernetes",
+				"cluster-id": defaultClusterID,
 			},
 		},
 		{
@@ -1116,7 +1116,7 @@ func TestUpdateArgList(t *testing.T) {
 				}
 			},
 			expectedArgs: map[string]string{
-				"cluster-id": "Kubernetes",
+				"cluster-id": defaultClusterID,
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Define `defaultClusterID` constant for the magic string `"Kubernetes"` used as the default cluster ID
- Define `defaultIstioRevision` constant for the magic string `"default"` used in certificate DNS SAN logic
- Consolidate duplicate constants `istiodCertificateCommonNameFmt` and `istiodCertificateDefaultDNSName` (both `"istiod.%s.svc"`) into a single constant
- Update test assertions to use the constants instead of duplicating the literals

## Test plan
- [x] Build passes
- [x] Unit tests pass
- [x] Lint clean (same pre-existing issues)
- [x] No behavioral change — same values, now named