### PR TITLE
OCPBUGS-85579: Add Console capability annotation to ConsoleYAMLSample resources

### DIFF
--- a/bundle/manifests/cert-manager-acme-issuer-sample_console.openshift.io_v1_consoleyamlsample.yaml
+++ b/bundle/manifests/cert-manager-acme-issuer-sample_console.openshift.io_v1_consoleyamlsample.yaml
@@ -1,6 +1,8 @@
 apiVersion: console.openshift.io/v1
 kind: ConsoleYAMLSample
 metadata:
+  annotations:
+    capability.openshift.io/name: Console
   name: cert-manager-acme-issuer-sample
 spec:
   description: An example ACME Issuer for Let's Encrypt production certificates with

--- a/bundle/manifests/cert-manager-certificate-sample_console.openshift.io_v1_consoleyamlsample.yaml
+++ b/bundle/manifests/cert-manager-certificate-sample_console.openshift.io_v1_consoleyamlsample.yaml
@@ -1,6 +1,8 @@
 apiVersion: console.openshift.io/v1
 kind: ConsoleYAMLSample
 metadata:
+  annotations:
+    capability.openshift.io/name: Console
   name: cert-manager-certificate-sample
 spec:
   description: A simple Certificate example

--- a/bundle/manifests/cert-manager-issuer-sample_console.openshift.io_v1_consoleyamlsample.yaml
+++ b/bundle/manifests/cert-manager-issuer-sample_console.openshift.io_v1_consoleyamlsample.yaml
@@ -1,6 +1,8 @@
 apiVersion: console.openshift.io/v1
 kind: ConsoleYAMLSample
 metadata:
+  annotations:
+    capability.openshift.io/name: Console
   name: cert-manager-issuer-sample
 spec:
   description: A simple self-signed Issuer for development and testing

--- a/config/console/cert-manager-acme-issuer-sample.yaml
+++ b/config/console/cert-manager-acme-issuer-sample.yaml
@@ -2,6 +2,8 @@ apiVersion: console.openshift.io/v1
 kind: ConsoleYAMLSample
 metadata:
   name: cert-manager-acme-issuer-sample
+  annotations:
+    capability.openshift.io/name: Console
 spec:
   targetResource:
     apiVersion: cert-manager.io/v1

--- a/config/console/cert-manager-certificate-sample.yaml
+++ b/config/console/cert-manager-certificate-sample.yaml
@@ -2,6 +2,8 @@ apiVersion: console.openshift.io/v1
 kind: ConsoleYAMLSample
 metadata:
   name: cert-manager-certificate-sample
+  annotations:
+    capability.openshift.io/name: Console
 spec:
   targetResource:
     apiVersion: cert-manager.io/v1

--- a/config/console/cert-manager-issuer-sample.yaml
+++ b/config/console/cert-manager-issuer-sample.yaml
@@ -2,6 +2,8 @@ apiVersion: console.openshift.io/v1
 kind: ConsoleYAMLSample
 metadata:
   name: cert-manager-issuer-sample
+  annotations:
+    capability.openshift.io/name: Console
 spec:
   targetResource:
     apiVersion: cert-manager.io/v1


### PR DESCRIPTION
## Summary

Add `capability.openshift.io/name: Console` annotation to the three `ConsoleYAMLSample` resources so OLM skips them on clusters where the Console capability is disabled.

## Problem

On clusters without the Console capability (e.g., RAN RDS deployments), the cert-manager operator install fails with:

```
api-server resource not found installing ConsoleYAMLSample cert-manager-acme-issuer-sample:
GroupVersionKind console.openshift.io/v1, Kind=ConsoleYAMLSample not found on the cluster.
```

PR [#355](https://github.com/openshift/cert-manager-operator/pull/355) added Console resources (QuickStart + YAML samples) to the operator bundle. The `ConsoleQuickStart` correctly includes the `capability.openshift.io/name: Console` annotation, but the three `ConsoleYAMLSample` resources were missed.

## Fix

Add `capability.openshift.io/name: Console` annotation to:
- `config/console/cert-manager-acme-issuer-sample.yaml`
- `config/console/cert-manager-certificate-sample.yaml`
- `config/console/cert-manager-issuer-sample.yaml`
- Corresponding `bundle/manifests/` files

This tells OLM to skip these optional UI resources when Console is not available, allowing the operator to install successfully on Console-less clusters.

## Testing

- Verified the annotated resources apply correctly on a Console-enabled cluster (OCP 4.22)
- Annotation format matches the existing `ConsoleQuickStart` resource from PR #355
- The `ConsoleYAMLSample` resources are cosmetic (YAML examples in the web console sidebar) and not required for cert-manager functionality

Jira: [CNF-23785](https://redhat.atlassian.net/browse/CNF-23785)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Console capability metadata annotation to cert-manager console YAML samples across bundled and config manifests.
  * Applies to ACME issuer, certificate, and issuer sample manifests so console samples consistently include the capability.openshift.io/name: Console annotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->