### PR TITLE
NO-JIRA: e2e: fix label-filter shell quoting in test-e2e target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ test-e2e: test-e2e-wait-for-stable-state ## Run end-to-end tests.
 		-timeout $(E2E_TIMEOUT) \
 		-count 1 -v -p 1 \
 		-tags e2e -run "$(TEST)" . \
-		-ginkgo.label-filter=$(E2E_GINKGO_LABEL_FILTER)
+		-ginkgo.label-filter='$(E2E_GINKGO_LABEL_FILTER)'
 
 .PHONY: test-e2e-wait-for-stable-state
 test-e2e-wait-for-stable-state:


### PR DESCRIPTION
## Problem
`make test-e2e` fails immediately with a Ginkgo label-filter syntax error because bash word-splits the unquoted `$(E2E_GINKGO_LABEL_FILTER)` expansion at spaces and `&&`.

## Fix
Wrap `$(E2E_GINKGO_LABEL_FILTER)` in single quotes at the Makefile call site.

Same fix as openshift/cert-manager-operator#447 (merged to `cert-manager-1.19`).

## Note
A companion PR to openshift/release is required to remove embedded `"` from CI `E2E_GINKGO_LABEL_FILTER` job values once this lands.

## Test plan
- [ ] `make test-e2e` with default filter parses correctly
- [ ] CI e2e jobs pass after openshift/release update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test execution to handle label filters more reliably during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->