### PR TITLE
fix(deployment): ensure OverrideEnv takes precedence over cluster pro…

### DIFF
--- a/pkg/controller/deployment/deployment_helper.go
+++ b/pkg/controller/deployment/deployment_helper.go
@@ -40,11 +40,48 @@ func mergeContainerArgs(sourceArgs []string, overrideArgs []string) (destArgs []
 }
 
 // mergeContainerEnvs merges source container env variables with those
-// provided as override env variables.
+// provided as override env variables. Override variables take precedence over source variables.
 func mergeContainerEnvs(sourceEnvs []corev1.EnvVar, overrideEnvs []corev1.EnvVar) []corev1.EnvVar {
 	destEnvsMap := map[string]corev1.EnvVar{}
 	parseEnvMap(destEnvsMap, sourceEnvs)
 	parseEnvMap(destEnvsMap, overrideEnvs)
+
+	keys := make([]string, 0)
+	for k := range destEnvsMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	destEnvs := make([]corev1.EnvVar, 0)
+	for _, k := range keys {
+		destEnvs = append(destEnvs, destEnvsMap[k])
+	}
+	return destEnvs
+}
+
+// mergeContainerEnvsWithPrecedence merges source container env variables with those provided
+// as override env variables. The precedence parameter specifies which env var names should
+// not be overwritten by source variables (e.g., user-specified OverrideEnv should not be
+// overwritten by cluster-wide proxy settings).
+func mergeContainerEnvsWithPrecedence(sourceEnvs []corev1.EnvVar, overrideEnvs []corev1.EnvVar, precedenceKeys []string) []corev1.EnvVar {
+	destEnvsMap := map[string]corev1.EnvVar{}
+	precedenceSet := map[string]bool{}
+	for _, key := range precedenceKeys {
+		precedenceSet[key] = true
+	}
+
+	// First, add override envs (highest precedence)
+	parseEnvMap(destEnvsMap, overrideEnvs)
+
+	// Then, add source envs (but don't overwrite entries marked for precedence)
+	for _, env := range sourceEnvs {
+		if _, exists := destEnvsMap[env.Name]; !exists {
+			destEnvsMap[env.Name] = env
+		} else if !precedenceSet[env.Name] {
+			// Only overwrite if the key is not marked for precedence
+			destEnvsMap[env.Name] = env
+		}
+	}
 
 	keys := make([]string, 0)
 	for k := range destEnvsMap {

--- a/pkg/controller/deployment/deployment_helper_test.go
+++ b/pkg/controller/deployment/deployment_helper_test.go
@@ -1,9 +1,11 @@
 package deployment
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/cert-manager-operator/api/operator/v1alpha1"
 	"github.com/openshift/cert-manager-operator/pkg/operator/clientset/versioned/fake"
 	certmanoperatorinformer "github.com/openshift/cert-manager-operator/pkg/operator/informers/externalversions"
@@ -1144,6 +1146,93 @@ func TestGetOverrideReplicasFor(t *testing.T) {
 			case <-certManagerChan:
 			case <-time.After(wait.ForeverTestTimeout):
 				t.Fatal("Informer did not get the deleted cert manager")
+			}
+		})
+	}
+}
+func TestMergeContainerEnvsWithPrecedence(t *testing.T) {
+	tests := []struct {
+		name           string
+		sourceEnvs     []corev1.EnvVar
+		overrideEnvs   []corev1.EnvVar
+		precedenceKeys []string
+		expectedEnvs   []corev1.EnvVar
+	}{
+		{
+			name: "source overwrites override when no precedence keys specified",
+			sourceEnvs: []corev1.EnvVar{
+				{Name: "HTTP_PROXY", Value: "http://source-proxy:3128"},
+				{Name: "PATH", Value: "/usr/bin"},
+			},
+			overrideEnvs: []corev1.EnvVar{
+				{Name: "HTTP_PROXY", Value: "http://override-proxy:8080"},
+			},
+			precedenceKeys: []string{},
+			expectedEnvs: []corev1.EnvVar{
+				{Name: "HTTP_PROXY", Value: "http://source-proxy:3128"},
+				{Name: "PATH", Value: "/usr/bin"},
+			},
+		},
+		{
+			name: "precedence env is protected from being overwritten by source",
+			sourceEnvs: []corev1.EnvVar{
+				{Name: "HTTP_PROXY", Value: "http://source-proxy:3128"},
+				{Name: "HTTPS_PROXY", Value: "https://source-proxy:3128"},
+				{Name: "PATH", Value: "/usr/bin"},
+			},
+			overrideEnvs: []corev1.EnvVar{
+				{Name: "HTTP_PROXY", Value: "http://override-proxy:8080"},
+			},
+			precedenceKeys: []string{"HTTP_PROXY"},
+			expectedEnvs: []corev1.EnvVar{
+				{Name: "HTTPS_PROXY", Value: "https://source-proxy:3128"},
+				{Name: "HTTP_PROXY", Value: "http://override-proxy:8080"},
+				{Name: "PATH", Value: "/usr/bin"},
+			},
+		},
+		{
+			name: "proxy override env takes precedence over cluster proxy",
+			sourceEnvs: []corev1.EnvVar{
+				{Name: "HTTP_PROXY", Value: "http://cluster-proxy.example.com:3128"},
+				{Name: "HTTPS_PROXY", Value: "https://cluster-proxy.example.com:3128"},
+				{Name: "NO_PROXY", Value: "kubernetes.default,localhost"},
+			},
+			overrideEnvs: []corev1.EnvVar{
+				{Name: "HTTP_PROXY", Value: "http://custom-proxy.example.com:8080"},
+				{Name: "HTTPS_PROXY", Value: "https://custom-proxy.example.com:8080"},
+			},
+			precedenceKeys: []string{"HTTP_PROXY", "HTTPS_PROXY"},
+			expectedEnvs: []corev1.EnvVar{
+				{Name: "HTTPS_PROXY", Value: "https://custom-proxy.example.com:8080"},
+				{Name: "HTTP_PROXY", Value: "http://custom-proxy.example.com:8080"},
+				{Name: "NO_PROXY", Value: "kubernetes.default,localhost"},
+			},
+		},
+		{
+			name: "multiple precedence keys protected from source overwrite",
+			sourceEnvs: []corev1.EnvVar{
+				{Name: "VAR_A", Value: "source_a"},
+				{Name: "VAR_B", Value: "source_b"},
+				{Name: "VAR_C", Value: "source_c"},
+			},
+			overrideEnvs: []corev1.EnvVar{
+				{Name: "VAR_A", Value: "override_a"},
+				{Name: "VAR_B", Value: "override_b"},
+			},
+			precedenceKeys: []string{"VAR_A", "VAR_B"},
+			expectedEnvs: []corev1.EnvVar{
+				{Name: "VAR_A", Value: "override_a"},
+				{Name: "VAR_B", Value: "override_b"},
+				{Name: "VAR_C", Value: "source_c"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := mergeContainerEnvsWithPrecedence(tc.sourceEnvs, tc.overrideEnvs, tc.precedenceKeys)
+			if !reflect.DeepEqual(actual, tc.expectedEnvs) {
+				t.Fatalf("mergeContainerEnvsWithPrecedence() mismatch:\n%s", cmp.Diff(tc.expectedEnvs, actual))
 			}
 		})
 	}

--- a/pkg/controller/deployment/deployment_overrides.go
+++ b/pkg/controller/deployment/deployment_overrides.go
@@ -107,7 +107,8 @@ func withContainerArgsOverrideHook(certmanagerinformer certmanagerinformer.CertM
 }
 
 // withContainerEnvOverrideHook verrides the container env with those provided by
-// the overrideEnvFunc function.
+// the overrideEnvFunc function. Override env variables take precedence and will not
+// be overwritten by other env sources (e.g., cluster-wide proxy settings).
 func withContainerEnvOverrideHook(certmanagerinformer certmanagerinformer.CertManagerInformer, deploymentName string, fn overrideEnvFunc) func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 	return func(operatorSpec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
 		overrideEnv, err := fn(certmanagerinformer, deploymentName)
@@ -116,8 +117,13 @@ func withContainerEnvOverrideHook(certmanagerinformer certmanagerinformer.CertMa
 		}
 
 		if overrideEnv != nil && len(overrideEnv) > 0 && len(deployment.Spec.Template.Spec.Containers) == 1 && deployment.Name == deploymentName {
-			deployment.Spec.Template.Spec.Containers[0].Env = mergeContainerEnvs(
-				deployment.Spec.Template.Spec.Containers[0].Env, overrideEnv)
+			// Collect override env variable names to protect them from being overwritten
+			precedenceKeys := make([]string, len(overrideEnv))
+			for i, env := range overrideEnv {
+				precedenceKeys[i] = env.Name
+			}
+			deployment.Spec.Template.Spec.Containers[0].Env = mergeContainerEnvsWithPrecedence(
+				deployment.Spec.Template.Spec.Containers[0].Env, overrideEnv, precedenceKeys)
 		}
 		return nil
 	}

--- a/pkg/controller/deployment/generic_deployment_controller.go
+++ b/pkg/controller/deployment/generic_deployment_controller.go
@@ -38,6 +38,7 @@ func newGenericDeploymentController(
 		withPodLabelsValidateHook(certManagerOperatorInformers.Operator().V1alpha1().CertManagers(), deployment.Name),
 		withContainerArgsOverrideHook(certManagerOperatorInformers.Operator().V1alpha1().CertManagers(), deployment.Name, getOverrideArgsFor),
 		withContainerArgsValidateHook(certManagerOperatorInformers.Operator().V1alpha1().CertManagers(), deployment.Name),
+		withProxyEnv,
 		withContainerEnvOverrideHook(certManagerOperatorInformers.Operator().V1alpha1().CertManagers(), deployment.Name, getOverrideEnvFor),
 		withContainerEnvValidateHook(certManagerOperatorInformers.Operator().V1alpha1().CertManagers(), deployment.Name),
 		withDeploymentReplicasOverrideHook(certManagerOperatorInformers.Operator().V1alpha1().CertManagers(), deployment.Name, getOverrideReplicasFor),
@@ -46,7 +47,6 @@ func newGenericDeploymentController(
 		withPodSchedulingOverrideHook(certManagerOperatorInformers.Operator().V1alpha1().CertManagers(), deployment.Name, getOverrideSchedulingFor),
 		withPodSchedulingValidateHook(certManagerOperatorInformers.Operator().V1alpha1().CertManagers(), deployment.Name),
 		withUnsupportedArgsOverrideHook,
-		withProxyEnv,
 		withCAConfigMap(kubeInformersForTargetNamespace.Core().V1().ConfigMaps(), deployment, trustedCAConfigmapName),
 		withSABoundToken,
 	}


### PR DESCRIPTION
…xy settings

Fix [CM-852](https://redhat.atlassian.net/browse/CM-852) where user-configured proxy environment variables via spec.controllerConfig.overrideEnv were being silently overwritten by cluster-wide proxy settings.

Changes:
- Add new mergeContainerEnvsWithPrecedence() function that respects environment variable precedence
- Reorder deployment hooks so withProxyEnv executes before withContainerEnvOverrideHook, ensuring override env variables are applied last and won't be overwritten
- Update withContainerEnvOverrideHook to use new merge function with precedence protection
- Add comprehensive tests for precedence logic

This ensures user-specified proxy values (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) take precedence over automatically injected cluster proxy settings, as documented in the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment variable overrides now consistently take precedence over values from other deployment sources.
  * Proxy-related environment settings are applied earlier, preventing them from being unintentionally overwritten.
  * Environment variable merging remains consistently ordered for more predictable deployment behavior.

* **Tests**
  * Added coverage for default precedence, protected override values, proxy settings, and multiple precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->