### PR TITLE
CM-1106: Add CI Dockerfiles for istio-csr and trust-manager operands

### DIFF
--- a/images/ci/certmanager.Dockerfile
+++ b/images/ci/certmanager.Dockerfile
@@ -33,7 +33,7 @@ RUN go mod vendor
 RUN go build -mod=vendor -tags $GO_BUILD_TAGS -o /app/_output/webhook main.go
 
 
-FROM registry.access.redhat.com/ubi9-minimal:9.4
+FROM registry.access.redhat.com/ubi9-minimal:latest
 
 COPY --from=builder /app/_output/acmesolver /app/cmd/acmesolver/acmesolver
 COPY --from=builder /app/_output/cainjector /app/cmd/cainjector/cainjector

--- a/images/ci/istiocsr.Dockerfile
+++ b/images/ci/istiocsr.Dockerfile
@@ -1,0 +1,19 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 AS builder
+
+ARG RELEASE_BRANCH=v0.16.0
+
+ARG GO_BUILD_TAGS=strictfipsruntime,openssl
+ENV GOEXPERIMENT strictfipsruntime
+ENV CGO_ENABLED 1
+
+RUN mkdir -p /go/src/github.com/cert-manager
+RUN git clone --depth 1 --branch $RELEASE_BRANCH https://github.com/openshift/cert-manager-istio-csr.git /go/src/github.com/cert-manager/istio-csr
+WORKDIR /go/src/github.com/cert-manager/istio-csr
+
+RUN go mod vendor
+RUN go build -mod=vendor -tags $GO_BUILD_TAGS -ldflags '-w -s' -o /app/cert-manager-istio-csr ./cmd
+
+FROM registry.access.redhat.com/ubi9-minimal:latest
+COPY --from=builder /app/cert-manager-istio-csr /usr/local/bin/cert-manager-istio-csr
+USER 65532:65532
+ENTRYPOINT ["/usr/local/bin/cert-manager-istio-csr"]

--- a/images/ci/trustmanager.Dockerfile
+++ b/images/ci/trustmanager.Dockerfile
@@ -1,0 +1,19 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 AS builder
+
+ARG RELEASE_BRANCH=v0.20.3
+
+ARG GO_BUILD_TAGS=strictfipsruntime,openssl
+ENV GOEXPERIMENT strictfipsruntime
+ENV CGO_ENABLED 1
+
+RUN mkdir -p /go/src/github.com/cert-manager
+RUN git clone --depth 1 --branch $RELEASE_BRANCH https://github.com/openshift/cert-manager-trust-manager.git /go/src/github.com/cert-manager/trust-manager
+WORKDIR /go/src/github.com/cert-manager/trust-manager
+
+RUN go mod vendor
+RUN go build -mod=vendor -tags $GO_BUILD_TAGS -ldflags '-w -s' -o /app/cert-manager-trust-manager ./cmd/trust-manager
+
+FROM registry.access.redhat.com/ubi9-minimal:latest
+COPY --from=builder /app/cert-manager-trust-manager /usr/local/bin/cert-manager-trust-manager
+USER 65532:65532
+ENTRYPOINT ["/usr/local/bin/cert-manager-trust-manager"]


### PR DESCRIPTION
## Summary

Adds `istiocsr.Dockerfile` and `trustmanager.Dockerfile` to `images/ci/` for building operand images in OpenShift CI, following the same pattern as the existing `operand.Dockerfile`.

These Dockerfiles are required by the openshift/release CI config update ([openshift/release#80046](https://github.com/openshift/release/pull/80046)) which adds istiocsr and trust-manager image builds and substitutions to both the `cert-manager-1.19` and `master` branch CI configs.

| Dockerfile | Builds from | Default RELEASE_BRANCH |
|---|---|---|
| `images/ci/istiocsr.Dockerfile` | `openshift/cert-manager-istio-csr` | `v0.16.0` |
| `images/ci/trustmanager.Dockerfile` | `openshift/cert-manager-trust-manager` | `v0.20.3` |

## Jira

[CM-1106](https://redhat.atlassian.net/browse/CM-1106)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added container image build configurations for cert-manager-istio-csr (default v0.16.0) and trust-manager (default v0.20.3) enabling containerized deployment.
  * Implemented multi-stage builds with vendored dependencies, strict FIPS-friendly build tags, and non-root runtime execution for secure production images.
  * Updated final runtime base image reference to use the latest UBI9 minimal tag for runtime images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->