### PR TITLE
CM-1039: Thread context.Context from Reconcile() through controller helpers

### DIFF
--- a/pkg/controller/istiocsr/certificates.go
+++ b/pkg/controller/istiocsr/certificates.go
@@ -1,6 +1,7 @@
 package istiocsr
 
 import (
+	"context"
 	"fmt"
 	"maps"
 
@@ -16,7 +17,7 @@ import (
 	"github.com/openshift/cert-manager-operator/pkg/operator/assets"
 )
 
-func (r *Reconciler) createOrApplyCertificates(istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
+func (r *Reconciler) createOrApplyCertificates(ctx context.Context, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
 	desired, err := r.getCertificateObject(istiocsr, resourceLabels)
 	if err != nil {
 		return fmt.Errorf("failed to generate certificate resource for creation in %s: %w", istiocsr.GetNamespace(), err)
@@ -25,7 +26,7 @@ func (r *Reconciler) createOrApplyCertificates(istiocsr *v1alpha1.IstioCSR, reso
 	certificateName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling certificate resource", "name", certificateName)
 	fetched := &certmanagerv1.Certificate{}
-	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), fetched)
+	exist, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), fetched)
 	if err != nil {
 		return common.FromClientError(err, "failed to check %s certificate resource already exists", certificateName)
 	}
@@ -36,7 +37,7 @@ func (r *Reconciler) createOrApplyCertificates(istiocsr *v1alpha1.IstioCSR, reso
 		}
 		if hasObjectChanged(desired, fetched) {
 			r.log.V(1).Info("certificate has been modified, updating to desired state", "name", certificateName)
-			if err := r.UpdateWithRetry(r.ctx, desired); err != nil {
+			if err := r.UpdateWithRetry(ctx, desired); err != nil {
 				return common.FromClientError(err, "failed to update %s certificate resource", certificateName)
 			}
 			r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "certificate resource %s reconciled back to desired state", certificateName)
@@ -46,7 +47,7 @@ func (r *Reconciler) createOrApplyCertificates(istiocsr *v1alpha1.IstioCSR, reso
 	}
 
 	if !exist {
-		if err := r.Create(r.ctx, desired); err != nil {
+		if err := r.Create(ctx, desired); err != nil {
 			return common.FromClientError(err, "failed to create %s certificate resource", certificateName)
 		}
 		r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "certificate resource %s created", certificateName)

--- a/pkg/controller/istiocsr/certificates_test.go
+++ b/pkg/controller/istiocsr/certificates_test.go
@@ -223,7 +223,7 @@ func TestCreateOrApplyCertificates(t *testing.T) {
 			}, istiocsr); err != nil {
 				t.Errorf("test error: %v", err)
 			}
-			err := r.createOrApplyCertificates(istiocsr, controllerDefaultResourceLabels, false)
+			err := r.createOrApplyCertificates(context.Background(), istiocsr, controllerDefaultResourceLabels, false)
 			if (tt.wantErr != "" || err != nil) && (err == nil || err.Error() != tt.wantErr) {
 				t.Errorf("createOrApplyCertificates() err: %v, wantErr: %v", err, tt.wantErr)
 			}

--- a/pkg/controller/istiocsr/controller.go
+++ b/pkg/controller/istiocsr/controller.go
@@ -39,7 +39,6 @@ const RequestEnqueueLabelValue = "cert-manager-istio-csr"
 type Reconciler struct {
 	common.CtrlClient
 
-	ctx           context.Context
 	eventRecorder record.EventRecorder
 	log           logr.Logger
 	scheme        *runtime.Scheme
@@ -58,7 +57,6 @@ func New(mgr ctrl.Manager) (*Reconciler, error) {
 	}
 	return &Reconciler{
 		CtrlClient:    c,
-		ctx:           context.Background(),
 		eventRecorder: mgr.GetEventRecorderFor(ControllerName),
 		log:           ctrl.Log.WithName(ControllerName),
 		scheme:        mgr.GetScheme(),
@@ -178,7 +176,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if !istiocsr.DeletionTimestamp.IsZero() {
 		r.log.V(1).Info("istiocsr.openshift.operator.io is marked for deletion", "namespace", req.NamespacedName)
 
-		if requeue, err := r.cleanUp(istiocsr); err != nil {
+		if requeue, err := r.cleanUp(ctx, istiocsr); err != nil {
 			return ctrl.Result{}, fmt.Errorf("clean up failed for %q istiocsr.openshift.operator.io instance deletion: %w", req.NamespacedName, err)
 		} else if requeue {
 			return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
@@ -197,17 +195,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, fmt.Errorf("failed to update %q istiocsr.openshift.operator.io with finalizers: %w", req.NamespacedName, err)
 	}
 
-	return r.processReconcileRequest(istiocsr, req.NamespacedName)
+	return r.processReconcileRequest(ctx, istiocsr, req.NamespacedName)
 }
 
-func (r *Reconciler) processReconcileRequest(istiocsr *v1alpha1.IstioCSR, req types.NamespacedName) (ctrl.Result, error) {
+func (r *Reconciler) processReconcileRequest(ctx context.Context, istiocsr *v1alpha1.IstioCSR, req types.NamespacedName) (ctrl.Result, error) {
 	istioCSRCreateRecon := false
 	if !containsProcessedAnnotation(istiocsr) && reflect.DeepEqual(istiocsr.Status, v1alpha1.IstioCSRStatus{}) {
 		r.log.V(1).Info("starting reconciliation of newly created istiocsr", "namespace", istiocsr.GetNamespace(), "name", istiocsr.GetName())
 		istioCSRCreateRecon = true
 	}
 
-	if err := r.disallowMultipleIstioCSRInstances(istiocsr); err != nil {
+	if err := r.disallowMultipleIstioCSRInstances(ctx, istiocsr); err != nil {
 		if common.IsMultipleInstanceError(err) {
 			r.eventRecorder.Eventf(istiocsr, corev1.EventTypeWarning, "MultiIstioCSRInstance", "creation of multiple istiocsr instances is not supported, will not be processed")
 			err = nil
@@ -215,7 +213,7 @@ func (r *Reconciler) processReconcileRequest(istiocsr *v1alpha1.IstioCSR, req ty
 		return ctrl.Result{}, err
 	}
 
-	reconcileErr := r.reconcileIstioCSRDeployment(istiocsr, istioCSRCreateRecon)
+	reconcileErr := r.reconcileIstioCSRDeployment(ctx, istiocsr, istioCSRCreateRecon)
 	if reconcileErr != nil {
 		r.log.Error(reconcileErr, "failed to reconcile IstioCSR deployment", "request", req)
 	}
@@ -225,7 +223,7 @@ func (r *Reconciler) processReconcileRequest(istiocsr *v1alpha1.IstioCSR, req ty
 		reconcileErr,
 		r.log.WithValues("namespace", istiocsr.GetNamespace(), "name", istiocsr.GetName()),
 		func(prependErr error) error {
-			return r.updateCondition(istiocsr, prependErr)
+			return r.updateCondition(ctx, istiocsr, prependErr)
 		},
 		defaultRequeueTime,
 	)
@@ -234,7 +232,7 @@ func (r *Reconciler) processReconcileRequest(istiocsr *v1alpha1.IstioCSR, req ty
 // cleanUp handles deletion of istiocsr.openshift.operator.io gracefully.
 //
 //nolint:unparam // error return is kept for future implementation
-func (r *Reconciler) cleanUp(istiocsr *v1alpha1.IstioCSR) (bool, error) {
+func (r *Reconciler) cleanUp(_ context.Context, istiocsr *v1alpha1.IstioCSR) (bool, error) {
 	// TODO: For GA, handle cleaning up of resources created for installing istio-csr operand.
 	// This might require a validation webhook to check for usage of service as GRPC endpoint in
 	// any of OpenShift Service Mesh or Istiod deployments to avoid disruptions across cluster.

--- a/pkg/controller/istiocsr/controller_test.go
+++ b/pkg/controller/istiocsr/controller_test.go
@@ -759,7 +759,7 @@ func TestProcessReconcileRequest(t *testing.T) {
 			}
 			r.CtrlClient = mock
 			istiocsr := tt.getIstioCSR()
-			_, err := r.processReconcileRequest(istiocsr,
+			_, err := r.processReconcileRequest(context.Background(), istiocsr,
 				types.NamespacedName{Name: istiocsr.GetName(), Namespace: istiocsr.GetNamespace()})
 			if (tt.wantErr != "" || err != nil) && (err == nil || err.Error() != tt.wantErr) {
 				t.Errorf("processReconcileRequest() err: %v, wantErr: %v", err, tt.wantErr)

--- a/pkg/controller/istiocsr/deployments.go
+++ b/pkg/controller/istiocsr/deployments.go
@@ -1,6 +1,7 @@
 package istiocsr
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -28,8 +29,8 @@ const (
 
 var errInvalidIssuerRefConfig = fmt.Errorf("invalid issuerRef config")
 
-func (r *Reconciler) createOrApplyDeployments(istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
-	desired, err := r.getDeploymentObject(istiocsr, resourceLabels)
+func (r *Reconciler) createOrApplyDeployments(ctx context.Context, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
+	desired, err := r.getDeploymentObject(ctx, istiocsr, resourceLabels)
 	if err != nil {
 		return fmt.Errorf("failed to generate deployment resource for creation in %s: %w", istiocsr.GetNamespace(), err)
 	}
@@ -37,7 +38,7 @@ func (r *Reconciler) createOrApplyDeployments(istiocsr *v1alpha1.IstioCSR, resou
 	deploymentName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling deployment resource", "name", deploymentName)
 	fetched := &appsv1.Deployment{}
-	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), fetched)
+	exist, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), fetched)
 	if err != nil {
 		return common.FromClientError(err, "failed to check %s deployment resource already exists", deploymentName)
 	}
@@ -48,7 +49,7 @@ func (r *Reconciler) createOrApplyDeployments(istiocsr *v1alpha1.IstioCSR, resou
 		}
 		if hasObjectChanged(desired, fetched) {
 			r.log.V(1).Info("deployment has been modified, updating to desired state", "name", deploymentName)
-			if err := r.UpdateWithRetry(r.ctx, desired); err != nil {
+			if err := r.UpdateWithRetry(ctx, desired); err != nil {
 				return common.FromClientError(err, "failed to update %s deployment resource", deploymentName)
 			}
 			r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "deployment resource %s reconciled back to desired state", deploymentName)
@@ -58,20 +59,20 @@ func (r *Reconciler) createOrApplyDeployments(istiocsr *v1alpha1.IstioCSR, resou
 	}
 
 	if !exist {
-		if err := r.Create(r.ctx, desired); err != nil {
+		if err := r.Create(ctx, desired); err != nil {
 			return common.FromClientError(err, "failed to create %s deployment resource", deploymentName)
 		}
 		r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "deployment resource %s created", deploymentName)
 	}
 
-	if err := r.updateImageInStatus(istiocsr, desired); err != nil {
+	if err := r.updateImageInStatus(ctx, istiocsr, desired); err != nil {
 		return common.FromClientError(err, "failed to update %s/%s istiocsr status with image info", istiocsr.GetNamespace(), istiocsr.GetName())
 	}
 	return nil
 }
 
-func (r *Reconciler) getDeploymentObject(istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string) (*appsv1.Deployment, error) {
-	if err := r.assertIssuerRefExists(istiocsr); err != nil {
+func (r *Reconciler) getDeploymentObject(ctx context.Context, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string) (*appsv1.Deployment, error) {
+	if err := r.assertIssuerRefExists(ctx, istiocsr); err != nil {
 		return nil, fmt.Errorf("failed to verify issuer in %s/%s: %w", istiocsr.GetNamespace(), istiocsr.GetName(), err)
 	}
 
@@ -98,7 +99,7 @@ func (r *Reconciler) getDeploymentObject(istiocsr *v1alpha1.IstioCSR, resourceLa
 	if err := r.updateImage(deployment); err != nil {
 		return nil, common.NewIrrecoverableError(err, "failed to update image %s/%s", istiocsr.GetNamespace(), istiocsr.GetName())
 	}
-	if err := r.updateVolumes(deployment, istiocsr, resourceLabels); err != nil {
+	if err := r.updateVolumes(ctx, deployment, istiocsr, resourceLabels); err != nil {
 		return nil, fmt.Errorf("failed to update volume %s/%s: %w", istiocsr.GetNamespace(), istiocsr.GetName(), err)
 	}
 
@@ -118,7 +119,7 @@ func (r *Reconciler) updateImage(deployment *appsv1.Deployment) error {
 	return nil
 }
 
-func (r *Reconciler) updateImageInStatus(istiocsr *v1alpha1.IstioCSR, deployment *appsv1.Deployment) error {
+func (r *Reconciler) updateImageInStatus(ctx context.Context, istiocsr *v1alpha1.IstioCSR, deployment *appsv1.Deployment) error {
 	for _, container := range deployment.Spec.Template.Spec.Containers {
 		if container.Name == istiocsrContainerName {
 			if istiocsr.Status.IstioCSRImage == container.Image {
@@ -127,7 +128,7 @@ func (r *Reconciler) updateImageInStatus(istiocsr *v1alpha1.IstioCSR, deployment
 			istiocsr.Status.IstioCSRImage = container.Image
 		}
 	}
-	return r.updateStatus(r.ctx, istiocsr)
+	return r.updateStatus(ctx, istiocsr)
 }
 
 func updatePodTemplateLabels(deployment *appsv1.Deployment, resourceLabels map[string]string) {
@@ -233,7 +234,7 @@ func updateNodeSelector(deployment *appsv1.Deployment, istiocsr *v1alpha1.IstioC
 	return nil
 }
 
-func (r *Reconciler) assertIssuerRefExists(istiocsr *v1alpha1.IstioCSR) error {
+func (r *Reconciler) assertIssuerRefExists(ctx context.Context, istiocsr *v1alpha1.IstioCSR) error {
 	issuerRefKind := strings.ToLower(istiocsr.Spec.IstioCSRConfig.CertManager.IssuerRef.Kind)
 	if issuerRefKind != clusterIssuerKind && issuerRefKind != issuerKind {
 		return common.NewIrrecoverableError(errInvalidIssuerRefConfig, "spec.istioCSRConfig.certManager.issuerRef.kind can be any of `%s` or `%s`, configured: %s", clusterIssuerKind, issuerKind, issuerRefKind)
@@ -244,7 +245,7 @@ func (r *Reconciler) assertIssuerRefExists(istiocsr *v1alpha1.IstioCSR) error {
 		return common.NewIrrecoverableError(errInvalidIssuerRefConfig, "spec.istioCSRConfig.certManager.issuerRef.group can be only `%s`, configured: %s", issuerGroup, issuerRefGroup)
 	}
 
-	obj, err := r.getIssuer(istiocsr)
+	obj, err := r.getIssuer(ctx, istiocsr)
 	if err != nil {
 		return common.FromClientError(err, "failed to fetch issuer")
 	}
@@ -268,17 +269,17 @@ func (r *Reconciler) assertIssuerRefExists(istiocsr *v1alpha1.IstioCSR) error {
 		return common.NewIrrecoverableError(errInvalidIssuerRefConfig, "spec.istioCSRConfig.certManager.issuerRef uses unsupported ACME issuer")
 	}
 
-	if err := r.updateWatchLabel(obj, istiocsr); err != nil {
+	if err := r.updateWatchLabel(ctx, obj, istiocsr); err != nil {
 		return common.FromClientError(err, "failed to update watch label on cert-manager issuer %s", istiocsr.Spec.IstioCSRConfig.CertManager.IssuerRef.Name)
 	}
 
 	return nil
 }
 
-func (r *Reconciler) updateVolumes(deployment *appsv1.Deployment, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string) error {
+func (r *Reconciler) updateVolumes(ctx context.Context, deployment *appsv1.Deployment, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string) error {
 	// Use user-configured CA certificate if provided
 	if istiocsr.Spec.IstioCSRConfig.CertManager.IstioCACertificate != nil {
-		if err := r.handleUserProvidedCA(deployment, istiocsr, resourceLabels); err != nil {
+		if err := r.handleUserProvidedCA(ctx, deployment, istiocsr, resourceLabels); err != nil {
 			return common.FromError(err, "failed to validate and mount CA certificate ConfigMap")
 		}
 		return nil
@@ -286,7 +287,7 @@ func (r *Reconciler) updateVolumes(deployment *appsv1.Deployment, istiocsr *v1al
 
 	// Fall back to issuer-based CA certificate if CA certificate is not configured
 	// Handle issuer-based CA configuration
-	if err := r.handleIssuerBasedCA(deployment, istiocsr, resourceLabels); err != nil {
+	if err := r.handleIssuerBasedCA(ctx, deployment, istiocsr, resourceLabels); err != nil {
 		return err
 	}
 
@@ -306,7 +307,7 @@ func (r *Reconciler) updateVolumes(deployment *appsv1.Deployment, istiocsr *v1al
 // is not nil before calling this function to avoid a panic.
 //
 // Returns an error if any validation fails or if ConfigMap operations fail.
-func (r *Reconciler) handleUserProvidedCA(deployment *appsv1.Deployment, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string) error {
+func (r *Reconciler) handleUserProvidedCA(ctx context.Context, deployment *appsv1.Deployment, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string) error {
 	caCertConfig := istiocsr.Spec.IstioCSRConfig.CertManager.IstioCACertificate
 
 	// Determine the namespace - use specified namespace or default to IstioCSR namespace
@@ -322,14 +323,14 @@ func (r *Reconciler) handleUserProvidedCA(deployment *appsv1.Deployment, istiocs
 	}
 
 	sourceConfigMap := &corev1.ConfigMap{}
-	if err := r.Get(r.ctx, sourceConfigMapKey, sourceConfigMap); err != nil {
+	if err := r.Get(ctx, sourceConfigMapKey, sourceConfigMap); err != nil {
 		return common.NewIrrecoverableError(err, "failed to fetch CA certificate ConfigMap %s/%s", sourceConfigMapKey.Namespace, sourceConfigMapKey.Name)
 	}
 
 	// Add watch label to the source ConfigMap to trigger reconciliation on changes.
 	// This is done before validation so that if validation fails now, fixing the ConfigMap
 	// will trigger reconciliation.
-	if err := r.updateWatchLabel(sourceConfigMap, istiocsr); err != nil {
+	if err := r.updateWatchLabel(ctx, sourceConfigMap, istiocsr); err != nil {
 		return common.FromClientError(err, "failed to update watch label on CA certificate ConfigMap %s/%s", sourceConfigMapKey.Namespace, sourceConfigMapKey.Name)
 	}
 
@@ -352,7 +353,7 @@ func (r *Reconciler) handleUserProvidedCA(deployment *appsv1.Deployment, istiocs
 	// ConfigMap triggers reconciliation when modified, allowing the operator to re-validate and update
 	// its managed copy. Additionally, if a user directly modifies the operator-managed copy, it will be
 	// reconciled back to the desired state derived from the validated source ConfigMap.
-	if err := r.createOrUpdateCAConfigMap(istiocsr, pemData, resourceLabels); err != nil {
+	if err := r.createOrUpdateCAConfigMap(ctx, istiocsr, pemData, resourceLabels); err != nil {
 		return common.FromClientError(err, "failed to create CA certificate ConfigMap copy")
 	}
 
@@ -363,12 +364,12 @@ func (r *Reconciler) handleUserProvidedCA(deployment *appsv1.Deployment, istiocs
 }
 
 // handleIssuerBasedCA handles the creation of CA ConfigMap from issuer secret and volume mounting.
-func (r *Reconciler) handleIssuerBasedCA(deployment *appsv1.Deployment, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string) error {
+func (r *Reconciler) handleIssuerBasedCA(ctx context.Context, deployment *appsv1.Deployment, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string) error {
 	var (
 		issuerConfig certmanagerv1.IssuerConfig
 	)
 
-	obj, err := r.getIssuer(istiocsr)
+	obj, err := r.getIssuer(ctx, istiocsr)
 	if err != nil {
 		return common.FromClientError(err, "failed to fetch issuer")
 	}
@@ -392,14 +393,14 @@ func (r *Reconciler) handleIssuerBasedCA(deployment *appsv1.Deployment, istiocsr
 	shouldUpdateVolume := false
 
 	if issuerConfig.CA != nil && issuerConfig.CA.SecretName != "" {
-		if err := r.createCAConfigMapFromIssuerSecret(istiocsr, issuerConfig, resourceLabels); err != nil {
+		if err := r.createCAConfigMapFromIssuerSecret(ctx, istiocsr, issuerConfig, resourceLabels); err != nil {
 			return common.FromClientError(err, "failed to create CA ConfigMap")
 		}
 		shouldUpdateVolume = true
 	}
 
 	if issuerConfig.CA == nil {
-		if err := r.createCAConfigMapFromIstiodCertificate(istiocsr, resourceLabels); err != nil {
+		if err := r.createCAConfigMapFromIstiodCertificate(ctx, istiocsr, resourceLabels); err != nil {
 			return common.FromClientError(err, "failed to create CA ConfigMap")
 		}
 		shouldUpdateVolume = true
@@ -483,7 +484,7 @@ func updateVolumeWithIssuerCA(deployment *appsv1.Deployment) {
 	}
 }
 
-func (r *Reconciler) getIssuer(istiocsr *v1alpha1.IstioCSR) (client.Object, error) {
+func (r *Reconciler) getIssuer(ctx context.Context, istiocsr *v1alpha1.IstioCSR) (client.Object, error) {
 	issuerRefKind := strings.ToLower(istiocsr.Spec.IstioCSRConfig.CertManager.IssuerRef.Kind)
 	key := client.ObjectKey{
 		Name:      istiocsr.Spec.IstioCSRConfig.CertManager.IssuerRef.Name,
@@ -498,13 +499,13 @@ func (r *Reconciler) getIssuer(istiocsr *v1alpha1.IstioCSR) (client.Object, erro
 		object = &certmanagerv1.Issuer{}
 	}
 
-	if err := r.Get(r.ctx, key, object); err != nil {
+	if err := r.Get(ctx, key, object); err != nil {
 		return nil, fmt.Errorf("failed to fetch %q issuer: %w", key, err)
 	}
 	return object, nil
 }
 
-func (r *Reconciler) createCAConfigMapFromIstiodCertificate(istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string) error {
+func (r *Reconciler) createCAConfigMapFromIstiodCertificate(ctx context.Context, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string) error {
 	istiodCertificate, err := r.getCertificateObject(istiocsr, resourceLabels)
 	if err != nil {
 		return common.FromClientError(err, "failed to fetch istiod certificate")
@@ -515,18 +516,18 @@ func (r *Reconciler) createCAConfigMapFromIstiodCertificate(istiocsr *v1alpha1.I
 		Namespace: istiodCertificate.GetNamespace(),
 	}
 	secret := &corev1.Secret{}
-	if err := r.Get(r.ctx, secretKey, secret); err != nil {
+	if err := r.Get(ctx, secretKey, secret); err != nil {
 		return fmt.Errorf("failed to fetch secret in issuer: %w", err)
 	}
-	if err := r.updateWatchLabel(secret, istiocsr); err != nil {
+	if err := r.updateWatchLabel(ctx, secret, istiocsr); err != nil {
 		return err
 	}
 
 	certData := string(secret.Data[IstiocsrCAKeyName])
-	return r.createOrUpdateCAConfigMap(istiocsr, certData, resourceLabels)
+	return r.createOrUpdateCAConfigMap(ctx, istiocsr, certData, resourceLabels)
 }
 
-func (r *Reconciler) createCAConfigMapFromIssuerSecret(istiocsr *v1alpha1.IstioCSR, issuerConfig certmanagerv1.IssuerConfig, resourceLabels map[string]string) error {
+func (r *Reconciler) createCAConfigMapFromIssuerSecret(ctx context.Context, istiocsr *v1alpha1.IstioCSR, issuerConfig certmanagerv1.IssuerConfig, resourceLabels map[string]string) error {
 	if issuerConfig.CA.SecretName == "" {
 		return fmt.Errorf("failed to fetch CA certificate configured for the %s issuer of CA type", istiocsr.Spec.IstioCSRConfig.CertManager.IssuerRef.Name)
 	}
@@ -536,19 +537,19 @@ func (r *Reconciler) createCAConfigMapFromIssuerSecret(istiocsr *v1alpha1.IstioC
 		Namespace: istiocsr.Spec.IstioCSRConfig.Istio.Namespace,
 	}
 	secret := &corev1.Secret{}
-	if err := r.Get(r.ctx, secretKey, secret); err != nil {
+	if err := r.Get(ctx, secretKey, secret); err != nil {
 		return fmt.Errorf("failed to fetch secret in issuer: %w", err)
 	}
-	if err := r.updateWatchLabel(secret, istiocsr); err != nil {
+	if err := r.updateWatchLabel(ctx, secret, istiocsr); err != nil {
 		return err
 	}
 
 	certData := string(secret.Data[IstiocsrCAKeyName])
-	return r.createOrUpdateCAConfigMap(istiocsr, certData, resourceLabels)
+	return r.createOrUpdateCAConfigMap(ctx, istiocsr, certData, resourceLabels)
 }
 
 // createOrUpdateCAConfigMap creates or updates the CA ConfigMap with the provided certificate data.
-func (r *Reconciler) createOrUpdateCAConfigMap(istiocsr *v1alpha1.IstioCSR, certData string, resourceLabels map[string]string) error {
+func (r *Reconciler) createOrUpdateCAConfigMap(ctx context.Context, istiocsr *v1alpha1.IstioCSR, certData string, resourceLabels map[string]string) error {
 	if certData == "" {
 		return fmt.Errorf("failed to find CA certificate")
 	}
@@ -558,7 +559,7 @@ func (r *Reconciler) createOrUpdateCAConfigMap(istiocsr *v1alpha1.IstioCSR, cert
 		Namespace: istiocsr.GetNamespace(),
 	}
 	fetched := &corev1.ConfigMap{}
-	exist, err := r.Exists(r.ctx, configmapKey, fetched)
+	exist, err := r.Exists(ctx, configmapKey, fetched)
 	if err != nil {
 		return fmt.Errorf("failed to check if CA configmap exists: %w", err)
 	}
@@ -576,7 +577,7 @@ func (r *Reconciler) createOrUpdateCAConfigMap(istiocsr *v1alpha1.IstioCSR, cert
 
 	if exist && hasObjectChanged(desired, fetched) {
 		r.log.V(1).Info("ca configmap need update", "name", configmapKey)
-		if err := r.UpdateWithRetry(r.ctx, desired); err != nil {
+		if err := r.UpdateWithRetry(ctx, desired); err != nil {
 			return fmt.Errorf("failed to update %s configmap resource: %w", configmapKey, err)
 		}
 		r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "configmap resource %s reconciled back to desired state", configmapKey)
@@ -585,7 +586,7 @@ func (r *Reconciler) createOrUpdateCAConfigMap(istiocsr *v1alpha1.IstioCSR, cert
 	}
 
 	if !exist {
-		if err := r.Create(r.ctx, desired); err != nil {
+		if err := r.Create(ctx, desired); err != nil {
 			return fmt.Errorf("failed to create %s configmap resource: %w", configmapKey, err)
 		}
 		r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "configmap resource %s created", configmapKey)
@@ -631,7 +632,7 @@ func (r *Reconciler) validatePEMData(pemData string) error {
 }
 
 // updateWatchLabel adds a watch label to any Kubernetes object that supports labels.
-func (r *Reconciler) updateWatchLabel(obj client.Object, istiocsr *v1alpha1.IstioCSR) error {
+func (r *Reconciler) updateWatchLabel(ctx context.Context, obj client.Object, istiocsr *v1alpha1.IstioCSR) error {
 	labels := obj.GetLabels()
 	if labels == nil {
 		labels = make(map[string]string)
@@ -639,7 +640,7 @@ func (r *Reconciler) updateWatchLabel(obj client.Object, istiocsr *v1alpha1.Isti
 	labels[IstiocsrResourceWatchLabelName] = fmt.Sprintf(istiocsrResourceWatchLabelValueFmt, istiocsr.GetNamespace(), istiocsr.GetName())
 	obj.SetLabels(labels)
 
-	if err := r.UpdateWithRetry(r.ctx, obj); err != nil {
+	if err := r.UpdateWithRetry(ctx, obj); err != nil {
 		return fmt.Errorf("failed to update %s resource with watch label: %w", obj.GetName(), err)
 	}
 	return nil

--- a/pkg/controller/istiocsr/deployments_test.go
+++ b/pkg/controller/istiocsr/deployments_test.go
@@ -1082,7 +1082,7 @@ func TestCreateOrApplyDeployments(t *testing.T) {
 			if !tt.skipEnvVar {
 				t.Setenv("RELATED_IMAGE_CERT_MANAGER_ISTIOCSR", image)
 			}
-			err := r.createOrApplyDeployments(istiocsr, controllerDefaultResourceLabels, false)
+			err := r.createOrApplyDeployments(context.Background(), istiocsr, controllerDefaultResourceLabels, false)
 			if tt.wantErrSubstring {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 					t.Errorf("createOrApplyDeployments() err: %v, want substring: %q", err, tt.wantErr)

--- a/pkg/controller/istiocsr/install_instiocsr_test.go
+++ b/pkg/controller/istiocsr/install_instiocsr_test.go
@@ -121,7 +121,7 @@ func TestReconcileIstioCSRDeployment(t *testing.T) {
 				tt.preReq(r, mock)
 			}
 			r.CtrlClient = mock
-			err := r.reconcileIstioCSRDeployment(istiocsr, true)
+			err := r.reconcileIstioCSRDeployment(context.Background(), istiocsr, true)
 			if (tt.wantErr != "" || err != nil) && (err == nil || err.Error() != tt.wantErr) {
 				t.Errorf("reconcileIstioCSRDeployment() err: %v, wantErr: %v", err, tt.wantErr)
 			}

--- a/pkg/controller/istiocsr/install_istiocsr.go
+++ b/pkg/controller/istiocsr/install_istiocsr.go
@@ -1,6 +1,7 @@
 package istiocsr
 
 import (
+	"context"
 	"fmt"
 	"maps"
 
@@ -8,7 +9,7 @@ import (
 	"github.com/openshift/cert-manager-operator/pkg/controller/common"
 )
 
-func (r *Reconciler) reconcileIstioCSRDeployment(istiocsr *v1alpha1.IstioCSR, istioCSRCreateRecon bool) error {
+func (r *Reconciler) reconcileIstioCSRDeployment(ctx context.Context, istiocsr *v1alpha1.IstioCSR, istioCSRCreateRecon bool) error {
 	if err := validateIstioCSRConfig(istiocsr); err != nil {
 		return common.NewIrrecoverableError(err, "%s/%s configuration validation failed", istiocsr.GetNamespace(), istiocsr.GetName())
 	}
@@ -21,38 +22,38 @@ func (r *Reconciler) reconcileIstioCSRDeployment(istiocsr *v1alpha1.IstioCSR, is
 	}
 	maps.Copy(resourceLabels, controllerDefaultResourceLabels)
 
-	if err := r.createOrApplyNetworkPolicies(istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
+	if err := r.createOrApplyNetworkPolicies(ctx, istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
 		r.log.Error(err, "failed to reconcile network policy resources")
 		return err
 	}
 
-	if err := r.createOrApplyServices(istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
+	if err := r.createOrApplyServices(ctx, istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
 		r.log.Error(err, "failed to reconcile service resource")
 		return err
 	}
 
-	if err := r.createOrApplyServiceAccounts(istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
+	if err := r.createOrApplyServiceAccounts(ctx, istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
 		r.log.Error(err, "failed to reconcile serviceaccount resource")
 		return err
 	}
 
-	if err := r.createOrApplyRBACResource(istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
+	if err := r.createOrApplyRBACResource(ctx, istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
 		r.log.Error(err, "failed to reconcile rbac resources")
 		return err
 	}
 
-	if err := r.createOrApplyCertificates(istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
+	if err := r.createOrApplyCertificates(ctx, istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
 		r.log.Error(err, "failed to reconcile certificate resource")
 		return err
 	}
 
-	if err := r.createOrApplyDeployments(istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
+	if err := r.createOrApplyDeployments(ctx, istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
 		r.log.Error(err, "failed to reconcile deployment resource")
 		return err
 	}
 
 	if addProcessedAnnotation(istiocsr) {
-		if err := r.UpdateWithRetry(r.ctx, istiocsr); err != nil {
+		if err := r.UpdateWithRetry(ctx, istiocsr); err != nil {
 			return fmt.Errorf("failed to update processed annotation to %s/%s: %w", istiocsr.GetNamespace(), istiocsr.GetName(), err)
 		}
 	}

--- a/pkg/controller/istiocsr/networkpolicies.go
+++ b/pkg/controller/istiocsr/networkpolicies.go
@@ -1,6 +1,7 @@
 package istiocsr
 
 import (
+	"context"
 	"fmt"
 	"maps"
 
@@ -14,7 +15,7 @@ import (
 	"github.com/openshift/cert-manager-operator/pkg/operator/assets"
 )
 
-func (r *Reconciler) createOrApplyNetworkPolicies(istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
+func (r *Reconciler) createOrApplyNetworkPolicies(ctx context.Context, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
 	r.log.V(4).Info("reconciling istio-csr network policies", "namespace", istiocsr.GetNamespace(), "name", istiocsr.GetName())
 
 	// Apply static network policy assets for istio-csr
@@ -23,7 +24,7 @@ func (r *Reconciler) createOrApplyNetworkPolicies(istiocsr *v1alpha1.IstioCSR, r
 		if err != nil {
 			return fmt.Errorf("failed to get network policy from asset %s: %w", assetPath, err)
 		}
-		if err := r.createOrUpdateNetworkPolicy(obj, istioCSRCreateRecon); err != nil {
+		if err := r.createOrUpdateNetworkPolicy(ctx, obj, istioCSRCreateRecon); err != nil {
 			return fmt.Errorf("failed to create/update network policy from %s: %w", assetPath, err)
 		}
 	}
@@ -62,7 +63,7 @@ func (r *Reconciler) getNetworkPolicyFromAsset(assetPath string, istiocsr *v1alp
 	return policy, nil
 }
 
-func (r *Reconciler) createOrUpdateNetworkPolicy(policy *networkingv1.NetworkPolicy, istioCSRCreateRecon bool) error {
+func (r *Reconciler) createOrUpdateNetworkPolicy(ctx context.Context, policy *networkingv1.NetworkPolicy, istioCSRCreateRecon bool) error {
 	desired := policy.DeepCopy()
 	policyName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling network policy resource", "name", policyName)
@@ -72,7 +73,7 @@ func (r *Reconciler) createOrUpdateNetworkPolicy(policy *networkingv1.NetworkPol
 		Name:      desired.GetName(),
 		Namespace: desired.GetNamespace(),
 	}
-	exist, err := r.Exists(r.ctx, key, fetched)
+	exist, err := r.Exists(ctx, key, fetched)
 	if err != nil {
 		return common.FromClientError(err, "failed to check %s network policy resource already exists", policyName)
 	}
@@ -83,7 +84,7 @@ func (r *Reconciler) createOrUpdateNetworkPolicy(policy *networkingv1.NetworkPol
 		}
 		if hasObjectChanged(desired, fetched) {
 			r.log.V(1).Info("network policy has been modified, updating to desired state", "name", policyName)
-			if err := r.UpdateWithRetry(r.ctx, desired); err != nil {
+			if err := r.UpdateWithRetry(ctx, desired); err != nil {
 				return common.FromClientError(err, "failed to update %s network policy resource", policyName)
 			}
 			r.eventRecorder.Eventf(policy, corev1.EventTypeNormal, "Reconciled", "network policy resource %s reconciled back to desired state", policyName)
@@ -93,7 +94,7 @@ func (r *Reconciler) createOrUpdateNetworkPolicy(policy *networkingv1.NetworkPol
 	}
 
 	if !exist {
-		if err := r.Create(r.ctx, desired); err != nil {
+		if err := r.Create(ctx, desired); err != nil {
 			return common.FromClientError(err, "failed to create %s network policy resource", policyName)
 		}
 		r.eventRecorder.Eventf(policy, corev1.EventTypeNormal, "Reconciled", "network policy resource %s created", policyName)

--- a/pkg/controller/istiocsr/rbacs.go
+++ b/pkg/controller/istiocsr/rbacs.go
@@ -1,6 +1,7 @@
 package istiocsr
 
 import (
+	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -17,36 +18,36 @@ const (
 	roleBindingSubjectKind = "ServiceAccount"
 )
 
-func (r *Reconciler) createOrApplyRBACResource(istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
+func (r *Reconciler) createOrApplyRBACResource(ctx context.Context, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
 	serviceAccount := decodeServiceAccountObjBytes(assets.MustAsset(serviceAccountAssetName)).GetName()
 
-	clusterRoleName, err := r.createOrApplyClusterRoles(istiocsr, resourceLabels, istioCSRCreateRecon)
+	clusterRoleName, err := r.createOrApplyClusterRoles(ctx, istiocsr, resourceLabels, istioCSRCreateRecon)
 	if err != nil {
 		r.log.Error(err, "failed to reconcile clusterrole resource")
 		return err
 	}
 
-	if err := r.createOrApplyClusterRoleBindings(istiocsr, clusterRoleName, serviceAccount, resourceLabels, istioCSRCreateRecon); err != nil {
+	if err := r.createOrApplyClusterRoleBindings(ctx, istiocsr, clusterRoleName, serviceAccount, resourceLabels, istioCSRCreateRecon); err != nil {
 		r.log.Error(err, "failed to reconcile clusterrolebinding resource")
 		return err
 	}
 
-	if err := r.createOrApplyRoles(istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
+	if err := r.createOrApplyRoles(ctx, istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
 		r.log.Error(err, "failed to reconcile role resource")
 		return err
 	}
 
-	if err := r.createOrApplyRoleBindings(istiocsr, serviceAccount, resourceLabels, istioCSRCreateRecon); err != nil {
+	if err := r.createOrApplyRoleBindings(ctx, istiocsr, serviceAccount, resourceLabels, istioCSRCreateRecon); err != nil {
 		r.log.Error(err, "failed to reconcile rolebinding resource")
 		return err
 	}
 
-	if err := r.createOrApplyRoleForLeases(istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
+	if err := r.createOrApplyRoleForLeases(ctx, istiocsr, resourceLabels, istioCSRCreateRecon); err != nil {
 		r.log.Error(err, "failed to reconcile role for leases resource")
 		return err
 	}
 
-	if err := r.createOrApplyRoleBindingForLeases(istiocsr, serviceAccount, resourceLabels, istioCSRCreateRecon); err != nil {
+	if err := r.createOrApplyRoleBindingForLeases(ctx, istiocsr, serviceAccount, resourceLabels, istioCSRCreateRecon); err != nil {
 		r.log.Error(err, "failed to reconcile rolebinding for leases resource")
 		return err
 	}
@@ -54,7 +55,7 @@ func (r *Reconciler) createOrApplyRBACResource(istiocsr *v1alpha1.IstioCSR, reso
 	return nil
 }
 
-func (r *Reconciler) createOrApplyClusterRoles(istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) (string, error) {
+func (r *Reconciler) createOrApplyClusterRoles(ctx context.Context, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) (string, error) {
 	desired := r.getClusterRoleObject(istiocsr.GetNamespace(), resourceLabels)
 
 	var (
@@ -72,7 +73,7 @@ func (r *Reconciler) createOrApplyClusterRoles(istiocsr *v1alpha1.IstioCSR, reso
 			Name:      istiocsr.Status.ClusterRole,
 			Namespace: desired.GetNamespace(),
 		}
-		exist, err = r.Exists(r.ctx, key, fetched)
+		exist, err = r.Exists(ctx, key, fetched)
 		if err != nil {
 			return "", common.FromClientError(err, "failed to check %s clusterrole resource already exists", roleName)
 		}
@@ -82,7 +83,7 @@ func (r *Reconciler) createOrApplyClusterRoles(istiocsr *v1alpha1.IstioCSR, reso
 		// resort to listing the resources and use the label selector to
 		// make sure required resource does not exist already.
 		clusterRoleList := &rbacv1.ClusterRoleList{}
-		if err := r.List(r.ctx, clusterRoleList, client.MatchingLabels(desired.GetLabels())); err != nil {
+		if err := r.List(ctx, clusterRoleList, client.MatchingLabels(desired.GetLabels())); err != nil {
 			return "", common.FromClientError(err, "failed to list clusterrole resources, impacted namespace %s", istiocsr.GetNamespace())
 		}
 		if len(clusterRoleList.Items) > 0 {
@@ -106,7 +107,7 @@ func (r *Reconciler) createOrApplyClusterRoles(istiocsr *v1alpha1.IstioCSR, reso
 			// desired is built with GenerateName for create; for update the name must match the live object.
 			desired.SetName(fetched.GetName())
 			desired.SetGenerateName("")
-			if err := r.UpdateWithRetry(r.ctx, desired); err != nil {
+			if err := r.UpdateWithRetry(ctx, desired); err != nil {
 				return "", common.FromClientError(err, "failed to update %s clusterrole resource", roleName)
 			}
 			r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "clusterrole resource %s reconciled back to desired state", roleName)
@@ -122,12 +123,12 @@ func (r *Reconciler) createOrApplyClusterRoles(istiocsr *v1alpha1.IstioCSR, reso
 		if desired.GetName() != "" {
 			roleName = fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 		}
-		if err := r.Create(r.ctx, desired); err != nil {
+		if err := r.Create(ctx, desired); err != nil {
 			return "", common.FromClientError(err, "failed to create %s clusterrole resource", roleName)
 		}
 		r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "clusterrole resource %s created", roleName)
 	}
-	if roleName, err = r.updateClusterRoleNameInStatus(istiocsr, desired, fetched); err != nil {
+	if roleName, err = r.updateClusterRoleNameInStatus(ctx, istiocsr, desired, fetched); err != nil {
 		return "", common.FromClientError(err, "failed to update %s/%s istiocsr status with %s clusterrole resource name", istiocsr.GetNamespace(), istiocsr.GetName(), roleName)
 	}
 
@@ -156,7 +157,7 @@ func useStableRBACNameForRecreate(obj client.Object, statusName string) {
 	obj.SetGenerateName("")
 }
 
-func (r *Reconciler) updateClusterRoleNameInStatus(istiocsr *v1alpha1.IstioCSR, desired, existing *rbacv1.ClusterRole) (string, error) {
+func (r *Reconciler) updateClusterRoleNameInStatus(ctx context.Context, istiocsr *v1alpha1.IstioCSR, desired, existing *rbacv1.ClusterRole) (string, error) {
 	name := desired.GetName()
 	if name == "" {
 		if existing != nil && existing.GetName() != "" {
@@ -166,10 +167,10 @@ func (r *Reconciler) updateClusterRoleNameInStatus(istiocsr *v1alpha1.IstioCSR, 
 		}
 	}
 	istiocsr.Status.ClusterRole = name
-	return name, r.updateStatus(r.ctx, istiocsr)
+	return name, r.updateStatus(ctx, istiocsr)
 }
 
-func (r *Reconciler) createOrApplyClusterRoleBindings(istiocsr *v1alpha1.IstioCSR, clusterRoleName, serviceAccount string, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
+func (r *Reconciler) createOrApplyClusterRoleBindings(ctx context.Context, istiocsr *v1alpha1.IstioCSR, clusterRoleName, serviceAccount string, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
 	desired := r.getClusterRoleBindingObject(clusterRoleName, serviceAccount, istiocsr.GetNamespace(), resourceLabels)
 
 	var (
@@ -187,7 +188,7 @@ func (r *Reconciler) createOrApplyClusterRoleBindings(istiocsr *v1alpha1.IstioCS
 			Name:      istiocsr.Status.ClusterRoleBinding,
 			Namespace: desired.GetNamespace(),
 		}
-		exist, err = r.Exists(r.ctx, key, fetched)
+		exist, err = r.Exists(ctx, key, fetched)
 		if err != nil {
 			return common.FromClientError(err, "failed to check %s clusterrolebinding resource already exists", roleBindingName)
 		}
@@ -197,7 +198,7 @@ func (r *Reconciler) createOrApplyClusterRoleBindings(istiocsr *v1alpha1.IstioCS
 		// resort to listing the resources and use the label selector to
 		// make sure required resource does not exist already.
 		clusterRoleBindingsList := &rbacv1.ClusterRoleBindingList{}
-		if err := r.List(r.ctx, clusterRoleBindingsList, client.MatchingLabels(desired.GetLabels())); err != nil {
+		if err := r.List(ctx, clusterRoleBindingsList, client.MatchingLabels(desired.GetLabels())); err != nil {
 			return common.FromClientError(err, "failed to list clusterrolebinding resources, impacted namespace %s", istiocsr.GetNamespace())
 		}
 		if len(clusterRoleBindingsList.Items) > 0 {
@@ -217,7 +218,7 @@ func (r *Reconciler) createOrApplyClusterRoleBindings(istiocsr *v1alpha1.IstioCS
 			r.eventRecorder.Eventf(istiocsr, corev1.EventTypeWarning, "ResourceAlreadyExists", "%s clusterrolebinding resource already exists, maybe from previous installation", roleBindingName)
 		}
 		if hasObjectChanged(desired, fetched) {
-			recreate, err := r.handleClusterRoleBindingModification(istiocsr, desired, fetched, roleBindingName)
+			recreate, err := r.handleClusterRoleBindingModification(ctx, istiocsr, desired, fetched, roleBindingName)
 			if err != nil {
 				return err
 			}
@@ -234,12 +235,12 @@ func (r *Reconciler) createOrApplyClusterRoleBindings(istiocsr *v1alpha1.IstioCS
 		if desired.GetName() != "" {
 			roleBindingName = fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 		}
-		if err := r.Create(r.ctx, desired); err != nil {
+		if err := r.Create(ctx, desired); err != nil {
 			return common.FromClientError(err, "failed to create %s clusterrolebinding resource", roleBindingName)
 		}
 		r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "clusterrolebinding resource %s created", roleBindingName)
 	}
-	if err := r.updateClusterRoleBindingNameInStatus(istiocsr, desired, fetched); err != nil {
+	if err := r.updateClusterRoleBindingNameInStatus(ctx, istiocsr, desired, fetched); err != nil {
 		return common.FromClientError(err, "failed to update %s/%s istiocsr status with %s clusterrolebinding resource name", istiocsr.GetNamespace(), istiocsr.GetName(), roleBindingName)
 	}
 
@@ -255,7 +256,7 @@ func (r *Reconciler) getClusterRoleBindingObject(clusterRoleName, serviceAccount
 	return clusterRoleBinding
 }
 
-func (r *Reconciler) updateClusterRoleBindingNameInStatus(istiocsr *v1alpha1.IstioCSR, desired, existing *rbacv1.ClusterRoleBinding) error {
+func (r *Reconciler) updateClusterRoleBindingNameInStatus(ctx context.Context, istiocsr *v1alpha1.IstioCSR, desired, existing *rbacv1.ClusterRoleBinding) error {
 	name := desired.GetName()
 	if name == "" {
 		if existing != nil && existing.GetName() != "" {
@@ -265,16 +266,16 @@ func (r *Reconciler) updateClusterRoleBindingNameInStatus(istiocsr *v1alpha1.Ist
 		}
 	}
 	istiocsr.Status.ClusterRoleBinding = name
-	return r.updateStatus(r.ctx, istiocsr)
+	return r.updateStatus(ctx, istiocsr)
 }
 
-func (r *Reconciler) createOrApplyRoles(istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
+func (r *Reconciler) createOrApplyRoles(ctx context.Context, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
 	desired := r.getRoleObject(istiocsr.GetNamespace(), istiocsr.Spec.IstioCSRConfig.Istio.Namespace, resourceLabels)
 
 	roleName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling role resource", "name", roleName)
 	fetched := &rbacv1.Role{}
-	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), fetched)
+	exist, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), fetched)
 	if err != nil {
 		return common.FromClientError(err, "failed to check %s role resource already exists", roleName)
 	}
@@ -285,7 +286,7 @@ func (r *Reconciler) createOrApplyRoles(istiocsr *v1alpha1.IstioCSR, resourceLab
 		}
 		if hasObjectChanged(desired, fetched) {
 			r.log.V(1).Info("role has been modified, updating to desired state", "name", roleName)
-			if err := r.UpdateWithRetry(r.ctx, desired); err != nil {
+			if err := r.UpdateWithRetry(ctx, desired); err != nil {
 				return common.FromClientError(err, "failed to update %s role resource", roleName)
 			}
 			r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "role resource %s reconciled back to desired state", roleName)
@@ -295,7 +296,7 @@ func (r *Reconciler) createOrApplyRoles(istiocsr *v1alpha1.IstioCSR, resourceLab
 	}
 
 	if !exist {
-		if err := r.Create(r.ctx, desired); err != nil {
+		if err := r.Create(ctx, desired); err != nil {
 			return common.FromClientError(err, "failed to create %s role resource", roleName)
 		}
 		r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "role resource %s created", roleName)
@@ -311,13 +312,13 @@ func (r *Reconciler) getRoleObject(istiocsrNamespace, roleNamespace string, reso
 	return role
 }
 
-func (r *Reconciler) createOrApplyRoleBindings(istiocsr *v1alpha1.IstioCSR, serviceAccount string, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
+func (r *Reconciler) createOrApplyRoleBindings(ctx context.Context, istiocsr *v1alpha1.IstioCSR, serviceAccount string, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
 	desired := r.getRoleBindingObject(serviceAccount, istiocsr.GetNamespace(), istiocsr.Spec.IstioCSRConfig.Istio.Namespace, resourceLabels)
 
 	roleBindingName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling rolebinding resource", "name", roleBindingName)
 	fetched := &rbacv1.RoleBinding{}
-	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), fetched)
+	exist, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), fetched)
 	if err != nil {
 		return common.FromClientError(err, "failed to check %s rolebinding resource already exists", roleBindingName)
 	}
@@ -328,7 +329,7 @@ func (r *Reconciler) createOrApplyRoleBindings(istiocsr *v1alpha1.IstioCSR, serv
 		}
 		if hasObjectChanged(desired, fetched) {
 			r.log.V(1).Info("rolebinding has been modified, updating to desired state", "name", roleBindingName)
-			if err := r.UpdateWithRetry(r.ctx, desired); err != nil {
+			if err := r.UpdateWithRetry(ctx, desired); err != nil {
 				return common.FromClientError(err, "failed to update %s rolebinding resource", roleBindingName)
 			}
 			r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "rolebinding resource %s reconciled back to desired state", roleBindingName)
@@ -338,7 +339,7 @@ func (r *Reconciler) createOrApplyRoleBindings(istiocsr *v1alpha1.IstioCSR, serv
 	}
 
 	if !exist {
-		if err := r.Create(r.ctx, desired); err != nil {
+		if err := r.Create(ctx, desired); err != nil {
 			return common.FromClientError(err, "failed to create %s rolebinding resource", roleBindingName)
 		}
 		r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "rolebinding resource %s created", roleBindingName)
@@ -355,13 +356,13 @@ func (r *Reconciler) getRoleBindingObject(serviceAccount, istiocsrNamespace, rol
 	return roleBinding
 }
 
-func (r *Reconciler) createOrApplyRoleForLeases(istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
+func (r *Reconciler) createOrApplyRoleForLeases(ctx context.Context, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
 	desired := r.getRoleForLeasesObject(istiocsr.GetNamespace(), istiocsr.Spec.IstioCSRConfig.Istio.Namespace, resourceLabels)
 
 	roleName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling role for lease resource", "name", roleName)
 	fetched := &rbacv1.Role{}
-	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), fetched)
+	exist, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), fetched)
 	if err != nil {
 		return common.FromClientError(err, "failed to check %s role resource already exists", roleName)
 	}
@@ -372,7 +373,7 @@ func (r *Reconciler) createOrApplyRoleForLeases(istiocsr *v1alpha1.IstioCSR, res
 		}
 		if hasObjectChanged(desired, fetched) {
 			r.log.V(1).Info("role has been modified, updating to desired state", "name", roleName)
-			if err := r.UpdateWithRetry(r.ctx, desired); err != nil {
+			if err := r.UpdateWithRetry(ctx, desired); err != nil {
 				return common.FromClientError(err, "failed to update %s role resource", roleName)
 			}
 			r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "role resource %s reconciled back to desired state", roleName)
@@ -382,7 +383,7 @@ func (r *Reconciler) createOrApplyRoleForLeases(istiocsr *v1alpha1.IstioCSR, res
 	}
 
 	if !exist {
-		if err := r.Create(r.ctx, desired); err != nil {
+		if err := r.Create(ctx, desired); err != nil {
 			return common.FromClientError(err, "failed to create %s role resource", roleName)
 		}
 		r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "role resource %s created", roleName)
@@ -398,13 +399,13 @@ func (r *Reconciler) getRoleForLeasesObject(istiocsrNamespace, roleNamespace str
 	return role
 }
 
-func (r *Reconciler) createOrApplyRoleBindingForLeases(istiocsr *v1alpha1.IstioCSR, serviceAccount string, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
+func (r *Reconciler) createOrApplyRoleBindingForLeases(ctx context.Context, istiocsr *v1alpha1.IstioCSR, serviceAccount string, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
 	desired := r.getRoleBindingForLeasesObject(serviceAccount, istiocsr.GetNamespace(), istiocsr.Spec.IstioCSRConfig.Istio.Namespace, resourceLabels)
 
 	roleBindingName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling rolebinding for lease resource", "name", roleBindingName)
 	fetched := &rbacv1.RoleBinding{}
-	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), fetched)
+	exist, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), fetched)
 	if err != nil {
 		return common.FromClientError(err, "failed to check %s rolebinding resource already exists", roleBindingName)
 	}
@@ -415,7 +416,7 @@ func (r *Reconciler) createOrApplyRoleBindingForLeases(istiocsr *v1alpha1.IstioC
 		}
 		if hasObjectChanged(desired, fetched) {
 			r.log.V(1).Info("rolebinding has been modified, updating to desired state", "name", roleBindingName)
-			if err := r.UpdateWithRetry(r.ctx, desired); err != nil {
+			if err := r.UpdateWithRetry(ctx, desired); err != nil {
 				return common.FromClientError(err, "failed to update %s rolebinding resource", roleBindingName)
 			}
 			r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "rolebinding resource %s reconciled back to desired state", roleBindingName)
@@ -425,7 +426,7 @@ func (r *Reconciler) createOrApplyRoleBindingForLeases(istiocsr *v1alpha1.IstioC
 	}
 
 	if !exist {
-		if err := r.Create(r.ctx, desired); err != nil {
+		if err := r.Create(ctx, desired); err != nil {
 			return common.FromClientError(err, "failed to create %s rolebinding resource", roleBindingName)
 		}
 		r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "rolebinding resource %s created", roleBindingName)
@@ -462,7 +463,7 @@ func updateServiceAccountNamespaceInRBACBindingObject[Object *rbacv1.RoleBinding
 // and then attempts an in-place update. Because the Kubernetes API treats RoleRef as immutable, a RoleRef
 // change requires deleting the existing binding first; in that case recreate is returned as true so the
 // caller can issue a fresh Create.
-func (r *Reconciler) handleClusterRoleBindingModification(istiocsr *v1alpha1.IstioCSR, desired, fetched *rbacv1.ClusterRoleBinding, roleBindingName string) (recreate bool, err error) {
+func (r *Reconciler) handleClusterRoleBindingModification(ctx context.Context, istiocsr *v1alpha1.IstioCSR, desired, fetched *rbacv1.ClusterRoleBinding, roleBindingName string) (recreate bool, err error) {
 	r.log.V(1).Info("clusterrolebinding has been modified, updating to desired state", "name", roleBindingName)
 	// desired is built with GenerateName for create; for update the name must match the live object.
 	desired.SetName(fetched.GetName())
@@ -471,7 +472,7 @@ func (r *Reconciler) handleClusterRoleBindingModification(istiocsr *v1alpha1.Ist
 	// with GenerateName) cannot be applied via Update.
 	if rbacRoleBindingRefModified(desired, fetched) {
 		r.log.V(1).Info("clusterrolebinding roleRef changed, deleting for recreation (roleRef is immutable)", "name", roleBindingName)
-		if err := r.Delete(r.ctx, fetched); err != nil {
+		if err := r.Delete(ctx, fetched); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return recreate, common.FromClientError(err, "failed to delete %s clusterrolebinding to replace roleRef", roleBindingName)
 			}
@@ -479,7 +480,7 @@ func (r *Reconciler) handleClusterRoleBindingModification(istiocsr *v1alpha1.Ist
 		recreate = true
 		return recreate, nil
 	}
-	if err := r.UpdateWithRetry(r.ctx, desired); err != nil {
+	if err := r.UpdateWithRetry(ctx, desired); err != nil {
 		return recreate, common.FromClientError(err, "failed to update %s clusterrolebinding resource", roleBindingName)
 	}
 	r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "clusterrolebinding resource %s reconciled back to desired state", roleBindingName)

--- a/pkg/controller/istiocsr/rbacs_test.go
+++ b/pkg/controller/istiocsr/rbacs_test.go
@@ -693,7 +693,7 @@ func TestCreateOrApplyRBACResource(t *testing.T) {
 			if tt.updateIstioCSR != nil {
 				tt.updateIstioCSR(istiocsr)
 			}
-			err := r.createOrApplyRBACResource(istiocsr, controllerDefaultResourceLabels, true)
+			err := r.createOrApplyRBACResource(context.Background(), istiocsr, controllerDefaultResourceLabels, true)
 			if (tt.wantErr != "" || err != nil) && (err == nil || err.Error() != tt.wantErr) {
 				t.Errorf("createOrApplyRBACResource() err: %v, wantErr: %v", err, tt.wantErr)
 			}

--- a/pkg/controller/istiocsr/serviceaccounts.go
+++ b/pkg/controller/istiocsr/serviceaccounts.go
@@ -1,6 +1,7 @@
 package istiocsr
 
 import (
+	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -11,13 +12,13 @@ import (
 	"github.com/openshift/cert-manager-operator/pkg/operator/assets"
 )
 
-func (r *Reconciler) createOrApplyServiceAccounts(istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
+func (r *Reconciler) createOrApplyServiceAccounts(ctx context.Context, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
 	desired := r.getServiceAccountObject(istiocsr, resourceLabels)
 
 	serviceAccountName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling serviceaccount resource", "name", serviceAccountName)
 	fetched := &corev1.ServiceAccount{}
-	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), fetched)
+	exist, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), fetched)
 	if err != nil {
 		return common.FromClientError(err, "failed to check %s serviceaccount resource already exists", serviceAccountName)
 	}
@@ -28,7 +29,7 @@ func (r *Reconciler) createOrApplyServiceAccounts(istiocsr *v1alpha1.IstioCSR, r
 		}
 		if hasObjectChanged(desired, fetched) {
 			r.log.V(1).Info("serviceaccount has been modified, updating to desired state", "name", serviceAccountName)
-			if err := r.UpdateWithRetry(r.ctx, desired); err != nil {
+			if err := r.UpdateWithRetry(ctx, desired); err != nil {
 				return common.FromClientError(err, "failed to update %s serviceaccount resource", serviceAccountName)
 			}
 			r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "serviceaccount resource %s reconciled back to desired state", serviceAccountName)
@@ -38,13 +39,13 @@ func (r *Reconciler) createOrApplyServiceAccounts(istiocsr *v1alpha1.IstioCSR, r
 	}
 
 	if !exist {
-		if err := r.Create(r.ctx, desired); err != nil {
+		if err := r.Create(ctx, desired); err != nil {
 			return common.FromClientError(err, "failed to create %s serviceaccount resource", serviceAccountName)
 		}
 		r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "serviceaccount resource %s created", serviceAccountName)
 	}
 
-	if err := r.updateServiceAccountNameInStatus(istiocsr, desired); err != nil {
+	if err := r.updateServiceAccountNameInStatus(ctx, istiocsr, desired); err != nil {
 		return common.FromClientError(err, "failed to update %s/%s istiocsr status with %s serviceaccount resource name", istiocsr.GetNamespace(), istiocsr.GetName(), serviceAccountName)
 	}
 	return nil
@@ -57,10 +58,10 @@ func (r *Reconciler) getServiceAccountObject(istiocsr *v1alpha1.IstioCSR, resour
 	return serviceAccount
 }
 
-func (r *Reconciler) updateServiceAccountNameInStatus(istiocsr *v1alpha1.IstioCSR, serviceAccount *corev1.ServiceAccount) error {
+func (r *Reconciler) updateServiceAccountNameInStatus(ctx context.Context, istiocsr *v1alpha1.IstioCSR, serviceAccount *corev1.ServiceAccount) error {
 	if istiocsr.Status.ServiceAccount == serviceAccount.GetName() {
 		return nil
 	}
 	istiocsr.Status.ServiceAccount = serviceAccount.GetName()
-	return r.updateStatus(r.ctx, istiocsr)
+	return r.updateStatus(ctx, istiocsr)
 }

--- a/pkg/controller/istiocsr/serviceaccounts_test.go
+++ b/pkg/controller/istiocsr/serviceaccounts_test.go
@@ -174,7 +174,7 @@ func TestCreateOrApplyServiceAccounts(t *testing.T) {
 			}
 			r.CtrlClient = mock
 			istiocsr := testIstioCSR()
-			err := r.createOrApplyServiceAccounts(istiocsr, controllerDefaultResourceLabels, tt.istioCSRCreateRecon)
+			err := r.createOrApplyServiceAccounts(context.Background(), istiocsr, controllerDefaultResourceLabels, tt.istioCSRCreateRecon)
 			if (tt.wantErr != "" || err != nil) && (err == nil || err.Error() != tt.wantErr) {
 				t.Errorf("createOrApplyServiceAccounts() err: %v, wantErr: %v", err, tt.wantErr)
 			}

--- a/pkg/controller/istiocsr/services.go
+++ b/pkg/controller/istiocsr/services.go
@@ -1,6 +1,7 @@
 package istiocsr
 
 import (
+	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -16,27 +17,27 @@ const (
 	grpcServicePortName = "web"
 )
 
-func (r *Reconciler) createOrApplyServices(istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
+func (r *Reconciler) createOrApplyServices(ctx context.Context, istiocsr *v1alpha1.IstioCSR, resourceLabels map[string]string, istioCSRCreateRecon bool) error {
 	service := r.getServiceObject(istiocsr, resourceLabels)
-	if err := r.createOrApplyService(istiocsr, service, istioCSRCreateRecon); err != nil {
+	if err := r.createOrApplyService(ctx, istiocsr, service, istioCSRCreateRecon); err != nil {
 		return err
 	}
-	if err := r.updateGRPCEndpointInStatus(istiocsr, service); err != nil {
+	if err := r.updateGRPCEndpointInStatus(ctx, istiocsr, service); err != nil {
 		return common.FromClientError(err, "failed to update %s/%s istiocsr status with %s service endpoint info", istiocsr.GetNamespace(), istiocsr.GetName(), service.GetName())
 	}
 
 	metricsService := r.getMetricsServiceObject(istiocsr, resourceLabels)
-	if err := r.createOrApplyService(istiocsr, metricsService, istioCSRCreateRecon); err != nil {
+	if err := r.createOrApplyService(ctx, istiocsr, metricsService, istioCSRCreateRecon); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (r *Reconciler) createOrApplyService(istiocsr *v1alpha1.IstioCSR, svc *corev1.Service, istioCSRCreateRecon bool) error {
+func (r *Reconciler) createOrApplyService(ctx context.Context, istiocsr *v1alpha1.IstioCSR, svc *corev1.Service, istioCSRCreateRecon bool) error {
 	serviceName := fmt.Sprintf("%s/%s", svc.GetNamespace(), svc.GetName())
 	r.log.V(4).Info("reconciling service resource", "name", serviceName)
 	fetched := &corev1.Service{}
-	exist, err := r.Exists(r.ctx, client.ObjectKeyFromObject(svc), fetched)
+	exist, err := r.Exists(ctx, client.ObjectKeyFromObject(svc), fetched)
 	if err != nil {
 		return common.FromClientError(err, "failed to check %s service resource already exists", serviceName)
 	}
@@ -47,7 +48,7 @@ func (r *Reconciler) createOrApplyService(istiocsr *v1alpha1.IstioCSR, svc *core
 		}
 		if hasObjectChanged(svc, fetched) {
 			r.log.V(1).Info("service has been modified, updating to desired state", "name", serviceName)
-			if err := r.UpdateWithRetry(r.ctx, svc); err != nil {
+			if err := r.UpdateWithRetry(ctx, svc); err != nil {
 				return common.FromClientError(err, "failed to update %s service resource", serviceName)
 			}
 			r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "service resource %s reconciled back to desired state", serviceName)
@@ -57,7 +58,7 @@ func (r *Reconciler) createOrApplyService(istiocsr *v1alpha1.IstioCSR, svc *core
 	}
 
 	if !exist {
-		if err := r.Create(r.ctx, svc); err != nil {
+		if err := r.Create(ctx, svc); err != nil {
 			return common.FromClientError(err, "failed to create %s service resource", serviceName)
 		}
 		r.eventRecorder.Eventf(istiocsr, corev1.EventTypeNormal, "Reconciled", "service resource %s created", serviceName)
@@ -90,7 +91,7 @@ func updateServicePort(service *corev1.Service, port int32) {
 	}
 }
 
-func (r *Reconciler) updateGRPCEndpointInStatus(istiocsr *v1alpha1.IstioCSR, service *corev1.Service) error {
+func (r *Reconciler) updateGRPCEndpointInStatus(ctx context.Context, istiocsr *v1alpha1.IstioCSR, service *corev1.Service) error {
 	for _, servicePort := range service.Spec.Ports {
 		if servicePort.Name == grpcServicePortName {
 			endpoint := fmt.Sprintf(istiocsrGRPCEndpointFmt, service.Name, service.Namespace, servicePort.Port)
@@ -100,5 +101,5 @@ func (r *Reconciler) updateGRPCEndpointInStatus(istiocsr *v1alpha1.IstioCSR, ser
 			istiocsr.Status.IstioCSRGRPCEndpoint = endpoint
 		}
 	}
-	return r.updateStatus(r.ctx, istiocsr)
+	return r.updateStatus(ctx, istiocsr)
 }

--- a/pkg/controller/istiocsr/services_test.go
+++ b/pkg/controller/istiocsr/services_test.go
@@ -111,7 +111,7 @@ func TestCreateOrApplyServices(t *testing.T) {
 			if tt.updateIstioCSR != nil {
 				tt.updateIstioCSR(istiocsr)
 			}
-			err := r.createOrApplyServices(istiocsr, controllerDefaultResourceLabels, false)
+			err := r.createOrApplyServices(context.Background(), istiocsr, controllerDefaultResourceLabels, false)
 			if (tt.wantErr != "" || err != nil) && (err == nil || err.Error() != tt.wantErr) {
 				t.Errorf("createOrApplyServices() err: %v, wantErr: %v", err, tt.wantErr)
 			}

--- a/pkg/controller/istiocsr/test_utils.go
+++ b/pkg/controller/istiocsr/test_utils.go
@@ -1,7 +1,6 @@
 package istiocsr
 
 import (
-	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -44,7 +43,6 @@ type CertificateTweak func(*x509.Certificate)
 
 func testReconciler(t *testing.T) *Reconciler {
 	return &Reconciler{
-		ctx:           context.Background(),
 		eventRecorder: record.NewFakeRecorder(100),
 		log:           testr.New(t),
 		scheme:        testutil.Scheme,

--- a/pkg/controller/istiocsr/utils.go
+++ b/pkg/controller/istiocsr/utils.go
@@ -478,8 +478,8 @@ func validateIstioCSRConfig(istiocsr *v1alpha1.IstioCSR) error {
 	return nil
 }
 
-func (r *Reconciler) updateCondition(istiocsr *v1alpha1.IstioCSR, prependErr error) error {
-	if err := r.updateStatus(r.ctx, istiocsr); err != nil {
+func (r *Reconciler) updateCondition(ctx context.Context, istiocsr *v1alpha1.IstioCSR, prependErr error) error {
+	if err := r.updateStatus(ctx, istiocsr); err != nil {
 		errUpdate := fmt.Errorf("failed to update %s/%s status: %w", istiocsr.GetNamespace(), istiocsr.GetName(), err)
 		if prependErr != nil {
 			return utilerrors.NewAggregate([]error{err, errUpdate})
@@ -489,7 +489,7 @@ func (r *Reconciler) updateCondition(istiocsr *v1alpha1.IstioCSR, prependErr err
 	return prependErr
 }
 
-func (r *Reconciler) disallowMultipleIstioCSRInstances(istiocsr *v1alpha1.IstioCSR) error {
+func (r *Reconciler) disallowMultipleIstioCSRInstances(ctx context.Context, istiocsr *v1alpha1.IstioCSR) error {
 	statusMessage := fmt.Sprintf("multiple instances of istiocsr exists, %s/%s will not be processed", istiocsr.GetNamespace(), istiocsr.GetName())
 
 	if containsProcessingRejectedAnnotation(istiocsr) {
@@ -497,13 +497,13 @@ func (r *Reconciler) disallowMultipleIstioCSRInstances(istiocsr *v1alpha1.IstioC
 		// ensure status is updated.
 		var updateErr error
 		if istiocsr.Status.SetCondition(v1alpha1.Ready, metav1.ConditionFalse, v1alpha1.ReasonFailed, statusMessage) {
-			updateErr = r.updateCondition(istiocsr, nil)
+			updateErr = r.updateCondition(ctx, istiocsr, nil)
 		}
 		return common.NewMultipleInstanceError(utilerrors.NewAggregate([]error{errors.New(statusMessage), updateErr}))
 	}
 
 	istiocsrList := &v1alpha1.IstioCSRList{}
-	if err := r.List(r.ctx, istiocsrList); err != nil {
+	if err := r.List(ctx, istiocsrList); err != nil {
 		return fmt.Errorf("failed to fetch list of istiocsr resources: %w", err)
 	}
 
@@ -534,10 +534,10 @@ func (r *Reconciler) disallowMultipleIstioCSRInstances(istiocsr *v1alpha1.IstioC
 	// This instance should be rejected as there's an older or equally old instance
 	var condUpdateErr, annUpdateErr error
 	if istiocsr.Status.SetCondition(v1alpha1.Ready, metav1.ConditionFalse, v1alpha1.ReasonFailed, statusMessage) {
-		condUpdateErr = r.updateCondition(istiocsr, nil)
+		condUpdateErr = r.updateCondition(ctx, istiocsr, nil)
 	}
 	if addProcessingRejectedAnnotation(istiocsr) {
-		if err := r.UpdateWithRetry(r.ctx, istiocsr); err != nil {
+		if err := r.UpdateWithRetry(ctx, istiocsr); err != nil {
 			annUpdateErr = fmt.Errorf("failed to update reject processing annotation to %s/%s: %w", istiocsr.GetNamespace(), istiocsr.GetName(), err)
 		}
 	}

--- a/pkg/controller/trustmanager/certificates.go
+++ b/pkg/controller/trustmanager/certificates.go
@@ -1,6 +1,7 @@
 package trustmanager
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"slices"
@@ -18,13 +19,13 @@ import (
 )
 
 // createOrApplyIssuer reconciles the self-signed Issuer used for trust-manager's webhook TLS.
-func (r *Reconciler) createOrApplyIssuer(trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
+func (r *Reconciler) createOrApplyIssuer(ctx context.Context, trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
 	desired := getIssuerObject(resourceLabels, resourceAnnotations)
 	resourceName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling issuer resource", "name", resourceName)
 
 	existing := &certmanagerv1.Issuer{}
-	exists, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), existing)
+	exists, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), existing)
 	if err != nil {
 		return common.FromClientError(err, "failed to check if issuer %q exists", resourceName)
 	}
@@ -34,7 +35,7 @@ func (r *Reconciler) createOrApplyIssuer(trustManager *v1alpha1.TrustManager, re
 	}
 
 	r.log.V(2).Info("issuer resource has been modified, updating to desired state", "name", resourceName)
-	if err := r.Patch(r.ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+	if err := r.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
 		return common.FromClientError(err, "failed to apply issuer %q", resourceName)
 	}
 
@@ -52,13 +53,13 @@ func getIssuerObject(resourceLabels, resourceAnnotations map[string]string) *cer
 }
 
 // createOrApplyCertificate reconciles the Certificate used for trust-manager's webhook TLS.
-func (r *Reconciler) createOrApplyCertificate(trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
+func (r *Reconciler) createOrApplyCertificate(ctx context.Context, trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
 	desired := getCertificateObject(resourceLabels, resourceAnnotations)
 	resourceName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling certificate resource", "name", resourceName)
 
 	existing := &certmanagerv1.Certificate{}
-	exists, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), existing)
+	exists, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), existing)
 	if err != nil {
 		return common.FromClientError(err, "failed to check if certificate %q exists", resourceName)
 	}
@@ -68,7 +69,7 @@ func (r *Reconciler) createOrApplyCertificate(trustManager *v1alpha1.TrustManage
 	}
 
 	r.log.V(2).Info("certificate resource has been modified, updating to desired state", "name", resourceName)
-	if err := r.Patch(r.ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+	if err := r.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
 		return common.FromClientError(err, "failed to apply certificate %q", resourceName)
 	}
 

--- a/pkg/controller/trustmanager/certificates_test.go
+++ b/pkg/controller/trustmanager/certificates_test.go
@@ -267,7 +267,7 @@ func TestIssuerReconciliation(t *testing.T) {
 				tmBuilder = testTrustManager()
 			}
 			tm := tmBuilder.Build()
-			err := r.createOrApplyIssuer(tm, getResourceLabels(tm), getResourceAnnotations(tm))
+			err := r.createOrApplyIssuer(context.Background(), tm, getResourceLabels(tm), getResourceAnnotations(tm))
 			assertError(t, err, tt.wantErr)
 
 			if got := mock.ExistsCallCount(); got != tt.wantExistsCount {
@@ -410,7 +410,7 @@ func TestCertificateReconciliation(t *testing.T) {
 				tmBuilder = testTrustManager()
 			}
 			tm := tmBuilder.Build()
-			err := r.createOrApplyCertificate(tm, getResourceLabels(tm), getResourceAnnotations(tm))
+			err := r.createOrApplyCertificate(context.Background(), tm, getResourceLabels(tm), getResourceAnnotations(tm))
 			assertError(t, err, tt.wantErr)
 
 			if got := mock.ExistsCallCount(); got != tt.wantExistsCount {

--- a/pkg/controller/trustmanager/configmaps.go
+++ b/pkg/controller/trustmanager/configmaps.go
@@ -1,6 +1,7 @@
 package trustmanager
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -27,12 +28,12 @@ type caPackage struct {
 // or updates the package ConfigMap in the operand namespace.
 // Returns the SHA-256 hash of the CA bundle content and any error.
 // Returns ("", nil) when defaultCAPackage is disabled.
-func (r *Reconciler) createOrApplyDefaultCAPackageConfigMap(trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) (string, error) {
+func (r *Reconciler) createOrApplyDefaultCAPackageConfigMap(ctx context.Context, trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) (string, error) {
 	if !defaultCAPackageEnabled(trustManager.Spec.TrustManagerConfig.DefaultCAPackage) {
 		return "", nil
 	}
 
-	caBundle, resourceVersion, err := r.readTrustedCABundle()
+	caBundle, resourceVersion, err := r.readTrustedCABundle(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -50,7 +51,7 @@ func (r *Reconciler) createOrApplyDefaultCAPackageConfigMap(trustManager *v1alph
 	r.log.V(4).Info("reconciling default CA package ConfigMap", "name", cmName)
 
 	existing := &corev1.ConfigMap{}
-	exists, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), existing)
+	exists, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), existing)
 	if err != nil {
 		return "", common.FromClientError(err, "failed to check if ConfigMap %q exists", cmName)
 	}
@@ -60,7 +61,7 @@ func (r *Reconciler) createOrApplyDefaultCAPackageConfigMap(trustManager *v1alph
 	}
 
 	r.log.V(2).Info("default CA package ConfigMap has been modified, updating to desired state", "name", cmName)
-	if err := r.Patch(r.ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+	if err := r.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
 		return "", common.FromClientError(err, "failed to apply ConfigMap %q", cmName)
 	}
 
@@ -70,13 +71,13 @@ func (r *Reconciler) createOrApplyDefaultCAPackageConfigMap(trustManager *v1alph
 
 // readTrustedCABundle reads the CNO-injected CA bundle from the operator namespace.
 // Returns the PEM bundle, the ConfigMap's resource version, and any error.
-func (r *Reconciler) readTrustedCABundle() (string, string, error) {
+func (r *Reconciler) readTrustedCABundle(ctx context.Context) (string, string, error) {
 	injectionCM := &corev1.ConfigMap{}
 	key := client.ObjectKey{
 		Namespace: common.OperatorNamespace,
 		Name:      common.TrustedCABundleConfigMapName,
 	}
-	if err := r.Get(r.ctx, key, injectionCM); err != nil {
+	if err := r.Get(ctx, key, injectionCM); err != nil {
 		return "", "", common.FromClientError(
 			err,
 			"failed to read CA bundle ConfigMap %q in namespace %q",

--- a/pkg/controller/trustmanager/configmaps_test.go
+++ b/pkg/controller/trustmanager/configmaps_test.go
@@ -318,7 +318,7 @@ func TestDefaultCAPackageConfigMapReconciliation(t *testing.T) {
 			tt.preReq(r, mock)
 
 			tm := tt.tm.Build()
-			hash, err := r.createOrApplyDefaultCAPackageConfigMap(tm, testResourceLabels(), testResourceAnnotations())
+			hash, err := r.createOrApplyDefaultCAPackageConfigMap(context.Background(), tm, testResourceLabels(), testResourceAnnotations())
 			assertError(t, err, tt.wantErr)
 
 			if tt.wantHash && hash == "" {

--- a/pkg/controller/trustmanager/controller.go
+++ b/pkg/controller/trustmanager/controller.go
@@ -38,7 +38,6 @@ const RequestEnqueueLabelValue = "cert-manager-trust-manager"
 type Reconciler struct {
 	common.CtrlClient
 
-	ctx           context.Context
 	eventRecorder record.EventRecorder
 	log           logr.Logger
 	scheme        *runtime.Scheme
@@ -68,7 +67,6 @@ func New(mgr ctrl.Manager) (*Reconciler, error) {
 	}
 	return &Reconciler{
 		CtrlClient:    c,
-		ctx:           context.Background(),
 		eventRecorder: mgr.GetEventRecorderFor(ControllerName),
 		log:           ctrl.Log.WithName(ControllerName),
 		scheme:        mgr.GetScheme(),
@@ -170,7 +168,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if !trustManager.DeletionTimestamp.IsZero() {
 		r.log.V(1).Info("trustmanager.openshift.operator.io is marked for deletion", "name", req.NamespacedName)
 
-		if requeue, err := r.cleanUp(trustManager); err != nil {
+		if requeue, err := r.cleanUp(ctx, trustManager); err != nil {
 			return ctrl.Result{}, fmt.Errorf("clean up failed for %q trustmanager.openshift.operator.io instance deletion: %w", req.NamespacedName, err)
 		} else if requeue {
 			return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
@@ -189,11 +187,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, fmt.Errorf("failed to update %q trustmanager.openshift.operator.io with finalizers: %w", req.NamespacedName, err)
 	}
 
-	return r.processReconcileRequest(trustManager, req.NamespacedName)
+	return r.processReconcileRequest(ctx, trustManager, req.NamespacedName)
 }
 
-func (r *Reconciler) processReconcileRequest(trustManager *v1alpha1.TrustManager, req types.NamespacedName) (ctrl.Result, error) {
-	reconcileErr := r.reconcileTrustManagerDeployment(trustManager)
+func (r *Reconciler) processReconcileRequest(ctx context.Context, trustManager *v1alpha1.TrustManager, req types.NamespacedName) (ctrl.Result, error) {
+	reconcileErr := r.reconcileTrustManagerDeployment(ctx, trustManager)
 	if reconcileErr != nil {
 		r.log.Error(reconcileErr, "failed to reconcile TrustManager deployment", "request", req)
 	}
@@ -203,14 +201,14 @@ func (r *Reconciler) processReconcileRequest(trustManager *v1alpha1.TrustManager
 		reconcileErr,
 		r.log.WithValues("name", trustManager.GetName()),
 		func(prependErr error) error {
-			return r.updateCondition(trustManager, prependErr)
+			return r.updateCondition(ctx, trustManager, prependErr)
 		},
 		defaultRequeueTime,
 	)
 }
 
 // cleanUp handles deletion of trustmanager.openshift.operator.io gracefully.
-func (r *Reconciler) cleanUp(trustManager *v1alpha1.TrustManager) (bool, error) {
+func (r *Reconciler) cleanUp(_ context.Context, trustManager *v1alpha1.TrustManager) (bool, error) {
 	// TODO: For GA, handle cleaning up of resources created for installing trust-manager operand.
 	// As per Non-Goals in the enhancement, removing the TrustManager CR will not remove the
 	// trust-manager deployment or its associated resources.

--- a/pkg/controller/trustmanager/controller_test.go
+++ b/pkg/controller/trustmanager/controller_test.go
@@ -345,7 +345,7 @@ func TestProcessReconcileRequest(t *testing.T) {
 			r.CtrlClient = mock
 
 			tm := tt.getTrustManager()
-			_, err := r.processReconcileRequest(tm, types.NamespacedName{Name: tm.GetName()})
+			_, err := r.processReconcileRequest(context.Background(), tm, types.NamespacedName{Name: tm.GetName()})
 			assertError(t, err, tt.wantErr)
 
 			for _, want := range tt.wantConditions {
@@ -391,7 +391,7 @@ func TestCleanUp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Reconciler{eventRecorder: record.NewFakeRecorder(10)}
-			requeue, err := r.cleanUp(tt.trustManager)
+			requeue, err := r.cleanUp(context.Background(), tt.trustManager)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("cleanUp() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/controller/trustmanager/deployments.go
+++ b/pkg/controller/trustmanager/deployments.go
@@ -1,6 +1,7 @@
 package trustmanager
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"os"
@@ -17,7 +18,7 @@ import (
 	"github.com/openshift/cert-manager-operator/pkg/operator/assets"
 )
 
-func (r *Reconciler) createOrApplyDeployment(trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string, caBundleHash string) error {
+func (r *Reconciler) createOrApplyDeployment(ctx context.Context, trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string, caBundleHash string) error {
 	desired, err := r.getDeploymentObject(trustManager, resourceLabels, resourceAnnotations, caBundleHash)
 	if err != nil {
 		return err
@@ -27,7 +28,7 @@ func (r *Reconciler) createOrApplyDeployment(trustManager *v1alpha1.TrustManager
 	r.log.V(4).Info("reconciling deployment resource", "name", deploymentName)
 
 	existing := &appsv1.Deployment{}
-	exists, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), existing)
+	exists, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), existing)
 	if err != nil {
 		return common.FromClientError(err, "failed to check if deployment %q exists", deploymentName)
 	}
@@ -37,7 +38,7 @@ func (r *Reconciler) createOrApplyDeployment(trustManager *v1alpha1.TrustManager
 	}
 
 	r.log.V(2).Info("deployment resource has been modified, updating to desired state", "name", deploymentName)
-	if err := r.Patch(r.ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+	if err := r.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
 		return common.FromClientError(err, "failed to apply deployment %q", deploymentName)
 	}
 

--- a/pkg/controller/trustmanager/deployments_test.go
+++ b/pkg/controller/trustmanager/deployments_test.go
@@ -702,7 +702,7 @@ func TestDeploymentReconciliation(t *testing.T) {
 				tmBuilder = testTrustManager()
 			}
 			tm := tmBuilder.Build()
-			err := r.createOrApplyDeployment(tm, getResourceLabels(tm), getResourceAnnotations(tm), tt.caBundleHash)
+			err := r.createOrApplyDeployment(context.Background(), tm, getResourceLabels(tm), getResourceAnnotations(tm), tt.caBundleHash)
 			assertError(t, err, tt.wantErr)
 
 			if got := mock.ExistsCallCount(); got != tt.wantExistsCount {

--- a/pkg/controller/trustmanager/install_trustmanager.go
+++ b/pkg/controller/trustmanager/install_trustmanager.go
@@ -1,6 +1,7 @@
 package trustmanager
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -8,7 +9,7 @@ import (
 	"github.com/openshift/cert-manager-operator/pkg/controller/common"
 )
 
-func (r *Reconciler) reconcileTrustManagerDeployment(trustManager *v1alpha1.TrustManager) error {
+func (r *Reconciler) reconcileTrustManagerDeployment(ctx context.Context, trustManager *v1alpha1.TrustManager) error {
 	if err := validateTrustManagerConfig(trustManager); err != nil {
 		return common.NewIrrecoverableError(err, "%s configuration validation failed", trustManager.GetName())
 	}
@@ -17,52 +18,52 @@ func (r *Reconciler) reconcileTrustManagerDeployment(trustManager *v1alpha1.Trus
 	resourceAnnotations := getResourceAnnotations(trustManager)
 
 	trustNamespace := getTrustNamespace(trustManager)
-	if err := r.validateTrustNamespace(trustNamespace); err != nil {
+	if err := r.validateTrustNamespace(ctx, trustNamespace); err != nil {
 		return common.NewIrrecoverableError(err, "trust namespace %q validation failed", trustNamespace)
 	}
 
-	caBundleHash, err := r.createOrApplyDefaultCAPackageConfigMap(trustManager, resourceLabels, resourceAnnotations)
+	caBundleHash, err := r.createOrApplyDefaultCAPackageConfigMap(ctx, trustManager, resourceLabels, resourceAnnotations)
 	if err != nil {
 		r.log.Error(err, "failed to reconcile default CA package ConfigMap")
 		return err
 	}
 
-	if err := r.createOrApplyServiceAccounts(trustManager, resourceLabels, resourceAnnotations); err != nil {
+	if err := r.createOrApplyServiceAccounts(ctx, trustManager, resourceLabels, resourceAnnotations); err != nil {
 		r.log.Error(err, "failed to reconcile serviceaccount resource")
 		return err
 	}
 
-	if err := r.createOrApplyRBACResources(trustManager, resourceLabels, resourceAnnotations, trustNamespace); err != nil {
+	if err := r.createOrApplyRBACResources(ctx, trustManager, resourceLabels, resourceAnnotations, trustNamespace); err != nil {
 		r.log.Error(err, "failed to reconcile RBAC resources")
 		return err
 	}
 
-	if err := r.createOrApplyServices(trustManager, resourceLabels, resourceAnnotations); err != nil {
+	if err := r.createOrApplyServices(ctx, trustManager, resourceLabels, resourceAnnotations); err != nil {
 		r.log.Error(err, "failed to reconcile service resources")
 		return err
 	}
 
-	if err := r.createOrApplyIssuer(trustManager, resourceLabels, resourceAnnotations); err != nil {
+	if err := r.createOrApplyIssuer(ctx, trustManager, resourceLabels, resourceAnnotations); err != nil {
 		r.log.Error(err, "failed to reconcile issuer resource")
 		return err
 	}
 
-	if err := r.createOrApplyCertificate(trustManager, resourceLabels, resourceAnnotations); err != nil {
+	if err := r.createOrApplyCertificate(ctx, trustManager, resourceLabels, resourceAnnotations); err != nil {
 		r.log.Error(err, "failed to reconcile certificate resource")
 		return err
 	}
 
-	if err := r.createOrApplyDeployment(trustManager, resourceLabels, resourceAnnotations, caBundleHash); err != nil {
+	if err := r.createOrApplyDeployment(ctx, trustManager, resourceLabels, resourceAnnotations, caBundleHash); err != nil {
 		r.log.Error(err, "failed to reconcile deployment resource")
 		return err
 	}
 
-	if err := r.createOrApplyValidatingWebhookConfiguration(trustManager, resourceLabels, resourceAnnotations); err != nil {
+	if err := r.createOrApplyValidatingWebhookConfiguration(ctx, trustManager, resourceLabels, resourceAnnotations); err != nil {
 		r.log.Error(err, "failed to reconcile validatingwebhookconfiguration resource")
 		return err
 	}
 
-	if err := r.updateStatusObservedState(trustManager); err != nil {
+	if err := r.updateStatusObservedState(ctx, trustManager); err != nil {
 		return common.FromClientError(err, "failed to update status observed state")
 	}
 
@@ -71,8 +72,8 @@ func (r *Reconciler) reconcileTrustManagerDeployment(trustManager *v1alpha1.Trus
 }
 
 // validateTrustNamespace validates that the trust namespace exists.
-func (r *Reconciler) validateTrustNamespace(namespace string) error {
-	exists, err := r.namespaceExists(namespace)
+func (r *Reconciler) validateTrustNamespace(ctx context.Context, namespace string) error {
+	exists, err := r.namespaceExists(ctx, namespace)
 	if err != nil {
 		return fmt.Errorf("failed to check if namespace %q exists: %w", namespace, err)
 	}
@@ -84,7 +85,7 @@ func (r *Reconciler) validateTrustNamespace(namespace string) error {
 
 // updateStatusObservedState populates and persists the TrustManager status with the observed state.
 // Returns nil if no changes were needed, otherwise returns an error if the update fails.
-func (r *Reconciler) updateStatusObservedState(trustManager *v1alpha1.TrustManager) error {
+func (r *Reconciler) updateStatusObservedState(ctx context.Context, trustManager *v1alpha1.TrustManager) error {
 	changed := false
 
 	if image := os.Getenv(trustManagerImageNameEnvVarName); trustManager.Status.TrustManagerImage != image {
@@ -116,5 +117,5 @@ func (r *Reconciler) updateStatusObservedState(trustManager *v1alpha1.TrustManag
 		return nil
 	}
 
-	return r.updateStatus(r.ctx, trustManager)
+	return r.updateStatus(ctx, trustManager)
 }

--- a/pkg/controller/trustmanager/install_trustmanager_test.go
+++ b/pkg/controller/trustmanager/install_trustmanager_test.go
@@ -90,7 +90,7 @@ func TestUpdateStatusObservedState(t *testing.T) {
 			})
 			r.CtrlClient = mock
 
-			if err := r.updateStatusObservedState(tm); err != nil {
+			if err := r.updateStatusObservedState(context.Background(), tm); err != nil {
 				t.Fatalf("updateStatusObservedState: %v", err)
 			}
 			if got := mock.StatusUpdateCallCount(); got != tt.wantStatusUpdate {

--- a/pkg/controller/trustmanager/rbacs.go
+++ b/pkg/controller/trustmanager/rbacs.go
@@ -1,6 +1,7 @@
 package trustmanager
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"slices"
@@ -14,33 +15,33 @@ import (
 	"github.com/openshift/cert-manager-operator/pkg/operator/assets"
 )
 
-func (r *Reconciler) createOrApplyRBACResources(trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string, trustNamespace string) error {
-	if err := r.createOrApplyClusterRole(trustManager, resourceLabels, resourceAnnotations); err != nil {
+func (r *Reconciler) createOrApplyRBACResources(ctx context.Context, trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string, trustNamespace string) error {
+	if err := r.createOrApplyClusterRole(ctx, trustManager, resourceLabels, resourceAnnotations); err != nil {
 		r.log.Error(err, "failed to reconcile clusterrole resource")
 		return err
 	}
 
-	if err := r.createOrApplyClusterRoleBinding(trustManager, resourceLabels, resourceAnnotations); err != nil {
+	if err := r.createOrApplyClusterRoleBinding(ctx, trustManager, resourceLabels, resourceAnnotations); err != nil {
 		r.log.Error(err, "failed to reconcile clusterrolebinding resource")
 		return err
 	}
 
-	if err := r.createOrApplyTrustNamespaceRole(trustManager, resourceLabels, resourceAnnotations, trustNamespace); err != nil {
+	if err := r.createOrApplyTrustNamespaceRole(ctx, trustManager, resourceLabels, resourceAnnotations, trustNamespace); err != nil {
 		r.log.Error(err, "failed to reconcile role resource for trust namespace")
 		return err
 	}
 
-	if err := r.createOrApplyTrustNamespaceRoleBinding(trustManager, resourceLabels, resourceAnnotations, trustNamespace); err != nil {
+	if err := r.createOrApplyTrustNamespaceRoleBinding(ctx, trustManager, resourceLabels, resourceAnnotations, trustNamespace); err != nil {
 		r.log.Error(err, "failed to reconcile rolebinding resource for trust namespace")
 		return err
 	}
 
-	if err := r.createOrApplyLeaderElectionRole(trustManager, resourceLabels, resourceAnnotations); err != nil {
+	if err := r.createOrApplyLeaderElectionRole(ctx, trustManager, resourceLabels, resourceAnnotations); err != nil {
 		r.log.Error(err, "failed to reconcile leader election role resource")
 		return err
 	}
 
-	if err := r.createOrApplyLeaderElectionRoleBinding(trustManager, resourceLabels, resourceAnnotations); err != nil {
+	if err := r.createOrApplyLeaderElectionRoleBinding(ctx, trustManager, resourceLabels, resourceAnnotations); err != nil {
 		r.log.Error(err, "failed to reconcile leader election rolebinding resource")
 		return err
 	}
@@ -50,13 +51,13 @@ func (r *Reconciler) createOrApplyRBACResources(trustManager *v1alpha1.TrustMana
 
 // ClusterRole
 
-func (r *Reconciler) createOrApplyClusterRole(trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
+func (r *Reconciler) createOrApplyClusterRole(ctx context.Context, trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
 	desired := getClusterRoleObject(trustManager.Spec.TrustManagerConfig.SecretTargets, resourceLabels, resourceAnnotations)
 	resourceName := desired.GetName()
 	r.log.V(4).Info("reconciling clusterrole resource", "name", resourceName)
 
 	existing := &rbacv1.ClusterRole{}
-	exists, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), existing)
+	exists, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), existing)
 	if err != nil {
 		return common.FromClientError(err, "failed to check if clusterrole %q exists", resourceName)
 	}
@@ -66,7 +67,7 @@ func (r *Reconciler) createOrApplyClusterRole(trustManager *v1alpha1.TrustManage
 	}
 
 	r.log.V(2).Info("clusterrole resource has been modified, updating to desired state", "name", resourceName)
-	if err := r.Patch(r.ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+	if err := r.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
 		return common.FromClientError(err, "failed to apply clusterrole %q", resourceName)
 	}
 
@@ -110,13 +111,13 @@ func appendSecretTargetRules(clusterRole *rbacv1.ClusterRole, secretTargets v1al
 
 // ClusterRoleBinding
 
-func (r *Reconciler) createOrApplyClusterRoleBinding(trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
+func (r *Reconciler) createOrApplyClusterRoleBinding(ctx context.Context, trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
 	desired := getClusterRoleBindingObject(resourceLabels, resourceAnnotations)
 	resourceName := desired.GetName()
 	r.log.V(4).Info("reconciling clusterrolebinding resource", "name", resourceName)
 
 	existing := &rbacv1.ClusterRoleBinding{}
-	exists, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), existing)
+	exists, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), existing)
 	if err != nil {
 		return common.FromClientError(err, "failed to check if clusterrolebinding %q exists", resourceName)
 	}
@@ -126,7 +127,7 @@ func (r *Reconciler) createOrApplyClusterRoleBinding(trustManager *v1alpha1.Trus
 	}
 
 	r.log.V(2).Info("clusterrolebinding resource has been modified, updating to desired state", "name", resourceName)
-	if err := r.Patch(r.ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+	if err := r.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
 		return common.FromClientError(err, "failed to apply clusterrolebinding %q", resourceName)
 	}
 
@@ -146,13 +147,13 @@ func getClusterRoleBindingObject(resourceLabels, resourceAnnotations map[string]
 
 // Role for trust namespace (secrets access)
 
-func (r *Reconciler) createOrApplyTrustNamespaceRole(trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string, trustNamespace string) error {
+func (r *Reconciler) createOrApplyTrustNamespaceRole(ctx context.Context, trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string, trustNamespace string) error {
 	desired := getTrustNamespaceRoleObject(resourceLabels, resourceAnnotations, trustNamespace)
 	resourceName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling role resource for trust namespace", "name", resourceName)
 
 	existing := &rbacv1.Role{}
-	exists, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), existing)
+	exists, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), existing)
 	if err != nil {
 		return common.FromClientError(err, "failed to check if role %q exists", resourceName)
 	}
@@ -162,7 +163,7 @@ func (r *Reconciler) createOrApplyTrustNamespaceRole(trustManager *v1alpha1.Trus
 	}
 
 	r.log.V(2).Info("role resource has been modified, updating to desired state", "name", resourceName)
-	if err := r.Patch(r.ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+	if err := r.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
 		return common.FromClientError(err, "failed to apply role %q", resourceName)
 	}
 
@@ -181,13 +182,13 @@ func getTrustNamespaceRoleObject(resourceLabels, resourceAnnotations map[string]
 
 // RoleBinding for trust namespace (secrets access)
 
-func (r *Reconciler) createOrApplyTrustNamespaceRoleBinding(trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string, trustNamespace string) error {
+func (r *Reconciler) createOrApplyTrustNamespaceRoleBinding(ctx context.Context, trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string, trustNamespace string) error {
 	desired := getTrustNamespaceRoleBindingObject(resourceLabels, resourceAnnotations, trustNamespace)
 	resourceName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling rolebinding resource for trust namespace", "name", resourceName)
 
 	existing := &rbacv1.RoleBinding{}
-	exists, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), existing)
+	exists, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), existing)
 	if err != nil {
 		return common.FromClientError(err, "failed to check if rolebinding %q exists", resourceName)
 	}
@@ -197,7 +198,7 @@ func (r *Reconciler) createOrApplyTrustNamespaceRoleBinding(trustManager *v1alph
 	}
 
 	r.log.V(2).Info("rolebinding resource has been modified, updating to desired state", "name", resourceName)
-	if err := r.Patch(r.ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+	if err := r.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
 		return common.FromClientError(err, "failed to apply rolebinding %q", resourceName)
 	}
 
@@ -218,13 +219,13 @@ func getTrustNamespaceRoleBindingObject(resourceLabels, resourceAnnotations map[
 
 // Leader election Role (in operand namespace)
 
-func (r *Reconciler) createOrApplyLeaderElectionRole(trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
+func (r *Reconciler) createOrApplyLeaderElectionRole(ctx context.Context, trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
 	desired := getLeaderElectionRoleObject(resourceLabels, resourceAnnotations)
 	resourceName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling leader election role resource", "name", resourceName)
 
 	existing := &rbacv1.Role{}
-	exists, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), existing)
+	exists, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), existing)
 	if err != nil {
 		return common.FromClientError(err, "failed to check if leader election role %q exists", resourceName)
 	}
@@ -234,7 +235,7 @@ func (r *Reconciler) createOrApplyLeaderElectionRole(trustManager *v1alpha1.Trus
 	}
 
 	r.log.V(2).Info("leader election role resource has been modified, updating to desired state", "name", resourceName)
-	if err := r.Patch(r.ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+	if err := r.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
 		return common.FromClientError(err, "failed to apply leader election role %q", resourceName)
 	}
 
@@ -253,13 +254,13 @@ func getLeaderElectionRoleObject(resourceLabels, resourceAnnotations map[string]
 
 // Leader election RoleBinding (in operand namespace)
 
-func (r *Reconciler) createOrApplyLeaderElectionRoleBinding(trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
+func (r *Reconciler) createOrApplyLeaderElectionRoleBinding(ctx context.Context, trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
 	desired := getLeaderElectionRoleBindingObject(resourceLabels, resourceAnnotations)
 	resourceName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling leader election rolebinding resource", "name", resourceName)
 
 	existing := &rbacv1.RoleBinding{}
-	exists, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), existing)
+	exists, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), existing)
 	if err != nil {
 		return common.FromClientError(err, "failed to check if leader election rolebinding %q exists", resourceName)
 	}
@@ -269,7 +270,7 @@ func (r *Reconciler) createOrApplyLeaderElectionRoleBinding(trustManager *v1alph
 	}
 
 	r.log.V(2).Info("leader election rolebinding resource has been modified, updating to desired state", "name", resourceName)
-	if err := r.Patch(r.ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+	if err := r.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
 		return common.FromClientError(err, "failed to apply leader election rolebinding %q", resourceName)
 	}
 

--- a/pkg/controller/trustmanager/rbacs_test.go
+++ b/pkg/controller/trustmanager/rbacs_test.go
@@ -574,7 +574,7 @@ func TestRBACReconciliation(t *testing.T) {
 				tmBuilder = testTrustManager()
 			}
 			tm := tmBuilder.Build()
-			err := r.createOrApplyRBACResources(tm, getResourceLabels(tm), getResourceAnnotations(tm), defaultTrustNamespace)
+			err := r.createOrApplyRBACResources(context.Background(), tm, getResourceLabels(tm), getResourceAnnotations(tm), defaultTrustNamespace)
 			assertError(t, err, tt.wantErr)
 
 			if got := mock.ExistsCallCount(); got != tt.wantExistsCount {
@@ -783,7 +783,7 @@ func TestRBACReconciliationWithSecretTargets(t *testing.T) {
 			}
 			r.CtrlClient = mock
 
-			err := r.createOrApplyRBACResources(tm, getResourceLabels(tm), getResourceAnnotations(tm), defaultTrustNamespace)
+			err := r.createOrApplyRBACResources(context.Background(), tm, getResourceLabels(tm), getResourceAnnotations(tm), defaultTrustNamespace)
 			assertError(t, err, "")
 
 			if got := mock.ExistsCallCount(); got != tt.wantExistsCount {

--- a/pkg/controller/trustmanager/serviceaccounts.go
+++ b/pkg/controller/trustmanager/serviceaccounts.go
@@ -1,6 +1,7 @@
 package trustmanager
 
 import (
+	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -12,13 +13,13 @@ import (
 	"github.com/openshift/cert-manager-operator/pkg/operator/assets"
 )
 
-func (r *Reconciler) createOrApplyServiceAccounts(trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
+func (r *Reconciler) createOrApplyServiceAccounts(ctx context.Context, trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
 	desired := r.getServiceAccountObject(resourceLabels, resourceAnnotations)
 	serviceAccountName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling serviceaccount resource", "name", serviceAccountName)
 
 	existing := &corev1.ServiceAccount{}
-	exists, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), existing)
+	exists, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), existing)
 	if err != nil {
 		return common.FromClientError(err, "failed to check if serviceaccount %q exists", serviceAccountName)
 	}
@@ -28,7 +29,7 @@ func (r *Reconciler) createOrApplyServiceAccounts(trustManager *v1alpha1.TrustMa
 	}
 
 	r.log.V(2).Info("serviceaccount resource has been modified, updating to desired state", "name", serviceAccountName)
-	if err := r.Patch(r.ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+	if err := r.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
 		return common.FromClientError(err, "failed to apply serviceaccount %q", serviceAccountName)
 	}
 

--- a/pkg/controller/trustmanager/serviceaccounts_test.go
+++ b/pkg/controller/trustmanager/serviceaccounts_test.go
@@ -183,7 +183,7 @@ func TestServiceAccountReconciliation(t *testing.T) {
 				tmBuilder = testTrustManager()
 			}
 			tm := tmBuilder.Build()
-			err := r.createOrApplyServiceAccounts(tm, getResourceLabels(tm), getResourceAnnotations(tm))
+			err := r.createOrApplyServiceAccounts(context.Background(), tm, getResourceLabels(tm), getResourceAnnotations(tm))
 			assertError(t, err, tt.wantErr)
 
 			if got := mock.ExistsCallCount(); got != tt.wantExistsCount {

--- a/pkg/controller/trustmanager/services.go
+++ b/pkg/controller/trustmanager/services.go
@@ -1,6 +1,7 @@
 package trustmanager
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"reflect"
@@ -13,22 +14,22 @@ import (
 	"github.com/openshift/cert-manager-operator/pkg/operator/assets"
 )
 
-func (r *Reconciler) createOrApplyServices(trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
-	if err := r.createOrApplyService(trustManager, getWebhookServiceObject(resourceLabels, resourceAnnotations)); err != nil {
+func (r *Reconciler) createOrApplyServices(ctx context.Context, trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
+	if err := r.createOrApplyService(ctx, trustManager, getWebhookServiceObject(resourceLabels, resourceAnnotations)); err != nil {
 		return err
 	}
-	if err := r.createOrApplyService(trustManager, getMetricsServiceObject(resourceLabels, resourceAnnotations)); err != nil {
+	if err := r.createOrApplyService(ctx, trustManager, getMetricsServiceObject(resourceLabels, resourceAnnotations)); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (r *Reconciler) createOrApplyService(trustManager *v1alpha1.TrustManager, desired *corev1.Service) error {
+func (r *Reconciler) createOrApplyService(ctx context.Context, trustManager *v1alpha1.TrustManager, desired *corev1.Service) error {
 	serviceName := fmt.Sprintf("%s/%s", desired.GetNamespace(), desired.GetName())
 	r.log.V(4).Info("reconciling service resource", "name", serviceName)
 
 	existing := &corev1.Service{}
-	exists, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), existing)
+	exists, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), existing)
 	if err != nil {
 		return common.FromClientError(err, "failed to check if service %q exists", serviceName)
 	}
@@ -38,7 +39,7 @@ func (r *Reconciler) createOrApplyService(trustManager *v1alpha1.TrustManager, d
 	}
 
 	r.log.V(2).Info("service resource has been modified, updating to desired state", "name", serviceName)
-	if err := r.Patch(r.ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+	if err := r.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
 		return common.FromClientError(err, "failed to apply service %q", serviceName)
 	}
 

--- a/pkg/controller/trustmanager/services_test.go
+++ b/pkg/controller/trustmanager/services_test.go
@@ -262,7 +262,7 @@ func TestServiceReconciliation(t *testing.T) {
 				tmBuilder = testTrustManager()
 			}
 			tm := tmBuilder.Build()
-			err := r.createOrApplyServices(tm, getResourceLabels(tm), getResourceAnnotations(tm))
+			err := r.createOrApplyServices(context.Background(), tm, getResourceLabels(tm), getResourceAnnotations(tm))
 			assertError(t, err, tt.wantErr)
 
 			if got := mock.ExistsCallCount(); got != tt.wantExistsCount {

--- a/pkg/controller/trustmanager/test_utils.go
+++ b/pkg/controller/trustmanager/test_utils.go
@@ -1,7 +1,6 @@
 package trustmanager
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -108,7 +107,6 @@ func (b *trustManagerBuilder) Build() *v1alpha1.TrustManager {
 
 func testReconciler(t *testing.T) *Reconciler {
 	return &Reconciler{
-		ctx:           context.Background(),
 		eventRecorder: record.NewFakeRecorder(100),
 		log:           testr.New(t),
 		scheme:        testutil.Scheme,

--- a/pkg/controller/trustmanager/utils.go
+++ b/pkg/controller/trustmanager/utils.go
@@ -127,8 +127,8 @@ func validateTrustManagerConfig(trustManager *v1alpha1.TrustManager) error {
 	return nil
 }
 
-func (r *Reconciler) updateCondition(trustManager *v1alpha1.TrustManager, prependErr error) error {
-	if err := r.updateStatus(r.ctx, trustManager); err != nil {
+func (r *Reconciler) updateCondition(ctx context.Context, trustManager *v1alpha1.TrustManager, prependErr error) error {
+	if err := r.updateStatus(ctx, trustManager); err != nil {
 		errUpdate := fmt.Errorf("failed to update %s status: %w", trustManager.GetName(), err)
 		if prependErr != nil {
 			return utilerrors.NewAggregate([]error{prependErr, errUpdate})
@@ -225,8 +225,8 @@ func managedMetadataModified(desired, existing client.Object) bool {
 }
 
 // namespaceExists checks if a namespace exists in the cluster.
-func (r *Reconciler) namespaceExists(namespace string) (bool, error) {
+func (r *Reconciler) namespaceExists(ctx context.Context, namespace string) (bool, error) {
 	ns := &corev1.Namespace{}
 	key := client.ObjectKey{Name: namespace}
-	return r.Exists(r.ctx, key, ns)
+	return r.Exists(ctx, key, ns)
 }

--- a/pkg/controller/trustmanager/utils_test.go
+++ b/pkg/controller/trustmanager/utils_test.go
@@ -1,6 +1,7 @@
 package trustmanager
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -8,9 +9,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
 	"github.com/openshift/cert-manager-operator/pkg/controller/common"
+	"github.com/openshift/cert-manager-operator/pkg/controller/common/fakes"
 )
 
 func TestGetTrustNamespace(t *testing.T) {
@@ -353,4 +356,83 @@ func TestDecodeServiceAccountObjBytes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAddFinalizerAlreadyPresent(t *testing.T) {
+	r := testReconciler(t)
+	mock := &fakes.FakeCtrlClient{}
+	r.CtrlClient = mock
+
+	tm := testTrustManager().Build()
+	tm.Finalizers = []string{finalizer}
+
+	assertError(t, r.addFinalizer(context.Background(), tm), "")
+
+	if got := mock.UpdateWithRetryCallCount(); got != 0 {
+		t.Errorf("expected 0 UpdateWithRetry calls, got %d", got)
+	}
+	if got := mock.GetCallCount(); got != 0 {
+		t.Errorf("expected 0 Get calls, got %d", got)
+	}
+}
+
+func TestAddFinalizerGetAfterUpdateFails(t *testing.T) {
+	r := testReconciler(t)
+	mock := &fakes.FakeCtrlClient{}
+	mock.GetCalls(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+		return errTestClient
+	})
+	r.CtrlClient = mock
+
+	tm := testTrustManager().Build()
+
+	assertError(t, r.addFinalizer(context.Background(), tm), "failed to fetch trustmanager.openshift.operator.io")
+}
+
+func TestRemoveFinalizerNotPresent(t *testing.T) {
+	r := testReconciler(t)
+	mock := &fakes.FakeCtrlClient{}
+	r.CtrlClient = mock
+
+	tm := testTrustManager().Build()
+
+	assertError(t, r.removeFinalizer(context.Background(), tm, finalizer), "")
+
+	if got := mock.UpdateWithRetryCallCount(); got != 0 {
+		t.Errorf("expected 0 UpdateWithRetry calls, got %d", got)
+	}
+}
+
+func TestUpdateStatusGetFailure(t *testing.T) {
+	r := testReconciler(t)
+	mock := &fakes.FakeCtrlClient{}
+	mock.GetCalls(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+		return errTestClient
+	})
+	r.CtrlClient = mock
+
+	tm := testTrustManager().Build()
+
+	assertError(t, r.updateStatus(context.Background(), tm), "failed to fetch trustmanager.openshift.operator.io")
+}
+
+func TestUpdateStatusStatusUpdateFailure(t *testing.T) {
+	r := testReconciler(t)
+	mock := &fakes.FakeCtrlClient{}
+	fixture := testTrustManager().Build()
+	mock.GetCalls(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+		switch o := obj.(type) {
+		case *v1alpha1.TrustManager:
+			fixture.DeepCopyInto(o)
+		}
+		return nil
+	})
+	mock.StatusUpdateCalls(func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+		return errTestClient
+	})
+	r.CtrlClient = mock
+
+	tm := testTrustManager().Build()
+
+	assertError(t, r.updateStatus(context.Background(), tm), "failed to update trustmanager.openshift.operator.io")
 }

--- a/pkg/controller/trustmanager/webhooks.go
+++ b/pkg/controller/trustmanager/webhooks.go
@@ -1,6 +1,7 @@
 package trustmanager
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"reflect"
@@ -17,13 +18,13 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 )
 
-func (r *Reconciler) createOrApplyValidatingWebhookConfiguration(trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
+func (r *Reconciler) createOrApplyValidatingWebhookConfiguration(ctx context.Context, trustManager *v1alpha1.TrustManager, resourceLabels, resourceAnnotations map[string]string) error {
 	desired := getValidatingWebhookConfigObject(resourceLabels, resourceAnnotations)
 	resourceName := desired.GetName()
 	r.log.V(4).Info("reconciling validatingwebhookconfiguration resource", "name", resourceName)
 
 	existing := &admissionregistrationv1.ValidatingWebhookConfiguration{}
-	exists, err := r.Exists(r.ctx, client.ObjectKeyFromObject(desired), existing)
+	exists, err := r.Exists(ctx, client.ObjectKeyFromObject(desired), existing)
 	if err != nil {
 		return common.FromClientError(err, "failed to check if validatingwebhookconfiguration %q exists", resourceName)
 	}
@@ -33,7 +34,7 @@ func (r *Reconciler) createOrApplyValidatingWebhookConfiguration(trustManager *v
 	}
 
 	r.log.V(2).Info("validatingwebhookconfiguration resource has been modified, updating to desired state", "name", resourceName)
-	if err := r.Patch(r.ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+	if err := r.Patch(ctx, desired, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
 		return common.FromClientError(err, "failed to apply validatingwebhookconfiguration %q", resourceName)
 	}
 

--- a/pkg/controller/trustmanager/webhooks_test.go
+++ b/pkg/controller/trustmanager/webhooks_test.go
@@ -238,7 +238,7 @@ func TestValidatingWebhookConfigReconciliation(t *testing.T) {
 				tmBuilder = testTrustManager()
 			}
 			tm := tmBuilder.Build()
-			err := r.createOrApplyValidatingWebhookConfiguration(tm, getResourceLabels(tm), getResourceAnnotations(tm))
+			err := r.createOrApplyValidatingWebhookConfiguration(context.Background(), tm, getResourceLabels(tm), getResourceAnnotations(tm))
 			assertError(t, err, tt.wantErr)
 
 			if got := mock.ExistsCallCount(); got != tt.wantExistsCount {


### PR DESCRIPTION
## Summary

- Removes the stored `ctx context.Context` field from both `istiocsr` and `trustmanager` Reconciler structs
- Threads context from `Reconcile(ctx context.Context, ...)` through every helper method call chain (37 files, ~90 call sites)
- Tests pass `context.Background()` explicitly (semantically correct for test entrypoints)
- Removes a redundant `sort.Strings` call after `MergeContainerArgs` which already sorts its output

## Motivation

Both controllers stored a `context.Context` initialized once to `context.Background()` in `New()`. The `Reconcile()` method receives a proper request-scoped context from controller-runtime, but all helper methods used the stale struct field. This defeats cancellation and deadline propagation from the framework.

This supersedes #242, which attempted to standardize context usage by replacing `context.Background()` with `context.TODO()` everywhere -- semantically backwards since `context.TODO()` signals "placeholder, haven't decided yet" while `context.Background()` is correct for top-level contexts.

## Related PRs

| PR | Title | Status |
|----|-------|--------|
| [openshift/cert-manager-operator#418](https://github.com/openshift/cert-manager-operator/pull/418) | [CM-1038](https://redhat.atlassian.net/browse/CM-1038): Replace istiocsr type-specific decoders with generic DecodeObjBytes | Open |
| [openshift/cert-manager-operator#420](https://github.com/openshift/cert-manager-operator/pull/420) | [CM-1040](https://redhat.atlassian.net/browse/CM-1040): Extract shared ApplyResource helper and migrate istiocsr to SSA | Open |
| [openshift/cert-manager-operator#438](https://github.com/openshift/cert-manager-operator/pull/438) | [CM-1113](https://redhat.atlassian.net/browse/CM-1113): Replace unsafe.Pointer casts with Kubernetes conversion functions | Open |
| [openshift/cert-manager-operator#417](https://github.com/openshift/cert-manager-operator/pull/417) | [CM-1114](https://redhat.atlassian.net/browse/CM-1114): Add health probes and richer status conditions | Open |
| [openshift/cert-manager-operator#461](https://github.com/openshift/cert-manager-operator/pull/461) | [CNF-26153](https://redhat.atlassian.net/browse/CNF-26153): Add unit tests across codebase to close coverage gaps | Open |

## Jira

- [CM-1039](https://issues.redhat.com/browse/CM-1039) — Thread context.Context from Reconcile() through controller helpers

## Test Plan

- [x] `go test ./pkg/controller/istiocsr/...` passes
- [x] `go test ./pkg/controller/trustmanager/...` passes
- [x] `go build ./...` succeeds
- [x] `make lint` shows only pre-existing issues (none introduced)
- [x] No remaining `r.ctx` references in either package