### PR TITLE
NO-JIRA: e2e: fix label-filter shell quoting in test-e2e target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ test-e2e: test-e2e-wait-for-stable-state ## Run end-to-end tests.
 		-timeout $(E2E_TIMEOUT) \
 		-count 1 -v -p 1 \
 		-tags e2e -run "$(TEST)" . \
-		-ginkgo.label-filter=$(E2E_GINKGO_LABEL_FILTER)
+		-ginkgo.label-filter='$(E2E_GINKGO_LABEL_FILTER)'
 
 .PHONY: test-e2e-wait-for-stable-state
 test-e2e-wait-for-stable-state:


### PR DESCRIPTION
## Problem
`make test-e2e` fails immediately with:
  Syntax Error Parsing Label Filter
  Platform:
  Missing set operation.

The shell word-splits the unquoted $(E2E_GINKGO_LABEL_FILTER) expansion,
so Ginkgo only sees "Platform:" instead of the full expression.

## Fix
Wrap $(E2E_GINKGO_LABEL_FILTER) in single quotes at the call site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test execution by making label-based test filtering more reliable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->