### PR TITLE
CM-1112: Fix cluster-monitoring set as annotation instead of label

### DIFF
--- a/bindata/cert-manager-deployment/cert-manager-namespace.yaml
+++ b/bindata/cert-manager-deployment/cert-manager-namespace.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotations:
+  labels:
     openshift.io/cluster-monitoring: "true"
   name: cert-manager

--- a/pkg/controller/certmanager/namespace_manifest_test.go
+++ b/pkg/controller/certmanager/namespace_manifest_test.go
@@ -1,0 +1,21 @@
+package certmanager
+
+import (
+	"testing"
+
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openshift/cert-manager-operator/pkg/operator/assets"
+)
+
+func TestNamespaceManifestHasClusterMonitoringLabel(t *testing.T) {
+	manifestBytes, err := assets.Asset("cert-manager-deployment/cert-manager-namespace.yaml")
+	require.NoError(t, err, "failed to load namespace asset")
+
+	ns := resourceread.ReadNamespaceV1OrDie(manifestBytes)
+
+	require.Equal(t, "cert-manager", ns.Name)
+	require.Equal(t, "true", ns.Labels["openshift.io/cluster-monitoring"],
+		"openshift.io/cluster-monitoring must be a label (not annotation) for Prometheus namespace discovery")
+}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -650,7 +650,7 @@ func certManagerDeploymentCertManagerCertManagerControllerCertificatesigningrequ
 var _certManagerDeploymentCertManagerNamespaceYaml = []byte(`apiVersion: v1
 kind: Namespace
 metadata:
-  annotations:
+  labels:
     openshift.io/cluster-monitoring: "true"
   name: cert-manager
 `)


### PR DESCRIPTION
## Summary

- Moves `openshift.io/cluster-monitoring: "true"` from `annotations` to `labels` on the `cert-manager` namespace manifest
- Regenerates `bindata.go` to match

Per the [OCP docs](https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html), cluster monitoring requires the `openshift.io/cluster-monitoring: "true"` key to be set as a **label** on the namespace. The operator was incorrectly setting it as an annotation, which prevented Prometheus from discovering the namespace for metrics scraping.

**Note on existing clusters:** The operator's static resource controller (library-go `EnsureObjectMeta`) merges labels additively. On upgrade, the label will be added but the old annotation will remain. This is harmless — monitoring only checks for the label.

### Cluster verification (OCP 4.19)

**Before** — label missing, only annotation set:
```
$ oc get ns cert-manager -o jsonpath='{.metadata.annotations.openshift\.io/cluster-monitoring}'
true

$ oc get ns cert-manager -o jsonpath='{.metadata.labels.openshift\.io/cluster-monitoring}'
(empty)
```

**After** — label correctly set:
```
$ oc get ns cert-manager -o jsonpath='{.metadata.labels.openshift\.io/cluster-monitoring}'
true

$ oc get ns cert-manager -o jsonpath='{.metadata.labels}'
{
    "kubernetes.io/metadata.name": "cert-manager",
    "openshift.io/cluster-monitoring": "true",
    "pod-security.kubernetes.io/audit": "restricted",
    "pod-security.kubernetes.io/audit-version": "latest",
    "pod-security.kubernetes.io/warn": "restricted",
    "pod-security.kubernetes.io/warn-version": "latest"
}
```

The old annotation remains on existing clusters (additive merge), which is harmless:
```
$ oc get ns cert-manager -o jsonpath='{.metadata.annotations.openshift\.io/cluster-monitoring}'
true
```

Fixes https://github.com/openshift/cert-manager-operator/issues/336

## Test plan

- [x] Unit tests pass (`make test`)
- [x] Verified on live OCP 4.19 cluster: label present after applying fix
- [ ] CI e2e tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the cert-manager namespace manifest so the cluster monitoring setting is now applied via `metadata.labels` instead of `metadata.annotations`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->