### PR TITLE
ART-14816: Add package.yaml for ART OLM bundle generation

### DIFF
--- a/bundle/cert-manager-operator.package.yaml
+++ b/bundle/cert-manager-operator.package.yaml
@@ -1,0 +1,6 @@
+---
+packageName: cert-manager-operator
+channels:
+- name: stable
+  currentCSV: cert-manager-operator.v1.19.1
+defaultChannel: stable

--- a/bundle/image-references
+++ b/bundle/image-references
@@ -10,11 +10,19 @@ spec:
   - name: jetstack-cert-manager-rhel9
     from:
       kind: DockerImage
-      name: quay.io/jetstack/cert-manager-controller:v1.19.4
+      name: quay.io/jetstack/cert-manager-controller:v1.19.6
+  - name: jetstack-cert-manager-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/jetstack/cert-manager-cainjector:v1.19.6
+  - name: jetstack-cert-manager-rhel9
+    from:
+      kind: DockerImage
+      name: quay.io/jetstack/cert-manager-webhook:v1.19.6
   - name: jetstack-cert-manager-acmesolver-rhel9
     from:
       kind: DockerImage
-      name: quay.io/jetstack/cert-manager-acmesolver:v1.19.4
+      name: quay.io/jetstack/cert-manager-acmesolver:v1.19.6
   - name: cert-manager-istio-csr-rhel9
     from:
       kind: DockerImage


### PR DESCRIPTION
## Problem Statement

ART's OLM bundler (Doozer) requires a `*.package.yaml` file in the `bundle/` directory for bundle rebase. Without it, the `olm_bundle_konflux` job fails with `IndexError: list index out of range`.

## Related Issue

Part of [ART-14816](https://redhat.atlassian.net/browse/ART-14816) (Onboard OAP operators to ART).

## Proposed Changes

Add `bundle/cert-manager-operator.package.yaml` — same pattern used by OADP (`oadp-operator.package.yaml`) and Logging (`cluster-logging-operator.package.yaml`).