### PR TITLE
OAPE-883: Populate OpenSpec stage eval cases in harness-evals

### DIFF
--- a/harness-evals/evals/code-generation_eval.yaml
+++ b/harness-evals/evals/code-generation_eval.yaml
@@ -1,7 +1,7 @@
 stage: code-generation
 artifact: fork working copy (code + tests)
 version: 1
-eval_count: 0
+eval_count: 19
 oape_commands:
   - api-generate
   - api-generate-tests
@@ -9,4 +9,358 @@ oape_commands:
   - e2e-generate
   - manual
   - any
-evals: []
+evals:
+  - id: eval-r001-codegen-001
+    round: 1
+    stage: code-generation
+    oape_command: api-generate
+    source_issue_ids: [ISSUE-005, RCA-5]
+    prompt: |
+      New CR fields that are optional nested objects must be pointer or equivalent omitempty types
+      with validation that does not assume the nested object is always present. Immutable fields
+      need CEL/XValidation (or documented equivalent) once set.
+    assertions:
+      - type: must_use_pattern
+        value: omitempty
+      - type: must_include_tests
+        value: validation
+      - type: must_follow_constitution
+        value: API compatibility
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-codegen-002
+    round: 1
+    stage: code-generation
+    oape_command: api-generate
+    source_issue_ids: [ISSUE-001]
+    prompt: |
+      CRD status and printer-column documentation must describe this API only. Copy-pasted sibling
+      operand names in comments or OpenAPI descriptions fail.
+    assertions:
+      - type: must_not_use
+        value: sibling operand name in this CRD's status description
+      - type: must_match_task_payload
+        value: types and CRD markers
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-codegen-003
+    round: 1
+    stage: code-generation
+    oape_command: api-generate-tests
+    source_issue_ids: [ISSUE-005, ISSUE-007]
+    prompt: |
+      API/CRD tests must cover omitted optional blocks, every policy enum value, and invalid
+      transitions for immutable fields. Tests must run via the repo's API test target, not only go test on controllers.
+    assertions:
+      - type: must_include_tests
+        value: optional omitted
+      - type: must_pass_make_targets
+        value: API test harness target from agents.md / Makefile
+      - type: must_co_generate_tests
+        value: true
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-codegen-004
+    round: 1
+    stage: code-generation
+    oape_command: api-implement
+    source_issue_ids: [ISSUE-005, RCA-5]
+    prompt: |
+      Reconcile code must not dereference optional spec pointers unconditionally. Policy-driven
+      ClusterRole rules and container args must stay consistent (extra secret write verbs only when policy allows).
+    assertions:
+      - type: must_not_use
+        value: unconditional nested spec dereference without nil check
+      - type: must_use_pattern
+        value: policy
+      - type: must_include_tests
+        value: nil or omitted spec
+      - type: must_co_generate_tests
+        value: true
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-codegen-005
+    round: 1
+    stage: code-generation
+    oape_command: api-implement
+    source_issue_ids: [ISSUE-001, RCA-1]
+    prompt: |
+      New controllers must use the apply/error helpers named in the task payload. Copying a sibling
+      operand's Create+Update or library-go apply path without an explicit task mandate fails.
+    assertions:
+      - type: must_match_task_payload
+        value: apply strategy
+      - type: must_follow_effective_go
+        value: true
+      - type: must_execute_verification
+        value: go build and go vet
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-codegen-006
+    round: 1
+    stage: code-generation
+    oape_command: api-implement
+    source_issue_ids: [ISSUE-002, RCA-2]
+    prompt: |
+      Feature-gated controllers must be registered fail-closed (default off). Platform exceptions
+      for missing FeatureSets must match the spec/plan, not an accidental always-on starter path.
+    assertions:
+      - type: must_use_pattern
+        value: feature gate
+      - type: must_include_tests
+        value: disabled or fail-closed
+      - type: must_not_violate_non_goals
+        value: default-off Tech Preview
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-codegen-007
+    round: 1
+    stage: code-generation
+    oape_command: manual
+    source_issue_ids: [ISSUE-003, ISSUE-008]
+    prompt: |
+      Bindata/Helm render and CSV/alm-examples must match CRD defaults (optional sources not enabled
+      in samples unless the managing CR enables them). RELATED_IMAGE env, code constants, and CSV
+      relatedImages must stay in sync. Run bindata/bundle verify make targets.
+    assertions:
+      - type: must_pass_make_targets
+        value: bindata or bundle verify
+      - type: must_use_pattern
+        value: RELATED_IMAGE
+      - type: must_match_task_payload
+        value: examples aligned with defaults
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-codegen-008
+    round: 1
+    stage: code-generation
+    oape_command: e2e-generate
+    source_issue_ids: [ISSUE-007, RCA-7]
+    prompt: |
+      E2E must restore cluster-global mutations (feature-env on subscription, Proxy, user-CA
+      ConfigMaps), use unique names, and assert specific condition reasons. AlreadyExists must not
+      count as a successful create.
+    assertions:
+      - type: must_use_pattern
+        value: DeferCleanup or restore
+      - type: must_not_use
+        value: ignore AlreadyExists as success
+      - type: must_include_tests
+        value: condition reason
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-codegen-009
+    round: 1
+    stage: code-generation
+    oape_command: e2e-generate
+    source_issue_ids: [ISSUE-004]
+    prompt: |
+      If lifecycle non-goals retain resources after CR delete, e2e (or a dedicated test) must assert
+      that operand resources still exist after delete, and that a missing required namespace degrades
+      without the operator creating the namespace.
+    assertions:
+      - type: must_include_tests
+        value: delete
+      - type: must_not_violate_non_goals
+        value: no uninstall on CR delete
+    scoring:
+      pass_threshold: 75
+
+  - id: eval-r001-codegen-010
+    round: 1
+    stage: code-generation
+    oape_command: any
+    source_issue_ids: [ISSUE-001]
+    prompt: |
+      Every task that changes Go must run go build and go vet on the affected packages. Generated
+      files (deepcopy, bindata, clients) must not be hand-edited.
+    assertions:
+      - type: must_execute_verification
+        value: go build
+      - type: must_not_use
+        value: hand-edit of zz_generated or bindata.go
+      - type: must_follow_constitution
+        value: true
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-codegen-011
+    round: 2
+    stage: code-generation
+    oape_command: api-generate
+    source_issue_ids: [ISSUE-010, RCA-10]
+    prompt: |
+      New Go API types must be only for CRDs this operator reconciles. Operand-owned CRDs are
+      regenerated via the repo's manifest pipeline and kustomization, not by adding types in the
+      operator API package. Stub/dead CRDs must not be treated as the operator API. Do not
+      hand-author generated CRD YAML.
+    assertions:
+      - type: must_not_use
+        value: Go types for operand-owned CRDs
+      - type: must_match_task_payload
+        value: operator-reconciled API only
+      - type: must_pass_make_targets
+        value: generate or update-manifests
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-codegen-012
+    round: 2
+    stage: code-generation
+    oape_command: api-generate-tests
+    source_issue_ids: [ISSUE-011, RCA-11]
+    prompt: |
+      API/CRD test harnesses are not a substitute for controller unit tests that assert the apply
+      idiom. When generating API tests, do not fake a Patch vs Update vs library-go apply path that
+      the controller does not use.
+    assertions:
+      - type: must_include_tests
+        value: validation
+      - type: must_not_use
+        value: wrong apply idiom as a stand-in for controller tests
+      - type: must_co_generate_tests
+        value: true
+    scoring:
+      pass_threshold: 75
+
+  - id: eval-r002-codegen-013
+    round: 2
+    stage: code-generation
+    oape_command: api-implement
+    source_issue_ids: [ISSUE-011, RCA-11]
+    prompt: |
+      Controller unit tests must assert the real apply path of this package: Patch+Apply+FieldOwner
+      vs Update vs library-go resourceapply. Status/finalizers may still Update even when resource
+      apply is SSA. A green test that counts the wrong client method fails.
+    assertions:
+      - type: must_include_tests
+        value: Patch or Update or Apply
+      - type: must_use_pattern
+        value: FieldOwner or resourceapply matching this controller
+      - type: must_co_generate_tests
+        value: true
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-codegen-014
+    round: 2
+    stage: code-generation
+    oape_command: api-implement
+    source_issue_ids: [ISSUE-012, RCA-12]
+    prompt: |
+      New watches on a shared cache must not add label-filtered informers for GVKs that also watch
+      unlabeled objects. Use predicates. Do not merge two label selectors on one GVK.
+    assertions:
+      - type: must_not_use
+        value: label-filtered cache for unlabeled watches
+      - type: must_use_pattern
+        value: predicate
+      - type: must_follow_effective_go
+        value: true
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-codegen-015
+    round: 2
+    stage: code-generation
+    oape_command: api-implement
+    source_issue_ids: [ISSUE-009, RCA-9]
+    prompt: |
+      New or changed feature gates must wire all repo-documented touchpoints (API default/pre-release,
+      flag registration, starter parse, runtime IsEnabled, manager cache + reconciler registration).
+      Do not resurrect unused cluster-preview helpers. CRDs typically always install; only
+      controllers are gated. Fail-closed / default-off for Tech Preview still applies.
+    assertions:
+      - type: must_use_pattern
+        value: feature gate
+      - type: must_not_use
+        value: unused cluster-preview helper
+      - type: must_include_tests
+        value: disabled or fail-closed
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-codegen-016
+    round: 2
+    stage: code-generation
+    oape_command: api-implement
+    source_issue_ids: [ISSUE-014, RCA-14]
+    prompt: |
+      Placeholder / never-started reconcilers (RBAC-marker stubs) must not be extended with real
+      reconcile logic. Warn-only CR-delete cleanup must not be turned into uninstall unless the
+      task payload scopes that work.
+    assertions:
+      - type: must_not_use
+        value: extend placeholder reconciler
+      - type: must_not_violate_non_goals
+        value: warn-only cleanup or no uninstall on CR delete
+      - type: must_match_task_payload
+        value: true
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-codegen-017
+    round: 2
+    stage: code-generation
+    oape_command: e2e-generate
+    source_issue_ids: [ISSUE-013, RCA-13]
+    prompt: |
+      E2E must use distinct Ginkgo (or equivalent) label expressions for gate-enabled vs
+      gate-inverted suites. Do not merge those filters. `make test` typically does not run e2e —
+      invoke the documented e2e targets.
+    assertions:
+      - type: must_use_pattern
+        value: distinct label filter
+      - type: must_not_use
+        value: merged enabled and inverted suite
+      - type: must_pass_make_targets
+        value: e2e target from repo-assessment
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-codegen-018
+    round: 2
+    stage: code-generation
+    oape_command: manual
+    source_issue_ids: [ISSUE-013, RCA-13]
+    prompt: |
+      Operand image bumps must edit Deployment RELATED_IMAGE env literals and matching code
+      constants, then regenerate the bundle/CSV relatedImages. Changing only Makefile
+      operand-version variables is insufficient unless repo-assessment proves those literals are
+      generated from the Makefile.
+    assertions:
+      - type: must_use_pattern
+        value: RELATED_IMAGE
+      - type: must_pass_make_targets
+        value: bundle
+      - type: must_not_use
+        value: Makefile-only version bump
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-codegen-019
+    round: 2
+    stage: code-generation
+    oape_command: any
+    source_issue_ids: [ISSUE-010]
+    prompt: |
+      Generated CRD YAML, bindata, deepcopy, and clients must be regenerated with the repo's make
+      targets, not hand-edited. Operand CRD files belong in the manifest pipeline, not in the
+      operator API package.
+    assertions:
+      - type: must_not_use
+        value: hand-edit of generated CRD or bindata
+      - type: must_pass_make_targets
+        value: generate or update-manifests or verify-bindata
+      - type: must_execute_verification
+        value: go vet or make verify
+    scoring:
+      pass_threshold: 80

--- a/harness-evals/evals/plan_eval.yaml
+++ b/harness-evals/evals/plan_eval.yaml
@@ -1,3 +1,198 @@
 stage: plan
 template: templates/plan-template.md
-evals: []
+evals:
+  - id: eval-r001-plan-001
+    round: 1
+    stage: plan
+    source_issue_ids: [ISSUE-001, RCA-1]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      §1/§3.2 must record an apply/update strategy decision for a new controller: copy-source,
+      forbidden sibling helpers, and retry vs irrecoverable errors. "Follow existing controllers"
+      fails when the repo already has more than one stack.
+    assertions:
+      - type: must_cover_section
+        value: Architectural strategy
+      - type: must_mention
+        value: apply
+      - type: must_identify_pattern
+        value: irrecoverable or retry
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-plan-002
+    round: 1
+    stage: plan
+    source_issue_ids: [ISSUE-002, RCA-2]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      Feature enablement must be a first-class phase or verification row: operator gate, cluster
+      FeatureSet if used, platforms without FeatureSets, default-off, fail-closed starter.
+    assertions:
+      - type: must_mention
+        value: feature gate
+      - type: must_include_verification_matrix
+        value: fail-closed or FeatureSet or platform
+      - type: must_cover_phase
+        value: starter or gate
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-plan-003
+    round: 1
+    stage: plan
+    source_issue_ids: [ISSUE-003, ISSUE-008]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      Optional operand work must not be a single "implement controller" phase. Static install
+      manifests/bindata, CR overlay, RELATED_IMAGE/CSV/examples, and docs/packaging must be
+      sequenced with dependencies.
+    assertions:
+      - type: must_cover_phase
+        value: bindata or manifest
+      - type: must_mention
+        value: RELATED_IMAGE or CSV or bundle
+      - type: must_align_with_constitution
+        value: verification hooks
+    scoring:
+      pass_threshold: 75
+
+  - id: eval-r001-plan-004
+    round: 1
+    stage: plan
+    source_issue_ids: [ISSUE-004, RCA-4]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      If the spec says deleting the managing CR does not uninstall operand resources, or that a
+      namespace must pre-exist, the plan must put those in non-goals/risks AND in the verification
+      matrix (not only in prose).
+    assertions:
+      - type: must_mention
+        value: delete
+      - type: must_identify_pattern
+        value: uninstall or retain or namespace
+      - type: must_include_verification_matrix
+        value: lifecycle
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-plan-005
+    round: 1
+    stage: plan
+    source_issue_ids: [ISSUE-005, RCA-5]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      §3.4 must describe RBAC that changes with CR policy (default rules vs extra secret write
+      resourceNames) and how container args stay consistent with that policy.
+    assertions:
+      - type: must_cover_section
+        value: RBAC
+      - type: must_mention
+        value: policy
+      - type: must_identify_pattern
+        value: ClusterRole or resourceNames
+    scoring:
+      pass_threshold: 75
+
+  - id: eval-r001-plan-006
+    round: 1
+    stage: plan
+    source_issue_ids: [ISSUE-007, RCA-7]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      Verification matrix must include API/CRD test harness sequencing (harness before new CRD
+      suites when repo-assessment says so) and e2e that restores cluster-global mutations.
+    assertions:
+      - type: must_include_verification_matrix
+        value: e2e
+      - type: must_mention
+        value: restore or teardown or isolation
+      - type: must_reference_spec_ids
+        value: FR
+    scoring:
+      pass_threshold: 75
+
+  - id: eval-r002-plan-007
+    round: 2
+    stage: plan
+    source_issue_ids: [ISSUE-009, RCA-9]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      Enablement phases must cite CURRENT repo-assessment/ADR wiring (operator flag, five
+      registration touchpoints or the repo's equivalent, CRDs-always-on vs controllers-gated).
+      Copying a superseded original-EP cluster FeatureSet path, or resurrecting unused
+      cluster-preview helpers, fails.
+    assertions:
+      - type: must_mention
+        value: feature gate
+      - type: must_cover_phase
+        value: starter or gate
+      - type: must_identify_pattern
+        value: current enablement or touchpoint
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-plan-008
+    round: 2
+    stage: plan
+    source_issue_ids: [ISSUE-010, ISSUE-014, RCA-10, RCA-14]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      §3.1 must classify CRDs as operator-reconciled vs operand-owned vs stub/dead. Plans must not
+      add Go types for operand-owned CRDs or extend placeholder/never-started reconcilers.
+    assertions:
+      - type: must_cover_section
+        value: Kubernetes APIs
+      - type: must_mention
+        value: operand or stub
+      - type: must_identify_pattern
+        value: do not extend placeholder or no Go types for operand CRDs
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-plan-009
+    round: 2
+    stage: plan
+    source_issue_ids: [ISSUE-012, ISSUE-013, RCA-12, RCA-13]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      New watches on a shared cache must justify unfiltered informers plus predicates. E2E
+      verification must split gate-enabled vs gate-inverted label suites. Packaging must edit
+      RELATED_IMAGE / Deployment literals then bundle — not only Makefile version variables.
+    assertions:
+      - type: must_mention
+        value: predicate or cache
+      - type: must_include_verification_matrix
+        value: e2e
+      - type: must_mention
+        value: RELATED_IMAGE or literal
+    scoring:
+      pass_threshold: 75
+
+  - id: eval-r002-plan-010
+    round: 2
+    stage: plan
+    source_issue_ids: [ISSUE-011, RCA-11]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      Unit verification hooks for a new or changed controller must require tests that assert the
+      real apply path (Patch vs Update vs library-go), not merely that a test file exists.
+    assertions:
+      - type: must_include_verification_matrix
+        value: unit
+      - type: must_mention
+        value: Patch or Update or apply
+      - type: must_identify_pattern
+        value: apply path or FieldOwner
+    scoring:
+      pass_threshold: 80

--- a/harness-evals/evals/repo-assessment_eval.yaml
+++ b/harness-evals/evals/repo-assessment_eval.yaml
@@ -1,3 +1,205 @@
 stage: repo-assessment
 template: templates/repo-assessment-template.md
-evals: []
+evals:
+  - id: eval-r001-repo-assessment-001
+    round: 1
+    stage: repo-assessment
+    source_issue_ids: [ISSUE-001, RCA-1]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      For a repository that already runs more than one operand/controller stack, the assessment
+      must tell a planner which apply/update method and error helper to copy for a NEW controller.
+      Fail if the artifact lists controllers but does not distinguish apply strategies or names an
+      invalid sibling as the default copy-source.
+    assertions:
+      - type: must_identify_pattern
+        value: per-controller apply strategy
+      - type: must_cover_section
+        value: reusable assets or architectural guardrails
+      - type: must_mention
+        value: copy-source
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-repo-assessment-002
+    round: 1
+    stage: repo-assessment
+    source_issue_ids: [ISSUE-002, RCA-2]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      Optional/Tech Preview capabilities must document how enablement is evaluated at runtime:
+      operator-level flags, cluster FeatureSet (if used), platforms that cannot evaluate FeatureSets,
+      default value, and fail-closed registration. A list of gate names without runtime behavior is insufficient.
+    assertions:
+      - type: must_cover_section
+        value: feature gate
+      - type: must_identify_pattern
+        value: fail-closed
+      - type: must_mention
+        value: default
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-repo-assessment-003
+    round: 1
+    stage: repo-assessment
+    source_issue_ids: [ISSUE-003, RCA-3]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      If install manifests are generated (Helm/script → bindata) and then mutated from a CR,
+      the assessment must separate those pipelines and include change-cascade rows with real
+      make/hack verify commands. CSV/alm-examples must be called out as needing to match CRD defaults.
+    assertions:
+      - type: must_identify_pattern
+        value: bindata
+      - type: must_cover_section
+        value: change cascade
+      - type: must_cite_repo_evidence
+        value: make
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-repo-assessment-004
+    round: 1
+    stage: repo-assessment
+    source_issue_ids: [ISSUE-006, RCA-6]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      When the operator uses platform trusted-CA injection, the assessment must document operator
+      namespace vs operand namespace ConfigMaps, inject-label contract, requeue while empty, and
+      rollout when package content changes (hash/annotation).
+    assertions:
+      - type: must_identify_pattern
+        value: inject
+      - type: must_mention
+        value: namespace
+      - type: must_cover_section
+        value: image / dependency or configuration surface
+    scoring:
+      pass_threshold: 75
+
+  - id: eval-r001-repo-assessment-005
+    round: 1
+    stage: repo-assessment
+    source_issue_ids: [ISSUE-007, RCA-7]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      Test & CI reference must name the API/CRD test module or script (if separate from unit tests)
+      and the CI job that actually starts gated/optional controllers, not only the default e2e suite.
+    assertions:
+      - type: must_cover_section
+        value: test
+      - type: must_identify_pattern
+        value: e2e
+      - type: must_mention
+        value: Makefile
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-repo-assessment-006
+    round: 1
+    stage: repo-assessment
+    source_issue_ids: [ISSUE-008, RCA-8]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      Image resolution must document RELATED_IMAGE (or equivalent) triple-sync with deployment env
+      and CSV relatedImages. Assessments that only list container image names without the cascade
+      are incomplete.
+    assertions:
+      - type: must_identify_pattern
+        value: RELATED_IMAGE
+      - type: must_mention
+        value: relatedImages
+      - type: must_cover_section
+        value: change cascade
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-repo-assessment-007
+    round: 2
+    stage: repo-assessment
+    source_issue_ids: [ISSUE-009, RCA-9]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      Feature-enablement documentation must state the CURRENT runtime wiring (operator flag,
+      registration touchpoints, fail-closed default) and explicitly distinguish it from any
+      superseded cluster FeatureSet / original-EP matrix. Unused cluster-preview helpers must be
+      marked dead, not copy-sources. "Gated" must say whether CRDs always install while only
+      controllers are gated.
+    assertions:
+      - type: must_cover_section
+        value: feature gate
+      - type: must_identify_pattern
+        value: current vs historical or removed FeatureSet
+      - type: must_mention
+        value: CRD or controller
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-repo-assessment-008
+    round: 2
+    stage: repo-assessment
+    source_issue_ids: [ISSUE-010, RCA-10]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      CRD inventory must classify operator-reconciled APIs (Go types in this repo) vs operand-owned
+      CRDs (vendored/generated; no new Go types here) vs stub/dead CRDs. Shipping a CRD in the
+      bundle is not evidence that this operator Reconciles it.
+    assertions:
+      - type: must_identify_pattern
+        value: operator-owned vs operand-owned CRD
+      - type: must_mention
+        value: stub or dead or unused
+      - type: must_cover_section
+        value: API or architecture
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-repo-assessment-009
+    round: 2
+    stage: repo-assessment
+    source_issue_ids: [ISSUE-012, RCA-12]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      Shared manager caches must document which GVKs stay unfiltered because unlabeled objects are
+      also watched, and that predicates (not label-filtered ByObject) are the filter. Merging two
+      label selectors on one GVK is an invalid copy-source.
+    assertions:
+      - type: must_identify_pattern
+        value: cache or predicate
+      - type: must_mention
+        value: unlabeled or label-filter
+      - type: must_cover_section
+        value: architectural guardrails or reusable assets
+    scoring:
+      pass_threshold: 75
+
+  - id: eval-r002-repo-assessment-010
+    round: 2
+    stage: repo-assessment
+    source_issue_ids: [ISSUE-013, ISSUE-014, RCA-13, RCA-14]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      Image resolution must note whether Deployment RELATED_IMAGE env literals are derived from
+      Makefile operand-version variables (usually they are not). Test/CI must name distinct
+      gate-enabled vs gate-inverted e2e label suites when both exist. Placeholder/never-started
+      reconcilers must be listed as do-not-extend traps.
+    assertions:
+      - type: must_identify_pattern
+        value: RELATED_IMAGE
+      - type: must_mention
+        value: Makefile or literal
+      - type: must_cover_section
+        value: test or dead-code
+    scoring:
+      pass_threshold: 75

--- a/harness-evals/evals/tasks_eval.yaml
+++ b/harness-evals/evals/tasks_eval.yaml
@@ -1,3 +1,198 @@
 stage: tasks
 template: templates/tasks-template.md
-evals: []
+evals:
+  - id: eval-r001-tasks-001
+    round: 1
+    stage: tasks
+    source_issue_ids: [ISSUE-007, RCA-7]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      If repo-assessment documents a separate API test module or Makefile harness, the DAG must
+      include that harness task before API test-suite tasks. API tests must not depend only on
+      "types exist."
+    assertions:
+      - type: must_respect_dag
+        value: harness before API tests
+      - type: must_mention
+        value: test-apis or API test
+      - type: must_assign_agent
+        value: Testing_Agent or API_Agent
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-tasks-002
+    round: 1
+    stage: tasks
+    source_issue_ids: [ISSUE-005, RCA-5]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      Tasks that add enum/policy fields or optional nested spec must include table-driven tests for
+      every policy value and for omitted optional blocks (nil-safe). Deferred coverage requires an
+      explicit follow-up Testing task ID in Depends On.
+    assertions:
+      - type: must_define_acceptance_criteria
+        value: table-driven or permutation
+      - type: must_mention
+        value: optional
+      - type: must_cover_all_spec_requirements
+        value: policy
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-tasks-003
+    round: 1
+    stage: tasks
+    source_issue_ids: [ISSUE-007]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      E2E/cluster tasks must require restore of cluster-global mutations, unique object names
+      (AlreadyExists is not success), and assertions on specific condition type/reason rather than
+      Ready=False alone.
+    assertions:
+      - type: must_define_acceptance_criteria
+        value: restore
+      - type: must_mention
+        value: AlreadyExists or unique
+      - type: must_assign_agent
+        value: Testing_Agent
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r001-tasks-004
+    round: 1
+    stage: tasks
+    source_issue_ids: [ISSUE-001, RCA-1]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      Controller implementation tasks must name the allowed apply/error helper and the forbidden
+      sibling-operand copy in Non-goals / Implementation notes.
+    assertions:
+      - type: must_mention
+        value: forbidden or do not copy
+      - type: must_assign_agent
+        value: OperatorController_Agent
+      - type: must_define_acceptance_criteria
+        value: apply or SSA or Update
+    scoring:
+      pass_threshold: 75
+
+  - id: eval-r001-tasks-005
+    round: 1
+    stage: tasks
+    source_issue_ids: [ISSUE-003, ISSUE-008]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      Bindata/Helm generation, CR overlay, RELATED_IMAGE/CSV, and docs must be separate tasks with
+      distinct agents (ManifestsBindata, OperatorController, OLMRelease, Docs) — not one controller task.
+    assertions:
+      - type: must_assign_agent
+        value: ManifestsBindata_Agent
+      - type: must_assign_agent
+        value: OLMRelease_Agent
+      - type: must_mention
+        value: RELATED_IMAGE or bundle
+    scoring:
+      pass_threshold: 75
+
+  - id: eval-r001-tasks-006
+    round: 1
+    stage: tasks
+    source_issue_ids: [ISSUE-004, RCA-4]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      Coverage checklist must map lifecycle non-goals (CR delete retains resources; namespace not
+      auto-created) to at least one Testing or e2e task with explicit acceptance criteria.
+    assertions:
+      - type: must_cover_all_spec_requirements
+        value: delete or uninstall or namespace
+      - type: must_define_acceptance_criteria
+        value: retain or does not create
+      - type: must_respect_dag
+        value: e2e after install path
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-tasks-007
+    round: 2
+    stage: tasks
+    source_issue_ids: [ISSUE-011, RCA-11]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      Controller implementation tasks must require unit tests that assert the real apply path of
+      THIS package (Patch+Apply+FieldOwner vs Update vs library-go resourceapply). A green test on
+      the wrong client method fails the acceptance criteria.
+    assertions:
+      - type: must_define_acceptance_criteria
+        value: Patch or Update or apply
+      - type: must_assign_agent
+        value: OperatorController_Agent
+      - type: must_mention
+        value: FieldOwner or resourceapply or Fake
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-tasks-008
+    round: 2
+    stage: tasks
+    source_issue_ids: [ISSUE-013, RCA-13]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      E2E tasks must use distinct label expressions for gate-enabled vs gate-inverted suites and
+      must not merge those filters. Coverage checklist should map both suites when repo-assessment
+      documents both.
+    assertions:
+      - type: must_assign_agent
+        value: Testing_Agent
+      - type: must_mention
+        value: label or inverted
+      - type: must_define_acceptance_criteria
+        value: distinct suite or filter
+    scoring:
+      pass_threshold: 80
+
+  - id: eval-r002-tasks-009
+    round: 2
+    stage: tasks
+    source_issue_ids: [ISSUE-008, ISSUE-013, RCA-13]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/rca-summary.md
+    prompt: |
+      OLMRelease / image tasks that bump operand versions must edit Deployment RELATED_IMAGE
+      literals (and matching constants) then bundle verify — not only Makefile version variables.
+    assertions:
+      - type: must_assign_agent
+        value: OLMRelease_Agent
+      - type: must_mention
+        value: RELATED_IMAGE
+      - type: must_define_acceptance_criteria
+        value: literal or Deployment env or bundle
+    scoring:
+      pass_threshold: 75
+
+  - id: eval-r002-tasks-010
+    round: 2
+    stage: tasks
+    source_issue_ids: [ISSUE-010, ISSUE-014, RCA-10, RCA-14]
+    input_refs:
+      - eval-generation/eval-generation-workflow/outputs/epic-bug-analysis/pattern-analysis.md
+    prompt: |
+      API tasks must forbid adding Go types for operand-owned CRDs. Controller tasks must list
+      placeholder/never-started reconcilers as Non-goals (do not extend). Warn-only CR-delete
+      cleanup remains a non-goal unless the spec/plan scopes uninstall.
+    assertions:
+      - type: must_mention
+        value: forbidden or do not
+      - type: must_cover_all_spec_requirements
+        value: operand CRD or placeholder or cleanup
+      - type: must_assign_agent
+        value: API_Agent or OperatorController_Agent
+    scoring:
+      pass_threshold: 75


### PR DESCRIPTION
## Summary
- Copy OpenSpec stage eval cases into `harness-evals/evals` so `/opsx-continue` can gate repo-assessment, plan, tasks, and code-generation.
- Adds 10 repo-assessment, 10 plan, 10 tasks, and 19 code-generation cases (rounds 1–2).

https://redhat.atlassian.net/browse/OAPE-883

## Test plan
- [x] Confirm the PR contains only `harness-evals/evals/` YAML
- [x] Confirm eval counts: repo-assessment 10, plan 10, tasks 10, code-generation 19
- [x] YAML parses (`python3 -c 'import yaml,pathlib,sys; [yaml.safe_load(p.read_text()) for p in pathlib.Path("harness-evals/evals").glob("*_eval.yaml")]'`)