### PR TITLE
CNF-26103: Add default case in istiocsr getIssuer to prevent nil-pointer

### DIFF
--- a/pkg/controller/istiocsr/deployments.go
+++ b/pkg/controller/istiocsr/deployments.go
@@ -496,6 +496,8 @@ func (r *Reconciler) getIssuer(istiocsr *v1alpha1.IstioCSR) (client.Object, erro
 		object = &certmanagerv1.ClusterIssuer{}
 	case issuerKind:
 		object = &certmanagerv1.Issuer{}
+	default:
+		return nil, fmt.Errorf("unsupported issuer kind %q: must be %q or %q", issuerRefKind, clusterIssuerKind, issuerKind)
 	}
 
 	if err := r.Get(r.ctx, key, object); err != nil {

--- a/pkg/controller/istiocsr/deployments_test.go
+++ b/pkg/controller/istiocsr/deployments_test.go
@@ -1319,3 +1319,51 @@ func TestUpdateVolumeWithIssuerCA(t *testing.T) {
 		})
 	}
 }
+
+func TestGetIssuerUnsupportedKind(t *testing.T) {
+	r := testReconciler(t)
+
+	istiocsr := testIstioCSR()
+	istiocsr.Spec.IstioCSRConfig.CertManager.IssuerRef.Kind = "bogus"
+
+	obj, err := r.getIssuer(istiocsr)
+	if obj != nil {
+		t.Errorf("expected nil object for unsupported kind, got %T", obj)
+	}
+	if err == nil {
+		t.Fatal("expected error for unsupported issuer kind")
+	}
+	if !strings.Contains(err.Error(), "unsupported issuer kind") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestGetIssuerValidKinds(t *testing.T) {
+	tests := []struct {
+		name string
+		kind string
+	}{
+		{name: "issuer kind", kind: certmanagerv1.IssuerKind},
+		{name: "cluster issuer kind", kind: certmanagerv1.ClusterIssuerKind},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := &fakes.FakeCtrlClient{}
+			fakeClient.GetReturns(nil)
+
+			r := testReconciler(t)
+			r.CtrlClient = fakeClient
+
+			istiocsr := testIstioCSR()
+			istiocsr.Spec.IstioCSRConfig.CertManager.IssuerRef.Kind = tt.kind
+
+			obj, err := r.getIssuer(istiocsr)
+			if err != nil {
+				t.Fatalf("unexpected error for kind %q: %v", tt.kind, err)
+			}
+			if obj == nil {
+				t.Fatalf("expected non-nil object for kind %q", tt.kind)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `default` case to the `getIssuer` switch statement that returns a descriptive error instead of leaving `object` as nil
- Without this, an unsupported issuer kind would cause a nil-pointer panic on the `r.Get()` call
- Currently guarded by `assertIssuerRefExists` validating the kind first, but the function itself was unsafe for direct callers
- Discovered during full-codebase unit test audit ([PR #461](https://github.com/openshift/cert-manager-operator/pull/461))

## Related PRs

| PR | Title | Status |
|----|-------|--------|
| [#461](https://github.com/openshift/cert-manager-operator/pull/461) | [CNF-26153](https://redhat.atlassian.net/browse/CNF-26153): Add unit tests across codebase to close coverage gaps | Open |
| [#462](https://github.com/openshift/cert-manager-operator/pull/462) | [CNF-26102](https://redhat.atlassian.net/browse/CNF-26102): Fix istiocsr updateCondition error aggregation bug | Open |
| [#464](https://github.com/openshift/cert-manager-operator/pull/464) | [CNF-26150](https://redhat.atlassian.net/browse/CNF-26150): Fix flaky e2e ConditionMatcher.Matches early-return | Open |

## Jira

- [CNF-26103](https://issues.redhat.com/browse/CNF-26103) -- Add default case in istiocsr getIssuer to prevent nil-pointer dereference (To Do)
- Epic: [CNF-23509](https://issues.redhat.com/browse/CNF-23509) -- cert-manager-operator Tuning (In Progress)

## Test Plan

- [x] Existing unit tests pass (go test ./pkg/controller/istiocsr/... -count=1 -- 117 passed)
- [x] make lint clean
- [ ] CI passes