### PR TITLE
CNF-26150: Fix flaky e2e ConditionMatcher.Matches early-return when Any mode is true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ test-e2e: test-e2e-wait-for-stable-state ## Run end-to-end tests.
 		-timeout $(E2E_TIMEOUT) \
 		-count 1 -v -p 1 \
 		-tags e2e -run "$(TEST)" . \
-		-ginkgo.label-filter='$(E2E_GINKGO_LABEL_FILTER)'
+		-ginkgo.label-filter="$(E2E_GINKGO_LABEL_FILTER)"
 
 .PHONY: test-e2e-wait-for-stable-state
 test-e2e-wait-for-stable-state:

--- a/test/e2e/condition_matcher_test.go
+++ b/test/e2e/condition_matcher_test.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"regexp"
+	"time"
 
 	"context"
 	"encoding/json"
@@ -53,7 +54,9 @@ func (m *ConditionMatcher) Matches(conditions []opv1.OperatorCondition) bool {
 		}
 
 		if m.MatchesType(&cond) && !m.MatchesStatus(&cond) {
-			return false
+			if !m.Any {
+				return false
+			}
 		}
 	}
 
@@ -94,9 +97,13 @@ func GenerateConditionMatchers(tuples []PrefixAndMatchTypeTuple, expectedConditi
 // match with the expected conditions. It returns an error if a timeout (few mins) occurs or an error was
 // encountered which polls the status.
 func verifyOperatorStatusCondition(client v1alpha1client.OperatorV1alpha1Interface, conditionMatchers []ConditionMatcher) error {
+	return verifyOperatorStatusConditionWithTimeout(client, conditionMatchers, lowTimeout)
+}
+
+func verifyOperatorStatusConditionWithTimeout(client v1alpha1client.OperatorV1alpha1Interface, conditionMatchers []ConditionMatcher, timeout time.Duration) error {
 	var lastFetchedConditions []opv1.OperatorCondition
 
-	err := wait.PollUntilContextTimeout(context.TODO(), fastPollInterval, lowTimeout, true, func(context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(context.TODO(), fastPollInterval, timeout, true, func(context.Context) (bool, error) {
 		operator, err := client.CertManagers().Get(context.TODO(), "cluster", metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {

--- a/test/e2e/condition_matcher_unit_test.go
+++ b/test/e2e/condition_matcher_unit_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"strings"
 	"testing"
+	"time"
 
 	opv1 "github.com/openshift/api/operator/v1"
 	operatorv1alpha1 "github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
@@ -102,6 +103,20 @@ func TestVerifyOperatorStatusCondition(t *testing.T) {
 			errorContains: "context deadline exceeded",
 		},
 		{
+			name: "Any mode succeeds when matching condition appears after non-matching one",
+			expectedConditions: map[string]opv1.ConditionStatus{
+				"Degraded": opv1.ConditionTrue,
+			},
+			initialObjects: []runtime.Object{
+				newCertManagerObjectWithConditions(
+					opv1.OperatorCondition{Type: controllerPrefix + "-static-resources-Degraded", Status: opv1.ConditionFalse},
+					opv1.OperatorCondition{Type: controllerPrefix + "Degraded", Status: opv1.ConditionTrue},
+				),
+			},
+			matchAny:    true,
+			expectError: false,
+		},
+		{
 			name: "A missing condition for Progressing",
 			expectedConditions: map[string]opv1.ConditionStatus{
 				"Available":   opv1.ConditionTrue,
@@ -131,7 +146,7 @@ func TestVerifyOperatorStatusCondition(t *testing.T) {
 				{controllerPrefix, tt.matchAny},
 			}, tt.expectedConditions)
 
-			err := verifyOperatorStatusCondition(fakeClient.OperatorV1alpha1(), matchers)
+			err := verifyOperatorStatusConditionWithTimeout(fakeClient.OperatorV1alpha1(), matchers, 10*time.Second)
 
 			if tt.expectError && err == nil {
 				t.Errorf("Expected an error, but got nil")


### PR DESCRIPTION
## Summary

- Fix `ConditionMatcher.Matches()` early-return bug that short-circuits in `Any` mode on the first status mismatch, causing false negatives when iteration order places a non-matching condition before a matching one
- Add regression test reproducing the exact CI failure scenario (static-resources Degraded=False iterated before deployment Degraded=True)
- Guard the early-return with `!m.Any` so `Any` mode continues searching for at least one match

## Problem

The `Matches` function short-circuits with `return false` when it finds a condition that matches the type pattern but not the expected status. This is correct for `All` mode but wrong for `Any` mode -- `Any` should keep looking for at least one match.

Since the Kubernetes API returns conditions in non-deterministic order, this produces flaky e2e failures in the overrides tests. The `e2e-operator-tech-preview` job fails when `cert-manager-webhook-static-resources-Degraded` (False) is iterated before `cert-manager-webhook-deploymentDegraded` (True).

## Affected PRs

This flaky failure has been causing spurious CI failures on these open PRs:
- #463 -- [CNF-26103](https://redhat.atlassian.net/browse/CNF-26103): Add default case in istiocsr getIssuer to prevent nil-pointer
- #437 -- [CM-1112](https://redhat.atlassian.net/browse/CM-1112): Fix cluster-monitoring set as annotation instead of label
- #420 -- [CM-1040](https://redhat.atlassian.net/browse/CM-1040): Extract shared ApplyResource helper and migrate istiocsr to SSA
- #417 -- [CM-1114](https://redhat.atlassian.net/browse/CM-1114): Add health probes and richer status conditions

## Related PRs

| PR | Title | Status |
|----|-------|--------|
| [#462](https://github.com/openshift/cert-manager-operator/pull/462) | [CNF-26102](https://redhat.atlassian.net/browse/CNF-26102): Fix istiocsr updateCondition error aggregation bug | Open |
| [#461](https://github.com/openshift/cert-manager-operator/pull/461) | [CNF-26153](https://redhat.atlassian.net/browse/CNF-26153): Add unit tests across codebase to close coverage gaps | Open |
| [#463](https://github.com/openshift/cert-manager-operator/pull/463) | [CNF-26103](https://redhat.atlassian.net/browse/CNF-26103): Add default case in istiocsr getIssuer | Open |

## Jira

- [CNF-26150](https://issues.redhat.com/browse/CNF-26150) -- Fix flaky e2e ConditionMatcher.Matches early-return (To Do)
- Epic: [CNF-23509](https://issues.redhat.com/browse/CNF-23509) -- cert-manager-operator Tuning (In Progress)

## Test Plan

- [ ] CI passes (e2e-operator, e2e-operator-tech-preview)
- [x] Existing unit test `TestVerifyOperatorStatusCondition` passes (5 cases)
- [x] New test case "Any mode succeeds when matching condition appears after non-matching one" passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed “Any” condition matching so it continues checking conditions after a status mismatch and can correctly find a later match.

* **Tests**
  * Expanded end-to-end coverage for condition matching, including varied condition statuses and configurable verification timeouts.

* **Chores**
  * Updated end-to-end test execution so label filters are passed reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->