### PR TITLE
CM-873: e2e: use size comparison for CA bundle propagation assertion

### DIFF
--- a/test/e2e/trustmanager_bundle_test.go
+++ b/test/e2e/trustmanager_bundle_test.go
@@ -827,8 +827,8 @@ var _ = Describe("Bundle", Ordered, Label("Platform:Generic", "Feature:TrustMana
 			Eventually(func(g Gomega) {
 				cm, err := k8sClientSet.CoreV1().ConfigMaps(operatorNamespace).Get(ctx, trustedCABundleConfigMapName, metav1.GetOptions{})
 				g.Expect(err).ShouldNot(HaveOccurred())
-				g.Expect(cm.Data[trustedCABundleKey]).ShouldNot(Equal(originalInjectedData),
-					"CNO should have updated the injected CA bundle")
+				g.Expect(len(cm.Data[trustedCABundleKey])).Should(BeNumerically(">", len(originalInjectedData)),
+					"CNO-injected CA bundle should have grown after adding a cert")
 			}, highTimeout, slowPollInterval).Should(Succeed())
 
 			// --- Verify operator propagated the change ---


### PR DESCRIPTION
## Summary

- Replaces the `ShouldNot(Equal(...))` assertion with a `BeNumerically(">", ...)` size comparison when verifying CNO has propagated the updated CA bundle to the operator namespace.
- Since the test appends a new certificate to the existing bundle, comparing the length is a more precise assertion that reflects the expected behavior (the bundle should grow), rather than just checking it changed.

## Closes
- https://github.com/openshift/cert-manager-operator/pull/394#discussion_r3128610500
- https://github.com/openshift/cert-manager-operator/issues/411
- https://github.com/openshift/cert-manager-operator/issues/410

/cc @bharath-b-rh 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CA bundle propagation test verification logic to check for bundle size growth after configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->