### PR TITLE
CM-1236: Use staged 1.19.2 operator and operand images for CI testing

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -276,7 +276,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Security
     console.openshift.io/disable-operand-delete: "true"
-    containerImage: openshift.io/cert-manager-operator:latest
+    containerImage: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:ebb988080e93a733111f641cda75c30fb773509e9e35d928fe41262871d0fa68
     createdAt: 2023-03-03T00:00:00
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -788,17 +788,17 @@ spec:
                 - name: OPERATOR_NAME
                   value: cert-manager-operator
                 - name: RELATED_IMAGE_CERT_MANAGER_WEBHOOK
-                  value: quay.io/jetstack/cert-manager-webhook:v1.19.6
+                  value: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:9144fd826b65687970a6a88a4e7e50cc9b4bf4b76d3c427f1de6899e6a79b7fa
                 - name: RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR
-                  value: quay.io/jetstack/cert-manager-cainjector:v1.19.6
+                  value: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:9144fd826b65687970a6a88a4e7e50cc9b4bf4b76d3c427f1de6899e6a79b7fa
                 - name: RELATED_IMAGE_CERT_MANAGER_CONTROLLER
-                  value: quay.io/jetstack/cert-manager-controller:v1.19.6
+                  value: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:9144fd826b65687970a6a88a4e7e50cc9b4bf4b76d3c427f1de6899e6a79b7fa
                 - name: RELATED_IMAGE_CERT_MANAGER_ACMESOLVER
-                  value: quay.io/jetstack/cert-manager-acmesolver:v1.19.6
+                  value: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:5e42c5983bf93e3d0f31de628dc7d96ceec6136cdcb5f9e22dd29cc5193951a0
                 - name: RELATED_IMAGE_CERT_MANAGER_ISTIOCSR
-                  value: quay.io/jetstack/cert-manager-istio-csr:v0.16.0
+                  value: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:ed4f77362a05546f5809ae3675f5c5e8093453e7785f580f93348419900c1f06
                 - name: RELATED_IMAGE_CERT_MANAGER_TRUST_MANAGER
-                  value: quay.io/jetstack/trust-manager:v0.20.3
+                  value: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
                 - name: OPERAND_IMAGE_VERSION
                   value: 1.19.6
                 - name: ISTIOCSR_OPERAND_IMAGE_VERSION
@@ -812,7 +812,7 @@ spec:
                 - name: TRUSTED_CA_CONFIGMAP_NAME
                 - name: CLOUD_CREDENTIALS_SECRET_NAME
                 - name: UNSUPPORTED_ADDON_FEATURES
-                image: openshift.io/cert-manager-operator:latest
+                image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:ebb988080e93a733111f641cda75c30fb773509e9e35d928fe41262871d0fa68
                 imagePullPolicy: IfNotPresent
                 name: cert-manager-operator
                 ports:
@@ -909,17 +909,13 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: quay.io/jetstack/cert-manager-webhook:v1.19.6
-    name: cert-manager-webhook
-  - image: quay.io/jetstack/cert-manager-cainjector:v1.19.6
-    name: cert-manager-ca-injector
-  - image: quay.io/jetstack/cert-manager-controller:v1.19.6
-    name: cert-manager-controller
-  - image: quay.io/jetstack/cert-manager-acmesolver:v1.19.6
+  - image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:9144fd826b65687970a6a88a4e7e50cc9b4bf4b76d3c427f1de6899e6a79b7fa
+    name: ""
+  - image: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:5e42c5983bf93e3d0f31de628dc7d96ceec6136cdcb5f9e22dd29cc5193951a0
     name: cert-manager-acmesolver
-  - image: quay.io/jetstack/cert-manager-istio-csr:v0.16.0
+  - image: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:ed4f77362a05546f5809ae3675f5c5e8093453e7785f580f93348419900c1f06
     name: cert-manager-istiocsr
-  - image: quay.io/jetstack/trust-manager:v0.20.3
+  - image: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
     name: cert-manager-trust-manager
   replaces: cert-manager-operator.v1.19.1
   version: 1.19.2

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -75,17 +75,17 @@ spec:
             - name: OPERATOR_NAME
               value: cert-manager-operator
             - name: RELATED_IMAGE_CERT_MANAGER_WEBHOOK
-              value: quay.io/jetstack/cert-manager-webhook:v1.19.6
+              value: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:9144fd826b65687970a6a88a4e7e50cc9b4bf4b76d3c427f1de6899e6a79b7fa
             - name: RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR
-              value: quay.io/jetstack/cert-manager-cainjector:v1.19.6
+              value: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:9144fd826b65687970a6a88a4e7e50cc9b4bf4b76d3c427f1de6899e6a79b7fa
             - name: RELATED_IMAGE_CERT_MANAGER_CONTROLLER
-              value: quay.io/jetstack/cert-manager-controller:v1.19.6
+              value: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:9144fd826b65687970a6a88a4e7e50cc9b4bf4b76d3c427f1de6899e6a79b7fa
             - name: RELATED_IMAGE_CERT_MANAGER_ACMESOLVER
-              value: quay.io/jetstack/cert-manager-acmesolver:v1.19.6
+              value: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:5e42c5983bf93e3d0f31de628dc7d96ceec6136cdcb5f9e22dd29cc5193951a0
             - name: RELATED_IMAGE_CERT_MANAGER_ISTIOCSR
-              value: quay.io/jetstack/cert-manager-istio-csr:v0.16.0
+              value: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:ed4f77362a05546f5809ae3675f5c5e8093453e7785f580f93348419900c1f06
             - name: RELATED_IMAGE_CERT_MANAGER_TRUST_MANAGER
-              value: quay.io/jetstack/trust-manager:v0.20.3
+              value: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
             - name: OPERAND_IMAGE_VERSION
               value: 1.19.6
             - name: ISTIOCSR_OPERAND_IMAGE_VERSION
@@ -99,7 +99,7 @@ spec:
             - name: TRUSTED_CA_CONFIGMAP_NAME
             - name: CLOUD_CREDENTIALS_SECRET_NAME
             - name: UNSUPPORTED_ADDON_FEATURES
-          image: controller:latest
+          image: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:ebb988080e93a733111f641cda75c30fb773509e9e35d928fe41262871d0fa68
           imagePullPolicy: IfNotPresent
           name: cert-manager-operator
           securityContext:


### PR DESCRIPTION
## Summary

**Test-only PR — do not merge.**

Points the operator image and `RELATED_IMAGE_*` env vars at the staged 1.19.2 digests from [`cert-manager-operator-release` `images_digest.conf` on `release-1.19`](https://github.com/openshift/cert-manager-operator-release/blob/release-1.19/images_digest.conf) so operator CI e2e (`e2e-operator`) runs the staged stack instead of pipeline-substituted `quay.io/jetstack` / `openshift.io/cert-manager-operator` images.

ci-operator substitutions only rewrite `quay.io/jetstack/...` and `openshift.io/cert-manager-operator:.*`. Using `registry.stage.redhat.io/...@sha256:...` means those substitutions no longer match. The `e2e-operator` job already runs `merge-stage-registry-credentials`, so the cluster can pull from `registry.stage.redhat.io`.

Jira: https://redhat.atlassian.net/browse/CM-1236

## Image mapping

| Component | Pullspec |
| --- | --- |
| Operator | `registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:ebb988080e93a733111f641cda75c30fb773509e9e35d928fe41262871d0fa68` |
| webhook / cainjector / controller | `registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:9144fd826b65687970a6a88a4e7e50cc9b4bf4b76d3c427f1de6899e6a79b7fa` |
| acmesolver | `registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:5e42c5983bf93e3d0f31de628dc7d96ceec6136cdcb5f9e22dd29cc5193951a0` |
| istio-csr | `registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:ed4f77362a05546f5809ae3675f5c5e8093453e7785f580f93348419900c1f06` |
| trust-manager | `registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82` |

The operator is pinned on `config/manager/manager.yaml` `image:` (replacing `controller:latest`), not via `kustomization.yaml`. `make bundle` always runs `kustomize edit set image controller=openshift.io/cert-manager-operator:latest`; pinning only in kustomize would be reset and ci-operator would inject the PR-built operator again.

The CSV is regenerated with `make bundle` so `hack/verify-bundle.sh` stays green. `spec.relatedImages` collapses webhook/cainjector/controller to one entry because they share a digest (operator-sdk warning); the `RELATED_IMAGE_*` env vars still list each component separately, which is what the operator uses at runtime.

## Test plan

- [ ] Confirm `e2e-operator` runs (not skipped)
- [ ] Operator pod uses `registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:ebb98808...`
- [ ] Operand deployments use the staged jetstack / acmesolver / istio-csr / trust-manager digests
- [ ] No ImagePullBackOff (stage credentials merged into the cluster pull secret)
- [ ] Close this PR without merging after CI results are collected

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

Made with [Cursor](https://cursor.com)