### PR TITLE
CM-1114: Add health probes and richer status conditions

### DIFF
--- a/api/operator/v1alpha1/conditions.go
+++ b/api/operator/v1alpha1/conditions.go
@@ -25,6 +25,13 @@ const (
 	//   - Failed
 	//   - Ready: operand successfully deployed and ready
 	Ready string = "Ready"
+
+	// Progressing indicates whether the operator is actively reconciling
+	// toward the desired state.
+	//   Status:
+	//   - True: reconciliation is in progress
+	//   - False: reconciliation is idle (succeeded or permanently failed)
+	Progressing string = "Progressing"
 )
 
 const (
@@ -33,6 +40,14 @@ const (
 	ReasonReady string = "Ready"
 
 	ReasonInProgress string = "Progressing"
+
+	ReasonReconciling string = "Reconciling"
+
+	ReasonWaitingForDependencies string = "WaitingForDependencies"
+
+	ReasonValidationFailed string = "ValidationFailed"
+
+	ReasonMultipleInstancesFound string = "MultipleInstancesFound"
 )
 
 func (c *ConditionalStatus) GetCondition(t string) *metav1.Condition {

--- a/api/operator/v1alpha1/conditions_test.go
+++ b/api/operator/v1alpha1/conditions_test.go
@@ -38,6 +38,29 @@ func TestGetCondition(t *testing.T) {
 			},
 		},
 		{
+			name: "progressing condition present",
+			conditionalStatus: ConditionalStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   Ready,
+						Status: metav1.ConditionTrue,
+						Reason: ReasonReady,
+					},
+					{
+						Type:   Progressing,
+						Status: metav1.ConditionFalse,
+						Reason: ReasonReady,
+					},
+				},
+			},
+			condition: Progressing,
+			expectedCondition: &metav1.Condition{
+				Type:   Progressing,
+				Status: metav1.ConditionFalse,
+				Reason: ReasonReady,
+			},
+		},
+		{
 			name: "requested condition not present",
 			conditionalStatus: ConditionalStatus{
 				Conditions: []metav1.Condition{
@@ -113,6 +136,22 @@ func TestSetCondition(t *testing.T) {
 			condition:        Ready,
 			conditionStatus:  metav1.ConditionFalse,
 			conditionReason:  ReasonReady,
+			conditionUpdated: true,
+		},
+		{
+			name: "condition exists and reason changed",
+			conditionalStatus: ConditionalStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   Ready,
+						Status: metav1.ConditionFalse,
+						Reason: ReasonFailed,
+					},
+				},
+			},
+			condition:        Ready,
+			conditionStatus:  metav1.ConditionFalse,
+			conditionReason:  ReasonValidationFailed,
 			conditionUpdated: true,
 		},
 		{

--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -826,11 +826,29 @@ spec:
                 - name: UNSUPPORTED_ADDON_FEATURES
                 image: openshift.io/cert-manager-operator:latest
                 imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /healthz
+                    port: https
+                    scheme: HTTPS
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 5
                 name: cert-manager-operator
                 ports:
                 - containerPort: 8443
                   name: https
                   protocol: TCP
+                readinessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /readyz
+                    port: https
+                    scheme: HTTPS
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 5
                 resources:
                   requests:
                     cpu: 10m

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -102,6 +102,24 @@ spec:
           image: controller:latest
           imagePullPolicy: IfNotPresent
           name: cert-manager-operator
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/pkg/controller/common/errors.go
+++ b/pkg/controller/common/errors.go
@@ -23,9 +23,10 @@ const (
 
 // ReconcileError represents an error that occurred during reconciliation.
 type ReconcileError struct {
-	Reason  ErrorReason `json:"reason,omitempty"`
-	Message string      `json:"message,omitempty"`
-	Err     error       `json:"error,omitempty"`
+	Reason          ErrorReason `json:"reason,omitempty"`
+	ConditionReason string      `json:"conditionReason,omitempty"`
+	Message         string      `json:"message,omitempty"`
+	Err             error       `json:"error,omitempty"`
 }
 
 var _ error = &ReconcileError{}
@@ -117,6 +118,16 @@ func IsMultipleInstanceError(err error) bool {
 	return false
 }
 
+// WithConditionReason sets the condition reason that will appear in status
+// conditions when this error is processed by HandleReconcileResult.
+func (e *ReconcileError) WithConditionReason(reason string) *ReconcileError {
+	if e == nil {
+		return nil
+	}
+	e.ConditionReason = reason
+	return e
+}
+
 // Error implements the error interface.
 func (e *ReconcileError) Error() string {
 	return fmt.Sprintf("%s: %s", e.Message, e.Err)
@@ -125,4 +136,14 @@ func (e *ReconcileError) Error() string {
 // Unwrap returns the underlying error for error chain traversal.
 func (e *ReconcileError) Unwrap() error {
 	return e.Err
+}
+
+// GetConditionReason extracts the ConditionReason from a ReconcileError in the
+// error chain. Returns empty string if not set or not a ReconcileError.
+func GetConditionReason(err error) string {
+	rerr := &ReconcileError{}
+	if errors.As(err, &rerr) {
+		return rerr.ConditionReason
+	}
+	return ""
 }

--- a/pkg/controller/common/errors_test.go
+++ b/pkg/controller/common/errors_test.go
@@ -284,6 +284,89 @@ func TestIsRetryRequiredError(t *testing.T) {
 	}
 }
 
+func TestWithConditionReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        *ReconcileError
+		reason     string
+		wantNil    bool
+		wantReason string
+	}{
+		{
+			name:       "sets condition reason on irrecoverable error",
+			err:        NewIrrecoverableError(fmt.Errorf("x"), "msg"),
+			reason:     "ValidationFailed",
+			wantReason: "ValidationFailed",
+		},
+		{
+			name:       "sets condition reason on retry error",
+			err:        NewRetryRequiredError(fmt.Errorf("x"), "msg"),
+			reason:     "ResourceApplyFailed",
+			wantReason: "ResourceApplyFailed",
+		},
+		{
+			name:    "nil error returns nil",
+			err:     nil,
+			reason:  "ValidationFailed",
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.WithConditionReason(tt.reason)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil")
+			}
+			if got.ConditionReason != tt.wantReason {
+				t.Errorf("ConditionReason = %q, want %q", got.ConditionReason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestGetConditionReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantReason string
+	}{
+		{
+			name:       "extracts reason from ReconcileError",
+			err:        NewIrrecoverableError(fmt.Errorf("x"), "msg").WithConditionReason("ValidationFailed"),
+			wantReason: "ValidationFailed",
+		},
+		{
+			name:       "returns empty for ReconcileError without ConditionReason",
+			err:        NewIrrecoverableError(fmt.Errorf("x"), "msg"),
+			wantReason: "",
+		},
+		{
+			name:       "returns empty for plain error",
+			err:        fmt.Errorf("plain"),
+			wantReason: "",
+		},
+		{
+			name:       "returns empty for nil",
+			err:        nil,
+			wantReason: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetConditionReason(tt.err)
+			if got != tt.wantReason {
+				t.Errorf("GetConditionReason() = %q, want %q", got, tt.wantReason)
+			}
+		})
+	}
+}
+
 func TestIsMultipleInstanceError(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/controller/common/reconcile_result.go
+++ b/pkg/controller/common/reconcile_result.go
@@ -11,6 +11,15 @@ import (
 	v1alpha1 "github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
 )
 
+// resolveConditionReason extracts a specific condition reason from the error
+// chain if one was set via WithConditionReason, otherwise returns the default.
+func resolveConditionReason(err error, defaultReason string) string {
+	if reason := GetConditionReason(err); reason != "" {
+		return reason
+	}
+	return defaultReason
+}
+
 // HandleReconcileResult processes the result of a reconciliation attempt and
 // updates status conditions accordingly.
 func HandleReconcileResult(
@@ -24,52 +33,54 @@ func HandleReconcileResult(
 
 	if reconcileErr != nil {
 		if IsIrrecoverableError(reconcileErr) {
-			// Permanent failure - don't retry
-			// Set Degraded=True, Ready=False
-			// Set both conditions atomically before updating status
-			degradedChanged := status.SetCondition(v1alpha1.Degraded, metav1.ConditionTrue, v1alpha1.ReasonFailed, fmt.Sprintf("reconciliation failed with irrecoverable error not retrying: %v", reconcileErr))
-			readyChanged := status.SetCondition(v1alpha1.Ready, metav1.ConditionFalse, v1alpha1.ReasonFailed, "")
+			reason := resolveConditionReason(reconcileErr, v1alpha1.ReasonFailed)
+			degradedChanged := status.SetCondition(v1alpha1.Degraded, metav1.ConditionTrue, reason, fmt.Sprintf("reconciliation failed with irrecoverable error not retrying: %v", reconcileErr))
+			readyChanged := status.SetCondition(v1alpha1.Ready, metav1.ConditionFalse, reason, "")
+			progressingChanged := status.SetCondition(v1alpha1.Progressing, metav1.ConditionFalse, reason, "")
 
-			if degradedChanged || readyChanged {
+			if degradedChanged || readyChanged || progressingChanged {
 				log.V(2).Info("updating conditions on irrecoverable error",
 					"degradedChanged", degradedChanged,
 					"readyChanged", readyChanged,
+					"progressingChanged", progressingChanged,
+					"reason", reason,
 					"error", reconcileErr)
 				errUpdate = updateConditionFn(nil)
 			}
 			return ctrl.Result{}, errUpdate
 		}
 
-		// Temporary failure - retry after delay
-		// Set Degraded=False, Ready=False with "in progress" message
-		// Set both conditions atomically before updating status
+		readyReason := resolveConditionReason(reconcileErr, v1alpha1.ReasonInProgress)
+		progressingReason := resolveConditionReason(reconcileErr, v1alpha1.ReasonReconciling)
 		degradedChanged := status.SetCondition(v1alpha1.Degraded, metav1.ConditionFalse, v1alpha1.ReasonReady, "")
-		readyChanged := status.SetCondition(v1alpha1.Ready, metav1.ConditionFalse, v1alpha1.ReasonInProgress, fmt.Sprintf("reconciliation failed, retrying: %v", reconcileErr))
+		readyChanged := status.SetCondition(v1alpha1.Ready, metav1.ConditionFalse, readyReason, fmt.Sprintf("reconciliation failed, retrying: %v", reconcileErr))
+		progressingChanged := status.SetCondition(v1alpha1.Progressing, metav1.ConditionTrue, progressingReason, fmt.Sprintf("reconciliation in progress: %v", reconcileErr))
 
-		if degradedChanged || readyChanged {
+		if degradedChanged || readyChanged || progressingChanged {
 			log.V(2).Info("updating conditions on recoverable error",
 				"degradedChanged", degradedChanged,
 				"readyChanged", readyChanged,
+				"progressingChanged", progressingChanged,
+				"reason", readyReason,
 				"error", reconcileErr)
 			errUpdate = updateConditionFn(reconcileErr)
 		}
-		// For recoverable errors, either requeue manually or return error, not both.
-		// If status update failed, return the update error; otherwise requeue.
+		// Return status-update error or requeue, not both.
 		if errUpdate != nil {
 			return ctrl.Result{}, errUpdate
 		}
 		return ctrl.Result{RequeueAfter: requeueDuration}, nil
 	}
 
-	// Success - update status
-	// Set both conditions atomically before updating status on success
 	degradedChanged := status.SetCondition(v1alpha1.Degraded, metav1.ConditionFalse, v1alpha1.ReasonReady, "")
 	readyChanged := status.SetCondition(v1alpha1.Ready, metav1.ConditionTrue, v1alpha1.ReasonReady, "reconciliation successful")
+	progressingChanged := status.SetCondition(v1alpha1.Progressing, metav1.ConditionFalse, v1alpha1.ReasonReady, "")
 
-	if degradedChanged || readyChanged {
+	if degradedChanged || readyChanged || progressingChanged {
 		log.V(2).Info("updating conditions on successful reconciliation",
 			"degradedChanged", degradedChanged,
-			"readyChanged", readyChanged)
+			"readyChanged", readyChanged,
+			"progressingChanged", progressingChanged)
 		errUpdate = updateConditionFn(nil)
 	}
 	return ctrl.Result{}, errUpdate

--- a/pkg/controller/common/reconcile_result_test.go
+++ b/pkg/controller/common/reconcile_result_test.go
@@ -1,0 +1,242 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1alpha1 "github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
+)
+
+func conditionByType(status *v1alpha1.ConditionalStatus, ct string) *metav1.Condition {
+	return status.GetCondition(ct)
+}
+
+func TestHandleReconcileResult(t *testing.T) {
+	tests := []struct {
+		name string
+
+		reconcileErr error
+
+		wantDegradedStatus    metav1.ConditionStatus
+		wantDegradedReason    string
+		wantReadyStatus       metav1.ConditionStatus
+		wantReadyReason       string
+		wantProgressingStatus metav1.ConditionStatus
+		wantProgressingReason string
+		wantRequeue           bool
+		wantUpdateCalled      bool
+	}{
+		{
+			name:                  "success sets Ready=True, Degraded=False, Progressing=False",
+			reconcileErr:          nil,
+			wantDegradedStatus:    metav1.ConditionFalse,
+			wantDegradedReason:    v1alpha1.ReasonReady,
+			wantReadyStatus:       metav1.ConditionTrue,
+			wantReadyReason:       v1alpha1.ReasonReady,
+			wantProgressingStatus: metav1.ConditionFalse,
+			wantProgressingReason: v1alpha1.ReasonReady,
+			wantUpdateCalled:      true,
+		},
+		{
+			name:                  "irrecoverable error sets Degraded=True, Ready=False, Progressing=False",
+			reconcileErr:          NewIrrecoverableError(fmt.Errorf("fatal"), "fatal failure"),
+			wantDegradedStatus:    metav1.ConditionTrue,
+			wantDegradedReason:    v1alpha1.ReasonFailed,
+			wantReadyStatus:       metav1.ConditionFalse,
+			wantReadyReason:       v1alpha1.ReasonFailed,
+			wantProgressingStatus: metav1.ConditionFalse,
+			wantProgressingReason: v1alpha1.ReasonFailed,
+			wantUpdateCalled:      true,
+		},
+		{
+			name:                  "irrecoverable error with custom ConditionReason uses it",
+			reconcileErr:          NewIrrecoverableError(fmt.Errorf("validation"), "invalid config").WithConditionReason(v1alpha1.ReasonValidationFailed),
+			wantDegradedStatus:    metav1.ConditionTrue,
+			wantDegradedReason:    v1alpha1.ReasonValidationFailed,
+			wantReadyStatus:       metav1.ConditionFalse,
+			wantReadyReason:       v1alpha1.ReasonValidationFailed,
+			wantProgressingStatus: metav1.ConditionFalse,
+			wantProgressingReason: v1alpha1.ReasonValidationFailed,
+			wantUpdateCalled:      true,
+		},
+		{
+			name:                  "recoverable error sets Progressing=True, Ready=False, Degraded=False",
+			reconcileErr:          NewRetryRequiredError(fmt.Errorf("transient"), "retrying"),
+			wantDegradedStatus:    metav1.ConditionFalse,
+			wantDegradedReason:    v1alpha1.ReasonReady,
+			wantReadyStatus:       metav1.ConditionFalse,
+			wantReadyReason:       v1alpha1.ReasonInProgress,
+			wantProgressingStatus: metav1.ConditionTrue,
+			wantProgressingReason: v1alpha1.ReasonReconciling,
+			wantRequeue:           true,
+			wantUpdateCalled:      true,
+		},
+		{
+			name:                  "recoverable error with custom ConditionReason uses it for Ready and Progressing",
+			reconcileErr:          NewRetryRequiredError(fmt.Errorf("waiting"), "waiting for dep").WithConditionReason(v1alpha1.ReasonWaitingForDependencies),
+			wantDegradedStatus:    metav1.ConditionFalse,
+			wantDegradedReason:    v1alpha1.ReasonReady,
+			wantReadyStatus:       metav1.ConditionFalse,
+			wantReadyReason:       v1alpha1.ReasonWaitingForDependencies,
+			wantProgressingStatus: metav1.ConditionTrue,
+			wantProgressingReason: v1alpha1.ReasonWaitingForDependencies,
+			wantRequeue:           true,
+			wantUpdateCalled:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status := &v1alpha1.ConditionalStatus{}
+			updateCalled := false
+
+			updateFn := func(_ error) error {
+				updateCalled = true
+				return nil
+			}
+
+			result, err := HandleReconcileResult(
+				status,
+				tc.reconcileErr,
+				logr.Discard(),
+				updateFn,
+				10*time.Second,
+			)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantUpdateCalled, updateCalled, "updateConditionFn called")
+
+			if tc.wantRequeue {
+				assert.NotZero(t, result.RequeueAfter, "expected requeue")
+			} else {
+				assert.Zero(t, result.RequeueAfter, "expected no requeue")
+			}
+
+			degraded := conditionByType(status, v1alpha1.Degraded)
+			require.NotNil(t, degraded, "Degraded condition should be set")
+			assert.Equal(t, tc.wantDegradedStatus, degraded.Status)
+			assert.Equal(t, tc.wantDegradedReason, degraded.Reason)
+
+			ready := conditionByType(status, v1alpha1.Ready)
+			require.NotNil(t, ready, "Ready condition should be set")
+			assert.Equal(t, tc.wantReadyStatus, ready.Status)
+			assert.Equal(t, tc.wantReadyReason, ready.Reason)
+
+			progressing := conditionByType(status, v1alpha1.Progressing)
+			require.NotNil(t, progressing, "Progressing condition should be set")
+			assert.Equal(t, tc.wantProgressingStatus, progressing.Status)
+			assert.Equal(t, tc.wantProgressingReason, progressing.Reason)
+		})
+	}
+}
+
+func TestHandleReconcileResult_NoChangeSkipsUpdate(t *testing.T) {
+	status := &v1alpha1.ConditionalStatus{}
+	status.SetCondition(v1alpha1.Degraded, metav1.ConditionFalse, v1alpha1.ReasonReady, "")
+	status.SetCondition(v1alpha1.Ready, metav1.ConditionTrue, v1alpha1.ReasonReady, "reconciliation successful")
+	status.SetCondition(v1alpha1.Progressing, metav1.ConditionFalse, v1alpha1.ReasonReady, "")
+
+	updateCalled := false
+	updateFn := func(_ error) error {
+		updateCalled = true
+		return nil
+	}
+
+	_, err := HandleReconcileResult(status, nil, logr.Discard(), updateFn, 10*time.Second)
+	require.NoError(t, err)
+	assert.False(t, updateCalled, "updateConditionFn should not be called when conditions are unchanged")
+}
+
+func TestHandleReconcileResult_UpdateFnErrorPropagated(t *testing.T) {
+	status := &v1alpha1.ConditionalStatus{}
+	updateErr := fmt.Errorf("status update failed")
+
+	updateFn := func(_ error) error {
+		return updateErr
+	}
+
+	_, err := HandleReconcileResult(status, nil, logr.Discard(), updateFn, 10*time.Second)
+	require.ErrorIs(t, err, updateErr)
+}
+
+func TestHandleReconcileResult_IrrecoverableUpdateFnErrorPropagated(t *testing.T) {
+	status := &v1alpha1.ConditionalStatus{}
+	updateErr := fmt.Errorf("status update failed")
+
+	updateFn := func(_ error) error {
+		return updateErr
+	}
+
+	_, err := HandleReconcileResult(
+		status,
+		NewIrrecoverableError(fmt.Errorf("fatal"), "fatal"),
+		logr.Discard(),
+		updateFn,
+		10*time.Second,
+	)
+	require.ErrorIs(t, err, updateErr)
+}
+
+func TestHandleReconcileResult_RecoverableUpdateFnErrorPropagated(t *testing.T) {
+	status := &v1alpha1.ConditionalStatus{}
+	updateErr := fmt.Errorf("status update failed")
+
+	updateFn := func(_ error) error {
+		return updateErr
+	}
+
+	result, err := HandleReconcileResult(
+		status,
+		NewRetryRequiredError(fmt.Errorf("transient"), "retrying"),
+		logr.Discard(),
+		updateFn,
+		10*time.Second,
+	)
+	require.ErrorIs(t, err, updateErr)
+	assert.Zero(t, result.RequeueAfter, "should not requeue when updateFn fails")
+}
+
+func TestHandleReconcileResult_RecoverableNoChangeSkipsUpdate(t *testing.T) {
+	status := &v1alpha1.ConditionalStatus{}
+	reconcileErr := NewRetryRequiredError(fmt.Errorf("transient"), "retrying")
+
+	// First call sets conditions.
+	_, err := HandleReconcileResult(status, reconcileErr, logr.Discard(), func(_ error) error { return nil }, 10*time.Second)
+	require.NoError(t, err)
+
+	// Second call with same error — conditions already match, so updateFn should be skipped.
+	updateCalled := false
+	result, err := HandleReconcileResult(status, reconcileErr, logr.Discard(), func(_ error) error {
+		updateCalled = true
+		return nil
+	}, 10*time.Second)
+	require.NoError(t, err)
+	assert.False(t, updateCalled, "updateConditionFn should not be called when conditions are unchanged")
+	assert.NotZero(t, result.RequeueAfter, "should still requeue even when conditions are unchanged")
+}
+
+func TestHandleReconcileResult_IrrecoverableNoChangeSkipsUpdate(t *testing.T) {
+	status := &v1alpha1.ConditionalStatus{}
+	reconcileErr := NewIrrecoverableError(fmt.Errorf("fatal"), "fatal failure")
+
+	// First call sets conditions.
+	_, err := HandleReconcileResult(status, reconcileErr, logr.Discard(), func(_ error) error { return nil }, 10*time.Second)
+	require.NoError(t, err)
+
+	// Second call with same error — conditions already match, so updateFn should be skipped.
+	updateCalled := false
+	result, err := HandleReconcileResult(status, reconcileErr, logr.Discard(), func(_ error) error {
+		updateCalled = true
+		return nil
+	}, 10*time.Second)
+	require.NoError(t, err)
+	assert.False(t, updateCalled, "updateConditionFn should not be called when conditions are unchanged")
+	assert.Zero(t, result.RequeueAfter, "irrecoverable error should not requeue")
+	assert.Equal(t, metav1.ConditionTrue, conditionByType(status, v1alpha1.Degraded).Status)
+}

--- a/pkg/controller/istiocsr/controller_test.go
+++ b/pkg/controller/istiocsr/controller_test.go
@@ -505,6 +505,11 @@ func TestProcessReconcileRequest(t *testing.T) {
 					Status: metav1.ConditionFalse,
 					Reason: v1alpha1.ReasonReady,
 				},
+				{
+					Type:   v1alpha1.Progressing,
+					Status: metav1.ConditionFalse,
+					Reason: v1alpha1.ReasonReady,
+				},
 			},
 			expectedAnnotations: map[string]string{
 				controllerProcessedAnnotation: "true",
@@ -566,6 +571,11 @@ func TestProcessReconcileRequest(t *testing.T) {
 					Status: metav1.ConditionFalse,
 					Reason: v1alpha1.ReasonReady,
 				},
+				{
+					Type:   v1alpha1.Progressing,
+					Status: metav1.ConditionFalse,
+					Reason: v1alpha1.ReasonReady,
+				},
 			},
 			expectedAnnotations: map[string]string{
 				controllerProcessedAnnotation: "true",
@@ -585,7 +595,13 @@ func TestProcessReconcileRequest(t *testing.T) {
 				{
 					Type:    v1alpha1.Ready,
 					Status:  metav1.ConditionFalse,
-					Reason:  v1alpha1.ReasonFailed,
+					Reason:  v1alpha1.ReasonMultipleInstancesFound,
+					Message: "multiple instances of istiocsr exists, istiocsr-test-ns/istiocsr-test-resource will not be processed",
+				},
+				{
+					Type:    v1alpha1.Progressing,
+					Status:  metav1.ConditionFalse,
+					Reason:  v1alpha1.ReasonMultipleInstancesFound,
 					Message: "multiple instances of istiocsr exists, istiocsr-test-ns/istiocsr-test-resource will not be processed",
 				},
 			},
@@ -642,7 +658,13 @@ func TestProcessReconcileRequest(t *testing.T) {
 				{
 					Type:    v1alpha1.Ready,
 					Status:  metav1.ConditionFalse,
-					Reason:  v1alpha1.ReasonFailed,
+					Reason:  v1alpha1.ReasonMultipleInstancesFound,
+					Message: "multiple instances of istiocsr exists, istiocsr3/istiocsr-test-resource will not be processed",
+				},
+				{
+					Type:    v1alpha1.Progressing,
+					Status:  metav1.ConditionFalse,
+					Reason:  v1alpha1.ReasonMultipleInstancesFound,
 					Message: "multiple instances of istiocsr exists, istiocsr3/istiocsr-test-resource will not be processed",
 				},
 			},
@@ -690,7 +712,13 @@ func TestProcessReconcileRequest(t *testing.T) {
 				{
 					Type:    v1alpha1.Ready,
 					Status:  metav1.ConditionFalse,
-					Reason:  v1alpha1.ReasonFailed,
+					Reason:  v1alpha1.ReasonMultipleInstancesFound,
+					Message: "multiple instances of istiocsr exists, istiocsr3/istiocsr-test-resource will not be processed",
+				},
+				{
+					Type:    v1alpha1.Progressing,
+					Status:  metav1.ConditionFalse,
+					Reason:  v1alpha1.ReasonMultipleInstancesFound,
 					Message: "multiple instances of istiocsr exists, istiocsr3/istiocsr-test-resource will not be processed",
 				},
 			},
@@ -739,7 +767,13 @@ func TestProcessReconcileRequest(t *testing.T) {
 				{
 					Type:    v1alpha1.Ready,
 					Status:  metav1.ConditionFalse,
-					Reason:  v1alpha1.ReasonFailed,
+					Reason:  v1alpha1.ReasonMultipleInstancesFound,
+					Message: "multiple instances of istiocsr exists, istiocsr3/istiocsr-test-resource will not be processed",
+				},
+				{
+					Type:    v1alpha1.Progressing,
+					Status:  metav1.ConditionFalse,
+					Reason:  v1alpha1.ReasonMultipleInstancesFound,
 					Message: "multiple instances of istiocsr exists, istiocsr3/istiocsr-test-resource will not be processed",
 				},
 			},

--- a/pkg/controller/istiocsr/install_istiocsr.go
+++ b/pkg/controller/istiocsr/install_istiocsr.go
@@ -10,7 +10,8 @@ import (
 
 func (r *Reconciler) reconcileIstioCSRDeployment(istiocsr *v1alpha1.IstioCSR, istioCSRCreateRecon bool) error {
 	if err := validateIstioCSRConfig(istiocsr); err != nil {
-		return common.NewIrrecoverableError(err, "%s/%s configuration validation failed", istiocsr.GetNamespace(), istiocsr.GetName())
+		return common.NewIrrecoverableError(err, "%s/%s configuration validation failed", istiocsr.GetNamespace(), istiocsr.GetName()).
+			WithConditionReason(v1alpha1.ReasonValidationFailed)
 	}
 
 	// if user has set custom labels to be added to all resources created by the controller

--- a/pkg/controller/istiocsr/utils.go
+++ b/pkg/controller/istiocsr/utils.go
@@ -493,10 +493,13 @@ func (r *Reconciler) disallowMultipleIstioCSRInstances(istiocsr *v1alpha1.IstioC
 	statusMessage := fmt.Sprintf("multiple instances of istiocsr exists, %s/%s will not be processed", istiocsr.GetNamespace(), istiocsr.GetName())
 
 	if containsProcessingRejectedAnnotation(istiocsr) {
-		r.log.V(4).Info("%s/%s istiocsr resource contains processing rejected annotation", istiocsr.Namespace, istiocsr.Name)
+		r.log.V(4).Info("istiocsr resource contains processing rejected annotation", "namespace", istiocsr.Namespace, "name", istiocsr.Name)
 		// ensure status is updated.
 		var updateErr error
-		if istiocsr.Status.SetCondition(v1alpha1.Ready, metav1.ConditionFalse, v1alpha1.ReasonFailed, statusMessage) {
+		degradedChanged := istiocsr.Status.SetCondition(v1alpha1.Degraded, metav1.ConditionFalse, v1alpha1.ReasonMultipleInstancesFound, "")
+		readyChanged := istiocsr.Status.SetCondition(v1alpha1.Ready, metav1.ConditionFalse, v1alpha1.ReasonMultipleInstancesFound, statusMessage)
+		progressingChanged := istiocsr.Status.SetCondition(v1alpha1.Progressing, metav1.ConditionFalse, v1alpha1.ReasonMultipleInstancesFound, statusMessage)
+		if degradedChanged || readyChanged || progressingChanged {
 			updateErr = r.updateCondition(istiocsr, nil)
 		}
 		return common.NewMultipleInstanceError(utilerrors.NewAggregate([]error{errors.New(statusMessage), updateErr}))
@@ -533,7 +536,10 @@ func (r *Reconciler) disallowMultipleIstioCSRInstances(istiocsr *v1alpha1.IstioC
 
 	// This instance should be rejected as there's an older or equally old instance
 	var condUpdateErr, annUpdateErr error
-	if istiocsr.Status.SetCondition(v1alpha1.Ready, metav1.ConditionFalse, v1alpha1.ReasonFailed, statusMessage) {
+	degradedChanged := istiocsr.Status.SetCondition(v1alpha1.Degraded, metav1.ConditionFalse, v1alpha1.ReasonMultipleInstancesFound, "")
+	readyChanged := istiocsr.Status.SetCondition(v1alpha1.Ready, metav1.ConditionFalse, v1alpha1.ReasonMultipleInstancesFound, statusMessage)
+	progressingChanged := istiocsr.Status.SetCondition(v1alpha1.Progressing, metav1.ConditionFalse, v1alpha1.ReasonMultipleInstancesFound, statusMessage)
+	if degradedChanged || readyChanged || progressingChanged {
 		condUpdateErr = r.updateCondition(istiocsr, nil)
 	}
 	if addProcessingRejectedAnnotation(istiocsr) {

--- a/pkg/controller/trustmanager/controller_test.go
+++ b/pkg/controller/trustmanager/controller_test.go
@@ -181,6 +181,11 @@ func TestProcessReconcileRequest(t *testing.T) {
 					Reason:  v1alpha1.ReasonReady,
 					Message: "reconciliation successful",
 				},
+				{
+					Type:   v1alpha1.Progressing,
+					Status: metav1.ConditionFalse,
+					Reason: v1alpha1.ReasonReady,
+				},
 			},
 		},
 		{
@@ -207,12 +212,17 @@ func TestProcessReconcileRequest(t *testing.T) {
 				{
 					Type:   v1alpha1.Degraded,
 					Status: metav1.ConditionTrue,
-					Reason: v1alpha1.ReasonFailed,
+					Reason: v1alpha1.ReasonValidationFailed,
 				},
 				{
 					Type:   v1alpha1.Ready,
 					Status: metav1.ConditionFalse,
-					Reason: v1alpha1.ReasonFailed,
+					Reason: v1alpha1.ReasonValidationFailed,
+				},
+				{
+					Type:   v1alpha1.Progressing,
+					Status: metav1.ConditionFalse,
+					Reason: v1alpha1.ReasonValidationFailed,
 				},
 			},
 		},
@@ -250,6 +260,11 @@ func TestProcessReconcileRequest(t *testing.T) {
 					Status: metav1.ConditionFalse,
 					Reason: v1alpha1.ReasonInProgress,
 				},
+				{
+					Type:   v1alpha1.Progressing,
+					Status: metav1.ConditionTrue,
+					Reason: v1alpha1.ReasonReconciling,
+				},
 			},
 			wantErr: "failed to check if serviceaccount",
 		},
@@ -279,7 +294,7 @@ func TestProcessReconcileRequest(t *testing.T) {
 				{
 					Type:   v1alpha1.Degraded,
 					Status: metav1.ConditionTrue,
-					Reason: v1alpha1.ReasonFailed,
+					Reason: v1alpha1.ReasonWaitingForDependencies,
 					Message: fmt.Sprintf(
 						"reconciliation failed with irrecoverable error not retrying: trust namespace %q validation failed: trust namespace %q does not exist, create the namespace before creating TrustManager CR",
 						defaultTrustNamespace,
@@ -289,7 +304,12 @@ func TestProcessReconcileRequest(t *testing.T) {
 				{
 					Type:   v1alpha1.Ready,
 					Status: metav1.ConditionFalse,
-					Reason: v1alpha1.ReasonFailed,
+					Reason: v1alpha1.ReasonWaitingForDependencies,
+				},
+				{
+					Type:   v1alpha1.Progressing,
+					Status: metav1.ConditionFalse,
+					Reason: v1alpha1.ReasonWaitingForDependencies,
 				},
 			},
 		},
@@ -330,6 +350,11 @@ func TestProcessReconcileRequest(t *testing.T) {
 					Status:  metav1.ConditionTrue,
 					Reason:  v1alpha1.ReasonReady,
 					Message: "reconciliation successful",
+				},
+				{
+					Type:   v1alpha1.Progressing,
+					Status: metav1.ConditionFalse,
+					Reason: v1alpha1.ReasonReady,
 				},
 			},
 		},

--- a/pkg/controller/trustmanager/deployments_test.go
+++ b/pkg/controller/trustmanager/deployments_test.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -416,6 +417,164 @@ func TestDeploymentOverrides(t *testing.T) {
 			}
 			if tt.wantAffinity && dep.Spec.Template.Spec.Affinity == nil {
 				t.Error("expected affinity to be set")
+			}
+		})
+	}
+}
+
+func TestContainerPortsMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  []corev1.ContainerPort
+		existing []corev1.ContainerPort
+		want     bool
+	}{
+		{
+			name:     "identical ports match",
+			desired:  []corev1.ContainerPort{{Name: "https", ContainerPort: 6443}},
+			existing: []corev1.ContainerPort{{Name: "https", ContainerPort: 6443}},
+			want:     true,
+		},
+		{
+			name:     "mismatched port counts do not match",
+			desired:  []corev1.ContainerPort{{Name: "https", ContainerPort: 6443}},
+			existing: []corev1.ContainerPort{{Name: "https", ContainerPort: 6443}, {Name: "metrics", ContainerPort: 9402}},
+			want:     false,
+		},
+		{
+			name:     "same count but unmatched port name",
+			desired:  []corev1.ContainerPort{{Name: "https", ContainerPort: 6443}},
+			existing: []corev1.ContainerPort{{Name: "webhook", ContainerPort: 6443}},
+			want:     false,
+		},
+		{
+			name:     "same count but unmatched port number",
+			desired:  []corev1.ContainerPort{{Name: "https", ContainerPort: 6443}},
+			existing: []corev1.ContainerPort{{Name: "https", ContainerPort: 8443}},
+			want:     false,
+		},
+		{
+			name:     "both empty match",
+			desired:  nil,
+			existing: nil,
+			want:     true,
+		},
+		{
+			name:     "different order still matches",
+			desired:  []corev1.ContainerPort{{Name: "https", ContainerPort: 6443}, {Name: "metrics", ContainerPort: 9402}},
+			existing: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 9402}, {Name: "https", ContainerPort: 6443}},
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := containerPortsMatch(tt.desired, tt.existing)
+			if got != tt.want {
+				t.Errorf("containerPortsMatch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadinessProbeModified(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  *corev1.Probe
+		existing *corev1.Probe
+		want     bool
+	}{
+		{
+			name:     "both nil not modified",
+			desired:  nil,
+			existing: nil,
+			want:     false,
+		},
+		{
+			name:     "desired nil existing non-nil is modified",
+			desired:  nil,
+			existing: &corev1.Probe{},
+			want:     true,
+		},
+		{
+			name:     "desired non-nil existing nil is modified",
+			desired:  &corev1.Probe{},
+			existing: nil,
+			want:     true,
+		},
+		{
+			name: "HTTPGet path difference is modified",
+			desired: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{Path: "/readyz"},
+				},
+			},
+			existing: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{Path: "/healthz"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "identical HTTPGet probes not modified",
+			desired: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{Path: "/readyz"},
+				},
+				InitialDelaySeconds: 3,
+				PeriodSeconds:       7,
+			},
+			existing: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{Path: "/readyz"},
+				},
+				InitialDelaySeconds: 3,
+				PeriodSeconds:       7,
+			},
+			want: false,
+		},
+		{
+			name: "desired has HTTPGet existing does not is modified",
+			desired: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{Path: "/readyz"},
+				},
+			},
+			existing: &corev1.Probe{},
+			want:     true,
+		},
+		{
+			name: "different PeriodSeconds is modified",
+			desired: &corev1.Probe{
+				PeriodSeconds: 10,
+			},
+			existing: &corev1.Probe{
+				PeriodSeconds: 5,
+			},
+			want: true,
+		},
+		{
+			name: "HTTPGet port difference is modified",
+			desired: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{Path: "/readyz", Port: intstr.FromInt32(6443)},
+				},
+			},
+			existing: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{Path: "/readyz", Port: intstr.FromInt32(8443)},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := readinessProbeModified(tt.desired, tt.existing)
+			if got != tt.want {
+				t.Errorf("readinessProbeModified() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/controller/trustmanager/install_trustmanager.go
+++ b/pkg/controller/trustmanager/install_trustmanager.go
@@ -10,7 +10,8 @@ import (
 
 func (r *Reconciler) reconcileTrustManagerDeployment(trustManager *v1alpha1.TrustManager) error {
 	if err := validateTrustManagerConfig(trustManager); err != nil {
-		return common.NewIrrecoverableError(err, "%s configuration validation failed", trustManager.GetName())
+		return common.NewIrrecoverableError(err, "%s configuration validation failed", trustManager.GetName()).
+			WithConditionReason(v1alpha1.ReasonValidationFailed)
 	}
 
 	resourceLabels := getResourceLabels(trustManager)
@@ -18,7 +19,8 @@ func (r *Reconciler) reconcileTrustManagerDeployment(trustManager *v1alpha1.Trus
 
 	trustNamespace := getTrustNamespace(trustManager)
 	if err := r.validateTrustNamespace(trustNamespace); err != nil {
-		return common.NewIrrecoverableError(err, "trust namespace %q validation failed", trustNamespace)
+		return common.NewIrrecoverableError(err, "trust namespace %q validation failed", trustNamespace).
+			WithConditionReason(v1alpha1.ReasonWaitingForDependencies)
 	}
 
 	caBundleHash, err := r.createOrApplyDefaultCAPackageConfigMap(trustManager, resourceLabels, resourceAnnotations)

--- a/test/e2e/trustmanager_test.go
+++ b/test/e2e/trustmanager_test.go
@@ -1316,7 +1316,7 @@ var _ = Describe("TrustManager", Ordered, Label("Platform:Generic", "Feature:Tru
 				degradedCondition := meta.FindStatusCondition(tm.Status.Conditions, v1alpha1.Degraded)
 				g.Expect(degradedCondition).ShouldNot(BeNil())
 				g.Expect(degradedCondition.Status).Should(Equal(metav1.ConditionTrue))
-				g.Expect(degradedCondition.Reason).Should(Equal(v1alpha1.ReasonFailed))
+				g.Expect(degradedCondition.Reason).Should(Equal(v1alpha1.ReasonWaitingForDependencies))
 				g.Expect(degradedCondition.Message).Should(And(
 					ContainSubstring("trust namespace"),
 					ContainSubstring(nonExistentNS),
@@ -1326,10 +1326,12 @@ var _ = Describe("TrustManager", Ordered, Label("Platform:Generic", "Feature:Tru
 				readyCondition := meta.FindStatusCondition(tm.Status.Conditions, v1alpha1.Ready)
 				g.Expect(readyCondition).ShouldNot(BeNil())
 				g.Expect(readyCondition.Status).Should(Equal(metav1.ConditionFalse))
-				g.Expect(readyCondition.Reason).Should(Equal(v1alpha1.ReasonFailed))
-				// Irrecoverable path: Ready message is left empty; detail is on Degraded only
-				// (see HandleReconcileResult for IsIrrecoverableError).
+				g.Expect(readyCondition.Reason).Should(Equal(v1alpha1.ReasonWaitingForDependencies))
 				g.Expect(readyCondition.Message).Should(BeEmpty())
+
+				progressingCondition := meta.FindStatusCondition(tm.Status.Conditions, v1alpha1.Progressing)
+				g.Expect(progressingCondition).ShouldNot(BeNil())
+				g.Expect(progressingCondition.Status).Should(Equal(metav1.ConditionFalse))
 			}, lowTimeout, fastPollInterval).Should(Succeed())
 
 			// Irrecoverable errors are not requeued, and Namespace is not watched, so creating the


### PR DESCRIPTION
## Summary

Adds two improvements to the cert-manager operator:

### Health probes

The operator deployment is the only cert-manager component without Kubernetes health probes. Since the library-go `controllercmd` framework already serves `/healthz` and `/readyz` over HTTPS on port 8443 via its GenericAPIServer, this change only requires manifest updates -- no Go code changes.

- **Liveness** (`/healthz`): ping, log, post-start hooks
- **Readiness** (`/readyz`): same checks plus `shutdown`, allowing the pod to drain traffic during graceful termination

### Richer status conditions

IstioCSR and TrustManager CRs previously reported only `Ready` and `Degraded` conditions with generic reason strings (`Failed`, `Ready`, `Progressing`). Users could not determine why a resource was progressing or degraded without reading operator logs.

This change adds:
- A **`Progressing`** condition type alongside `Ready` and `Degraded`
- Specific reason constants: `Reconciling`, `WaitingForDependencies`, `ValidationFailed`, `MultipleInstancesFound`
- A `ConditionReason` field on `ReconcileError` with a `WithConditionReason()` chainable setter
- Updated `HandleReconcileResult` to manage all three conditions and extract specific reasons from the error chain

**Behavioral change:** Duplicate-instance errors now report `MultipleInstancesFound` as the condition reason instead of the previous generic `Failed`. Validation errors report `ValidationFailed`.

## Related PRs

| PR | Title | Status |
|----|-------|--------|
| [openshift/cert-manager-operator#419](https://github.com/openshift/cert-manager-operator/pull/419) | [CM-1039](https://redhat.atlassian.net/browse/CM-1039): Thread context.Context from Reconcile() through controller helpers | Open |
| [openshift/cert-manager-operator#420](https://github.com/openshift/cert-manager-operator/pull/420) | [CM-1040](https://redhat.atlassian.net/browse/CM-1040): Extract shared ApplyResource helper and migrate istiocsr to SSA | Open |
| [openshift/cert-manager-operator#461](https://github.com/openshift/cert-manager-operator/pull/461) | [CNF-26153](https://redhat.atlassian.net/browse/CNF-26153): Add unit tests across codebase to close coverage gaps | Open |
| [openshift/cert-manager-operator#464](https://github.com/openshift/cert-manager-operator/pull/464) | [CNF-26150](https://redhat.atlassian.net/browse/CNF-26150): Fix flaky e2e ConditionMatcher.Matches early-return | Open |

## Jira

- [CM-1114](https://issues.redhat.com/browse/CM-1114) — Add health probes and richer status conditions

## Test Plan

### Health probes

Verified probe endpoints respond correctly on a running operator:

```
$ curl -sk "https://localhost:8443/healthz?verbose"
[+]ping ok
[+]log ok
[+]poststarthook/max-in-flight-filter ok
[+]poststarthook/storage-object-count-tracker-hook ok
healthz check passed

$ curl -sk "https://localhost:8443/readyz?verbose"
[+]ping ok
[+]log ok
[+]poststarthook/max-in-flight-filter ok
[+]poststarthook/storage-object-count-tracker-hook ok
[+]shutdown ok
readyz check passed
```

### Status conditions

- [x] All unit tests pass (123/123 Ginkgo specs + all Go packages)
- [x] No lint issues from changed files
- [x] Verified on OCP 4.22 cluster — all three conditions visible with correct reasons
- [ ] E2E tests pass