### PR TITLE
ai-eval: DNM, CM-735: Fix intermittent unreconciled IstioCSR CR due to dual-cache race

### DIFF
--- a/pkg/controller/istiocsr/client.go
+++ b/pkg/controller/istiocsr/client.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -30,14 +31,14 @@ type ctrlClient interface {
 	Exists(context.Context, client.ObjectKey, client.Object) (bool, error)
 }
 
-func NewClient(m manager.Manager) (ctrlClient, error) {
-	c, err := BuildCustomClient(m)
+func NewClient(m manager.Manager) (ctrlClient, cache.Cache, error) {
+	c, customCache, err := BuildCustomClient(m)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build custom client: %w", err)
+		return nil, nil, fmt.Errorf("failed to build custom client: %w", err)
 	}
 	return &ctrlClientImpl{
 		Client: c,
-	}, nil
+	}, customCache, nil
 }
 
 func (c *ctrlClientImpl) Get(

--- a/pkg/controller/istiocsr/controller.go
+++ b/pkg/controller/istiocsr/controller.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/go-logr/logr"
 
@@ -46,6 +47,11 @@ var (
 type Reconciler struct {
 	ctrlClient
 
+	// cache is the label-filtered cache backing ctrlClient reads. It is also
+	// used as the event source for the primary IstioCSR watch so that reconcile
+	// events and reads are served by the same informer (see SetupWithManager).
+	cache cache.Cache
+
 	ctx           context.Context
 	eventRecorder record.EventRecorder
 	log           logr.Logger
@@ -58,12 +64,13 @@ type Reconciler struct {
 
 // New returns a new Reconciler instance.
 func New(mgr ctrl.Manager) (*Reconciler, error) {
-	c, err := NewClient(mgr)
+	c, customCache, err := NewClient(mgr)
 	if err != nil {
 		return nil, err
 	}
 	return &Reconciler{
 		ctrlClient:    c,
+		cache:         customCache,
 		ctx:           context.Background(),
 		eventRecorder: mgr.GetEventRecorderFor(ControllerName),
 		log:           ctrl.Log.WithName(ControllerName),
@@ -71,7 +78,7 @@ func New(mgr ctrl.Manager) (*Reconciler, error) {
 	}, nil
 }
 
-func BuildCustomClient(mgr ctrl.Manager) (client.Client, error) {
+func BuildCustomClient(mgr ctrl.Manager) (client.Client, cache.Cache, error) {
 	managedResourceLabelReq, _ := labels.NewRequirement(requestEnqueueLabelKey, selection.Equals, []string{requestEnqueueLabelValue})
 	managedResourceLabelReqSelector := labels.NewSelector().Add(*managedResourceLabelReq)
 
@@ -109,51 +116,51 @@ func BuildCustomClient(mgr ctrl.Manager) (client.Client, error) {
 	}
 	customCache, err := cache.New(mgr.GetConfig(), customCacheOpts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err = customCache.GetInformer(context.Background(), &v1alpha1.IstioCSR{}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err = customCache.GetInformer(context.Background(), &certmanagerv1.Certificate{}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err = customCache.GetInformer(context.Background(), &appsv1.Deployment{}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err = customCache.GetInformer(context.Background(), &rbacv1.ClusterRole{}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err = customCache.GetInformer(context.Background(), &rbacv1.ClusterRoleBinding{}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err = customCache.GetInformer(context.Background(), &rbacv1.Role{}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err = customCache.GetInformer(context.Background(), &rbacv1.RoleBinding{}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err = customCache.GetInformer(context.Background(), &corev1.Service{}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err = customCache.GetInformer(context.Background(), &corev1.ServiceAccount{}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err = customCache.GetInformer(context.Background(), &corev1.Secret{}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err = customCache.GetInformer(context.Background(), &corev1.ConfigMap{}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err = customCache.GetInformer(context.Background(), &certmanagerv1.Issuer{}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if _, err = customCache.GetInformer(context.Background(), &certmanagerv1.ClusterIssuer{}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	err = mgr.Add(customCache)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	customClient, err := client.New(mgr.GetConfig(), client.Options{
@@ -165,10 +172,10 @@ func BuildCustomClient(mgr ctrl.Manager) (client.Client, error) {
 		},
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return customClient, nil
+	return customClient, customCache, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -234,9 +241,25 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controllerWatchResourcePredicates := builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}, controllerWatchResources)
 	controllerManagedResourcePredicates := builder.WithPredicates(controllerManagedResources)
 
+	// Source the primary IstioCSR watch from the same custom cache that backs
+	// the reconciler's reads (r.Get), instead of the manager's default cache
+	// used by For(). Using two independent informers for the same resource
+	// caused a race: the manager cache could enqueue a reconcile for a freshly
+	// created IstioCSR before the custom cache observed it, so r.Get returned
+	// NotFound and reconciliation was skipped with no requeue, leaving the CR
+	// with an empty status and no deployment until the operator pod restarted.
+	// Sharing a single informer guarantees the object is present in the cache
+	// whenever its create/update event triggers a reconcile.
+	istiocsrSource := source.Kind(
+		r.cache,
+		&v1alpha1.IstioCSR{},
+		&handler.TypedEnqueueRequestForObject[*v1alpha1.IstioCSR]{},
+		predicate.TypedGenerationChangedPredicate[*v1alpha1.IstioCSR]{},
+	)
+
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.IstioCSR{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Named(ControllerName).
+		WatchesRawSource(istiocsrSource).
 		Watches(&certmanagerv1.Certificate{}, handler.EnqueueRequestsFromMapFunc(mapFunc), withIgnoreStatusUpdatePredicates).
 		Watches(&appsv1.Deployment{}, handler.EnqueueRequestsFromMapFunc(mapFunc), withIgnoreStatusUpdatePredicates).
 		Watches(&rbacv1.ClusterRole{}, handler.EnqueueRequestsFromMapFunc(mapFunc), controllerManagedResourcePredicates).


### PR DESCRIPTION
## What

Fixes the intermittent failure where a newly created `IstioCSR` CR is not reconciled: its `.status` stays empty and the `cert-manager-istio-csr` Deployment is never created, with the operator logging:

```
"istiocsr.openshift.operator.io object not found, skipping reconciliation"
```

Restarting the operator pod resolves it, which pointed at a cache-consistency issue.

## Root cause

The controller used **two independent informers for the same `IstioCSR` resource**:

1. The manager's default cache drove reconcile events via `For(&IstioCSR{})`.
2. A separate label-filtered custom cache (built in `BuildCustomClient`) backed the reconciler's reads (`r.Get`).

On a freshly created `IstioCSR`, the manager cache could enqueue a reconcile before the custom cache observed the object. `Reconcile()` then read from the custom cache, got `NotFound`, and returned **without a requeue**. Since the object already existed, no further event reached the custom cache, so the CR stayed stuck until the pod restarted (forcing a LIST-based resync).

## Fix

Source the primary `IstioCSR` watch from the **same custom cache** that backs `r.Get`, using `WatchesRawSource(source.Kind(r.cache, ...))` instead of `For()`. The informer that triggers a reconcile is now the same one the read is served from, so the object is guaranteed present when its event fires. This also removes the redundant second `IstioCSR` informer on the manager's default cache.

- `BuildCustomClient` / `NewClient` now return the created `cache.Cache`.
- `Reconciler` gains a `cache` field, populated in `New`.
- `SetupWithManager` uses `WatchesRawSource` with a typed enqueue handler and generation-changed predicate; `.Named(ControllerName)` (already present) is required once `For()` is dropped.

## Testing

- `go build ./...` — passes
- `go vet ./pkg/controller/istiocsr/...` — clean
- `go test ./pkg/controller/istiocsr/...` — passes

Jira: https://issues.redhat.com/browse/CM-735

---
Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved controller resource monitoring with more targeted event filtering.
  * Reduced unnecessary processing during reconciliation for better operational efficiency.
  * Improved handling of controller cache initialization and resource access errors.
  * Reconciliation now responds more consistently to relevant resource updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->