### PR TITLE
Update bundle package.yaml channel to stable-v1

### DIFF
--- a/bundle/cert-manager-operator.package.yaml
+++ b/bundle/cert-manager-operator.package.yaml
@@ -1,6 +1,6 @@
 ---
 packageName: cert-manager-operator
 channels:
-- name: stable
+- name: stable-v1
   currentCSV: cert-manager-operator.v1.19.1
-defaultChannel: stable
+defaultChannel: stable-v1


### PR DESCRIPTION
## Summary
- Update bundle `package.yaml` channel from `stable` to `stable-v1` to match upstream production bundle annotations

## Context
Production bundle annotations use `stable-v1` as the channel name. Our `package.yaml` had `stable` which caused a mismatch in the rendered bundle branch annotations.

## Test plan
- [ ] Verify bundle build produces correct `annotations.yaml` with `channels.v1: stable-v1`
