### PR TITLE
fix: rename CLOUD_CREDENTIALS_SECRET_NAME to avoid ACS policy violation

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -784,7 +784,7 @@ spec:
                 - start
                 - --v=$(OPERATOR_LOG_LEVEL)
                 - --trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)
-                - --cloud-credentials-secret=$(CLOUD_CREDENTIALS_SECRET_NAME)
+                - --cloud-credentials-secret=$(CLOUD_CREDENTIALS_REF)
                 - --unsupported-addon-features=$(UNSUPPORTED_ADDON_FEATURES)
                 command:
                 - /usr/bin/cert-manager-operator
@@ -822,7 +822,7 @@ spec:
                 - name: OPERATOR_LOG_LEVEL
                   value: "2"
                 - name: TRUSTED_CA_CONFIGMAP_NAME
-                - name: CLOUD_CREDENTIALS_SECRET_NAME
+                - name: CLOUD_CREDENTIALS_REF
                 - name: UNSUPPORTED_ADDON_FEATURES
                 image: openshift.io/cert-manager-operator:latest
                 imagePullPolicy: IfNotPresent

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -61,7 +61,7 @@ spec:
             - start
             - '--v=$(OPERATOR_LOG_LEVEL)'
             - '--trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)'
-            - '--cloud-credentials-secret=$(CLOUD_CREDENTIALS_SECRET_NAME)'
+            - '--cloud-credentials-secret=$(CLOUD_CREDENTIALS_REF)'
             - '--unsupported-addon-features=$(UNSUPPORTED_ADDON_FEATURES)'
           env:
             - name: WATCH_NAMESPACE
@@ -97,7 +97,7 @@ spec:
             - name: OPERATOR_LOG_LEVEL
               value: '2'
             - name: TRUSTED_CA_CONFIGMAP_NAME
-            - name: CLOUD_CREDENTIALS_SECRET_NAME
+            - name: CLOUD_CREDENTIALS_REF
             - name: UNSUPPORTED_ADDON_FEATURES
           image: controller:latest
           imagePullPolicy: IfNotPresent

--- a/docs/cloud_credentials.md
+++ b/docs/cloud_credentials.md
@@ -84,7 +84,7 @@ oc get pods -n cert-manager -w
 
 7. Patch the subscription object on the cluster to inject the secret name in the operator deployment.
 ```sh
-oc -n cert-manager-operator patch subscription <subscription-name> --type='merge' -p '{"spec":{"config":{"env":[{"name":"CLOUD_CREDENTIALS_SECRET_NAME","value":"aws-creds"}]}}}'
+oc -n cert-manager-operator patch subscription <subscription-name> --type='merge' -p '{"spec":{"config":{"env":[{"name":"CLOUD_CREDENTIALS_REF","value":"aws-creds"}]}}}'
 ```
 
 ## GCP
@@ -127,5 +127,5 @@ ls manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
 
 5. Patch the subscription object on the cluster to inject the secret name in the operator deployment.
 ```sh
-oc -n cert-manager-operator patch subscription <subscription-name> --type='merge' -p '{"spec":{"config":{"env":[{"name":"CLOUD_CREDENTIALS_SECRET_NAME","value":"gcp-credentials"}]}}}'
+oc -n cert-manager-operator patch subscription <subscription-name> --type='merge' -p '{"spec":{"config":{"env":[{"name":"CLOUD_CREDENTIALS_REF","value":"gcp-credentials"}]}}}'
 ```

--- a/harness-evals/harness-docs/security-guidelines.md
+++ b/harness-evals/harness-docs/security-guidelines.md
@@ -92,7 +92,7 @@ if effective.MinTLSVersion == configv1.VersionTLS13 {
   (`../../docs/cloud_credentials.md`, `credentials_request.go` despite its filename). Do not add
   CredentialsRequest-creation logic here — that belongs to `ccoctl`/cloud-credential-operator flows
   documented for cluster admins.
-- `--cloud-credentials-secret` / `CLOUD_CREDENTIALS_SECRET_NAME` only mounts into the **CertManager
+- `--cloud-credentials-secret` / `CLOUD_CREDENTIALS_REF` only mounts into the **CertManager
   controller** deployment (`deploymentName != certmanagerControllerDeployment` short-circuits to a
   no-op) — don't expect webhook/cainjector to receive this mount.
 - Platform type is read from `Infrastructure/cluster` and only `AWSPlatformType` / `GCPPlatformType`

--- a/test/e2e/issuer_acme_dns01_test.go
+++ b/test/e2e/issuer_acme_dns01_test.go
@@ -291,14 +291,14 @@ var _ = Describe("ACME Issuer DNS01 solver", Ordered, func() {
 
 		By("setting cloud credential secret name in subscription object")
 		err = patchSubscriptionWithEnvVars(ctx, loader, map[string]string{
-			"CLOUD_CREDENTIALS_SECRET_NAME": "aws-creds",
+			"CLOUD_CREDENTIALS_REF": "aws-creds",
 		})
 		Expect(err).NotTo(HaveOccurred(), "failed to patch subscription with env vars")
 
 		DeferCleanup(func(cleanupCtx context.Context) {
-			By("removing 'CLOUD_CREDENTIALS_SECRET_NAME' from subscription")
+			By("removing 'CLOUD_CREDENTIALS_REF' from subscription")
 			if err := patchSubscriptionWithEnvVars(cleanupCtx, loader, map[string]string{
-				"CLOUD_CREDENTIALS_SECRET_NAME": "",
+				"CLOUD_CREDENTIALS_REF": "",
 			}); err != nil {
 				fmt.Fprintf(GinkgoWriter, "failed to remove env var from subscription during cleanup: %v\n", err)
 				return
@@ -361,14 +361,14 @@ var _ = Describe("ACME Issuer DNS01 solver", Ordered, func() {
 
 		By("setting cloud credential secret name in subscription object")
 		err = patchSubscriptionWithEnvVars(ctx, loader, map[string]string{
-			"CLOUD_CREDENTIALS_SECRET_NAME": "gcp-credentials",
+			"CLOUD_CREDENTIALS_REF": "gcp-credentials",
 		})
 		Expect(err).NotTo(HaveOccurred(), "failed to patch subscription with env vars")
 
 		DeferCleanup(func(cleanupCtx context.Context) {
-			By("removing 'CLOUD_CREDENTIALS_SECRET_NAME' from subscription")
+			By("removing 'CLOUD_CREDENTIALS_REF' from subscription")
 			if err := patchSubscriptionWithEnvVars(cleanupCtx, loader, map[string]string{
-				"CLOUD_CREDENTIALS_SECRET_NAME": "",
+				"CLOUD_CREDENTIALS_REF": "",
 			}); err != nil {
 				fmt.Fprintf(GinkgoWriter, "failed to remove env var from subscription during cleanup: %v\n", err)
 				return
@@ -487,7 +487,7 @@ var _ = Describe("ACME Issuer DNS01 solver", Ordered, func() {
 	// setupCCOAzureCredentials creates a CredentialsRequest for Azure with fine-grained
 	// DNS Zone Contributor permissions and returns the CCO-provisioned credentials.
 	// Note: Unlike setupAmbientAWSCredentials/setupAmbientGCPCredentials, this does NOT patch
-	// the subscription with 'CLOUD_CREDENTIALS_SECRET_NAME' because the operator does not yet
+	// the subscription with 'CLOUD_CREDENTIALS_REF' because the operator does not yet
 	// support mounting Azure credentials into the cert-manager pod. Once Azure support is added to
 	// 'withCloudCredentials' in credentials_request.go, it can be adapted to follow the AWS/GCP pattern.
 	setupCCOAzureCredentials := func(ctx context.Context) (clientID, clientSecret, tenantID []byte) {
@@ -984,16 +984,16 @@ var _ = Describe("ACME Issuer DNS01 solver", Ordered, func() {
 				}
 			})
 
-			By("patching subscription to inject 'CLOUD_CREDENTIALS_SECRET_NAME' env var")
+			By("patching subscription to inject 'CLOUD_CREDENTIALS_REF' env var")
 			err := patchSubscriptionWithEnvVars(ctx, loader, map[string]string{
-				"CLOUD_CREDENTIALS_SECRET_NAME": secretName,
+				"CLOUD_CREDENTIALS_REF": secretName,
 			})
-			Expect(err).NotTo(HaveOccurred(), "failed to patch subscription with 'CLOUD_CREDENTIALS_SECRET_NAME'")
+			Expect(err).NotTo(HaveOccurred(), "failed to patch subscription with 'CLOUD_CREDENTIALS_REF'")
 
 			DeferCleanup(func(ctx context.Context) {
-				By("Removing 'CLOUD_CREDENTIALS_SECRET_NAME' from subscription")
+				By("Removing 'CLOUD_CREDENTIALS_REF' from subscription")
 				if err := patchSubscriptionWithEnvVars(ctx, loader, map[string]string{
-					"CLOUD_CREDENTIALS_SECRET_NAME": "",
+					"CLOUD_CREDENTIALS_REF": "",
 				}); err != nil {
 					fmt.Fprintf(GinkgoWriter, "failed to remove env var from subscription during cleanup: %v\n", err)
 					return
@@ -1248,16 +1248,16 @@ var _ = Describe("ACME Issuer DNS01 solver", Ordered, func() {
 				}
 			}, "cert-manager", secretName)
 
-			By("patching subscription to inject 'CLOUD_CREDENTIALS_SECRET_NAME' env var")
+			By("patching subscription to inject 'CLOUD_CREDENTIALS_REF' env var")
 			err = patchSubscriptionWithEnvVars(ctx, loader, map[string]string{
-				"CLOUD_CREDENTIALS_SECRET_NAME": secretName,
+				"CLOUD_CREDENTIALS_REF": secretName,
 			})
-			Expect(err).NotTo(HaveOccurred(), "failed to patch subscription with CLOUD_CREDENTIALS_SECRET_NAME")
+			Expect(err).NotTo(HaveOccurred(), "failed to patch subscription with CLOUD_CREDENTIALS_REF")
 
 			DeferCleanup(func(ctx context.Context) {
-				By("Removing 'CLOUD_CREDENTIALS_SECRET_NAME' from subscription")
+				By("Removing 'CLOUD_CREDENTIALS_REF' from subscription")
 				if err := patchSubscriptionWithEnvVars(ctx, loader, map[string]string{
-					"CLOUD_CREDENTIALS_SECRET_NAME": "",
+					"CLOUD_CREDENTIALS_REF": "",
 				}); err != nil {
 					fmt.Fprintf(GinkgoWriter, "failed to remove env var from subscription during cleanup: %v\n", err)
 					return


### PR DESCRIPTION
## Problem

The ACS (Advanced Cluster Security) deploy-time policy **"Environment Variable Contains Secret"** flags any environment variable whose name contains the substring `SECRET`. The `CLOUD_CREDENTIALS_SECRET_NAME` env var on the operator controller-manager deployment triggers this policy, even though its value is the **name of a Kubernetes Secret resource**, not an actual secret value.

## Fix

Rename the env var from `CLOUD_CREDENTIALS_SECRET_NAME` to `CLOUD_CREDENTIALS_REF`.

The internal CLI flag `--cloud-credentials-secret` and Go variable names (`CloudCredentialSecret`, `cloudCredentialsSecretName`) remain unchanged — they are not visible to ACS deploy-time scanning and do not trigger the policy.

## Changed files

| File | Change |
|------|--------|
| `config/manager/manager.yaml` | Renamed env var and its arg reference |
| `bundle/manifests/cert-manager-operator.clusterserviceversion.yaml` | Renamed env var and its arg reference |
| `test/e2e/issuer_acme_dns01_test.go` | Updated all test references |
| `docs/cloud_credentials.md` | Updated `oc patch` examples |
| `harness-evals/harness-docs/security-guidelines.md` | Updated reference |

## Impact

- **No functional change** — the env var is consumed via `$(CLOUD_CREDENTIALS_REF)` expansion into the same `--cloud-credentials-secret` CLI flag
- Users who set this env var via Subscription patches (as documented in `docs/cloud_credentials.md`) will need to use the new name

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Renamed the cloud credentials environment variable to `CLOUD_CREDENTIALS_REF` across operator deployment configuration and credential setup.

* **Documentation**
  * Updated AWS, GCP, and security guidance to reference the new environment variable name.

* **Tests**
  * Updated end-to-end credential configuration and cleanup checks to use `CLOUD_CREDENTIALS_REF`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->