### PR TITLE
NO-JIRA: Fix Vault e2e Helm installer pod PSA seccomp violation

### DIFF
--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -2199,6 +2199,11 @@ func setupVaultServer(ctx context.Context, cfg *rest.Config, loader library.Dyna
 		Spec: corev1.PodSpec{
 			ServiceAccountName: serviceAccountName,
 			RestartPolicy:      corev1.RestartPolicyNever,
+			SecurityContext: &corev1.PodSecurityContext{
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
 			Containers: []corev1.Container{
 				{
 					Name:            "helm",
@@ -2216,6 +2221,9 @@ func setupVaultServer(ctx context.Context, cfg *rest.Config, loader library.Dyna
 						RunAsNonRoot:             &runAsNonRoot,
 						RunAsUser:                &runAsUser,
 						Privileged:               &privileged,
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{"ALL"},
 						},


### PR DESCRIPTION
## Summary
The Vault Issuer e2e tests intermittently fail in `BeforeEach` when creating the `vault-installer` Helm pod on clusters that enforce the Pod Security Admission `restricted` profile. The pod spec was missing a required seccomp profile.

This change sets `seccompProfile.type: RuntimeDefault` on both the pod and container security contexts for the Helm installer pod in `setupVaultServer()`, matching the pattern used by the operator's own deployments.

## Problem
On clusters enforcing `restricted:latest` PSA, pod creation fails with:

```
pods "vault-installer" is forbidden: violates PodSecurity "restricted:latest": seccompProfile (pod or container "helm" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

The failure is flaky because PSA enforcement depends on cluster configuration. Tests pass on clusters with permissive or audit-only defaults, and fail on clusters (including many OpenShift and generic CI environments) that strictly enforce the restricted profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container security settings to use the default seccomp profile in setup routines, aligning with current platform hardening practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->