### PR TITLE
NO-JIRA: undo changes for e2e label-filter shell quoting in test-e2e target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ test-e2e: test-e2e-wait-for-stable-state ## Run end-to-end tests.
 		-timeout $(E2E_TIMEOUT) \
 		-count 1 -v -p 1 \
 		-tags e2e -run "$(TEST)" . \
-		-ginkgo.label-filter='$(E2E_GINKGO_LABEL_FILTER)'
+		-ginkgo.label-filter=$(E2E_GINKGO_LABEL_FILTER)
 
 .PHONY: test-e2e-wait-for-stable-state
 test-e2e-wait-for-stable-state:


### PR DESCRIPTION
To undo the changes done by the PR: https://github.com/openshift/cert-manager-operator/pull/447/changes
for branch cert-manager-1.19.
We are keeping the label-filter-quoting change only in the "master" branch as of now.