### PR TITLE
CM-1236: Use prod 1.19.2 operator and operand images for CI testing

### DIFF
--- a/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cert-manager-operator.clusterserviceversion.yaml
@@ -276,7 +276,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Security
     console.openshift.io/disable-operand-delete: "true"
-    containerImage: openshift.io/cert-manager-operator:latest
+    containerImage: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a1f49ceaf14cbf12fcad5c7ce19cb8bec9222ee52533642092bfb60ce6f59f63
     createdAt: 2023-03-03T00:00:00
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -788,17 +788,17 @@ spec:
                 - name: OPERATOR_NAME
                   value: cert-manager-operator
                 - name: RELATED_IMAGE_CERT_MANAGER_WEBHOOK
-                  value: quay.io/jetstack/cert-manager-webhook:v1.19.6
+                  value: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:3afda61dcc3c22373e234bccd55ac2d09dd7db86e0c90b761ed967969b47541e
                 - name: RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR
-                  value: quay.io/jetstack/cert-manager-cainjector:v1.19.6
+                  value: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:3afda61dcc3c22373e234bccd55ac2d09dd7db86e0c90b761ed967969b47541e
                 - name: RELATED_IMAGE_CERT_MANAGER_CONTROLLER
-                  value: quay.io/jetstack/cert-manager-controller:v1.19.6
+                  value: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:3afda61dcc3c22373e234bccd55ac2d09dd7db86e0c90b761ed967969b47541e
                 - name: RELATED_IMAGE_CERT_MANAGER_ACMESOLVER
-                  value: quay.io/jetstack/cert-manager-acmesolver:v1.19.6
+                  value: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:309dcc51ac5c0c8651f5a14d389b16d9ea217c33fe2b15cb5bf7966f2928ff53
                 - name: RELATED_IMAGE_CERT_MANAGER_ISTIOCSR
-                  value: quay.io/jetstack/cert-manager-istio-csr:v0.16.0
+                  value: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:eb340b679c1b792b57cbd28b6ca049fc7df21fa8780bf96e746ca43fe3d4589a
                 - name: RELATED_IMAGE_CERT_MANAGER_TRUST_MANAGER
-                  value: quay.io/jetstack/trust-manager:v0.20.3
+                  value: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
                 - name: OPERAND_IMAGE_VERSION
                   value: 1.19.6
                 - name: ISTIOCSR_OPERAND_IMAGE_VERSION
@@ -806,13 +806,13 @@ spec:
                 - name: TRUSTMANAGER_OPERAND_IMAGE_VERSION
                   value: 0.20.3
                 - name: OPERATOR_IMAGE_VERSION
-                  value: 1.19.1
+                  value: 1.19.2
                 - name: OPERATOR_LOG_LEVEL
                   value: "2"
                 - name: TRUSTED_CA_CONFIGMAP_NAME
                 - name: CLOUD_CREDENTIALS_SECRET_NAME
                 - name: UNSUPPORTED_ADDON_FEATURES
-                image: openshift.io/cert-manager-operator:latest
+                image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a1f49ceaf14cbf12fcad5c7ce19cb8bec9222ee52533642092bfb60ce6f59f63
                 imagePullPolicy: IfNotPresent
                 name: cert-manager-operator
                 ports:
@@ -909,17 +909,13 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: quay.io/jetstack/cert-manager-webhook:v1.19.6
-    name: cert-manager-webhook
-  - image: quay.io/jetstack/cert-manager-cainjector:v1.19.6
-    name: cert-manager-ca-injector
-  - image: quay.io/jetstack/cert-manager-controller:v1.19.6
-    name: cert-manager-controller
-  - image: quay.io/jetstack/cert-manager-acmesolver:v1.19.6
+  - image: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:3afda61dcc3c22373e234bccd55ac2d09dd7db86e0c90b761ed967969b47541e
+    name: ""
+  - image: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:309dcc51ac5c0c8651f5a14d389b16d9ea217c33fe2b15cb5bf7966f2928ff53
     name: cert-manager-acmesolver
-  - image: quay.io/jetstack/cert-manager-istio-csr:v0.16.0
+  - image: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:eb340b679c1b792b57cbd28b6ca049fc7df21fa8780bf96e746ca43fe3d4589a
     name: cert-manager-istiocsr
-  - image: quay.io/jetstack/trust-manager:v0.20.3
+  - image: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
     name: cert-manager-trust-manager
   replaces: cert-manager-operator.v1.19.0
   version: 1.19.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -75,17 +75,17 @@ spec:
             - name: OPERATOR_NAME
               value: cert-manager-operator
             - name: RELATED_IMAGE_CERT_MANAGER_WEBHOOK
-              value: quay.io/jetstack/cert-manager-webhook:v1.19.6
+              value: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:3afda61dcc3c22373e234bccd55ac2d09dd7db86e0c90b761ed967969b47541e
             - name: RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR
-              value: quay.io/jetstack/cert-manager-cainjector:v1.19.6
+              value: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:3afda61dcc3c22373e234bccd55ac2d09dd7db86e0c90b761ed967969b47541e
             - name: RELATED_IMAGE_CERT_MANAGER_CONTROLLER
-              value: quay.io/jetstack/cert-manager-controller:v1.19.6
+              value: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:3afda61dcc3c22373e234bccd55ac2d09dd7db86e0c90b761ed967969b47541e
             - name: RELATED_IMAGE_CERT_MANAGER_ACMESOLVER
-              value: quay.io/jetstack/cert-manager-acmesolver:v1.19.6
+              value: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:309dcc51ac5c0c8651f5a14d389b16d9ea217c33fe2b15cb5bf7966f2928ff53
             - name: RELATED_IMAGE_CERT_MANAGER_ISTIOCSR
-              value: quay.io/jetstack/cert-manager-istio-csr:v0.16.0
+              value: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:eb340b679c1b792b57cbd28b6ca049fc7df21fa8780bf96e746ca43fe3d4589a
             - name: RELATED_IMAGE_CERT_MANAGER_TRUST_MANAGER
-              value: quay.io/jetstack/trust-manager:v0.20.3
+              value: registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
             - name: OPERAND_IMAGE_VERSION
               value: 1.19.6
             - name: ISTIOCSR_OPERAND_IMAGE_VERSION
@@ -93,13 +93,13 @@ spec:
             - name: TRUSTMANAGER_OPERAND_IMAGE_VERSION
               value: 0.20.3
             - name: OPERATOR_IMAGE_VERSION
-              value: 1.19.1
+              value: 1.19.2
             - name: OPERATOR_LOG_LEVEL
               value: '2'
             - name: TRUSTED_CA_CONFIGMAP_NAME
             - name: CLOUD_CREDENTIALS_SECRET_NAME
             - name: UNSUPPORTED_ADDON_FEATURES
-          image: controller:latest
+          image: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a1f49ceaf14cbf12fcad5c7ce19cb8bec9222ee52533642092bfb60ce6f59f63
           imagePullPolicy: IfNotPresent
           name: cert-manager-operator
           securityContext:


### PR DESCRIPTION
## Summary

**Test-only PR — do not merge.**

Points the operator image and `RELATED_IMAGE_*` env vars at the production 1.19.2 digests from [cert-manager-operator-release images_digest.conf on release-1.19](https://github.com/openshift/cert-manager-operator-release/blob/release-1.19/images_digest.conf) so operator CI e2e (`e2e-operator`) runs the prod stack instead of pipeline-substituted `quay.io/jetstack` / `openshift.io/cert-manager-operator` images.

ci-operator substitutions only rewrite `quay.io/jetstack/...` and `openshift.io/cert-manager-operator:.*`. Using `registry.redhat.io/...@sha256:...` means those substitutions no longer match.

Jira: https://redhat.atlassian.net/browse/CM-1236

## Image mapping

| Component | Pullspec | Version Label |
| --- | --- | --- |
| Operator | `registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a1f49ceaf14cbf12fcad5c7ce19cb8bec9222ee52533642092bfb60ce6f59f63` | `v1.19.2` |
| webhook / cainjector / controller | `registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:3afda61dcc3c22373e234bccd55ac2d09dd7db86e0c90b761ed967969b47541e` | `v1.19.6-1` |
| acmesolver | `registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:309dcc51ac5c0c8651f5a14d389b16d9ea217c33fe2b15cb5bf7966f2928ff53` | `v1.19.6-1` |
| istio-csr | `registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:eb340b679c1b792b57cbd28b6ca049fc7df21fa8780bf96e746ca43fe3d4589a` | `v0.16.0-1-1` |
| trust-manager | `registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82` | `v0.20.3` |

The operator is pinned on `config/manager/manager.yaml` `image:` (replacing `controller:latest`), not via `kustomization.yaml`. `make bundle` always runs `kustomize edit set image controller=openshift.io/cert-manager-operator:latest`; pinning only in kustomize would be reset and ci-operator would inject the PR-built operator again.

The CSV is regenerated with `make bundle` so `hack/verify-bundle.sh` stays green. `spec.relatedImages` collapses webhook/cainjector/controller to one entry because they share a digest (operator-sdk warning); the `RELATED_IMAGE_*` env vars still list each component separately, which is what the operator uses at runtime.

## Image inspection commands and output

Command used to fetch digests and version labels:

```
$ for img in \
    "registry.redhat.io/cert-manager/cert-manager-operator-rhel9:v1.19.2" \
    "registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9:v1.19.6-1" \
    "registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9:v1.19.6-1" \
    "registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9:v0.16.0-1-1" \
    "registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9:v0.20.3"; do
    echo "--- $img ---"
    skopeo inspect "docker://$img" --format '  Digest:  {{.Digest}}
  Version: {{index .Labels "version"}}'
    echo
done
```

Output:

```
--- registry.redhat.io/cert-manager/cert-manager-operator-rhel9:v1.19.2 ---
  Digest:  sha256:a1f49ceaf14cbf12fcad5c7ce19cb8bec9222ee52533642092bfb60ce6f59f63
  Version: v1.19.2

--- registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9:v1.19.6-1 ---
  Digest:  sha256:3afda61dcc3c22373e234bccd55ac2d09dd7db86e0c90b761ed967969b47541e
  Version: v1.19.6-1

--- registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9:v1.19.6-1 ---
  Digest:  sha256:309dcc51ac5c0c8651f5a14d389b16d9ea217c33fe2b15cb5bf7966f2928ff53
  Version: v1.19.6-1

--- registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9:v0.16.0-1-1 ---
  Digest:  sha256:eb340b679c1b792b57cbd28b6ca049fc7df21fa8780bf96e746ca43fe3d4589a
  Version: v0.16.0-1-1

--- registry.redhat.io/cert-manager/cert-manager-trust-manager-rhel9:v0.20.3 ---
  Digest:  sha256:d0834b140e53cb2b96d30f227b0c7dcab3463eeab80049df608582c45c792a82
  Version: v0.20.3
```

## Test plan

- Confirm `e2e-operator` runs (not skipped)
- Operator pod uses `registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:a1f49ceaf1...`
- Operand deployments use the prod jetstack / acmesolver / istio-csr / trust-manager digests
- No ImagePullBackOff (prod images are publicly accessible from `registry.redhat.io`)
- Close this PR without merging after CI results are collected

Always review AI generated responses prior to use.
Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin

Made with [Cursor](https://cursor.com)